### PR TITLE
Fixed geometry path in HydroNode SLD

### DIFF
--- a/feature-styles/HY_N_HydroNode.se
+++ b/feature-styles/HY_N_HydroNode.se
@@ -16,7 +16,7 @@ version="1.1.0">
     </se:Description>
     <se:PointSymbolizer>
       <se:Geometry>
-        <ogc:PropertyName>net:geometry/gml:Point</ogc:PropertyName>
+        <ogc:PropertyName>net:geometry</ogc:PropertyName>
       </se:Geometry>
       <se:Graphic>
         <se:Mark>
@@ -54,7 +54,7 @@ version="1.1.0">
     </ogc:Filter>
     <se:PointSymbolizer>
       <se:Geometry>
-        <ogc:PropertyName>net:geometry/gml:Point</ogc:PropertyName>
+        <ogc:PropertyName>net:geometry</ogc:PropertyName>
       </se:Geometry>
       <se:Graphic>
         <se:Mark>
@@ -88,7 +88,7 @@ version="1.1.0">
     </ogc:Filter>
     <se:PointSymbolizer>
       <se:Geometry>
-        <ogc:PropertyName>net:geometry/gml:Point</ogc:PropertyName>
+        <ogc:PropertyName>net:geometry</ogc:PropertyName>
       </se:Geometry>
       <se:Graphic>
         <se:Mark>
@@ -113,7 +113,7 @@ version="1.1.0">
     </ogc:Filter>
     <se:PointSymbolizer>
       <se:Geometry>
-        <ogc:PropertyName>net:geometry/gml:Point</ogc:PropertyName>
+        <ogc:PropertyName>net:geometry</ogc:PropertyName>
       </se:Geometry>
       <se:Graphic>
         <se:Mark>


### PR DESCRIPTION
The geometry path in the HydroNode SLD was set to net:geometry/gml:Point.
hc locates the geometry at net:geometry so I updated the SLD. I expect this update to fix ING-1369.