### PR TITLE
feat: adjust colors in INSPIRE PS 5.0 SE style

### DIFF
--- a/feature-styles/PS_ProtectedSites_v5.se
+++ b/feature-styles/PS_ProtectedSites_v5.se
@@ -23,10 +23,10 @@
         <ogc:PropertyName>ps:geometry</ogc:PropertyName>
       </se:Geometry>
       <se:Fill>
-        <se:SvgParameter name="fill">#800080</se:SvgParameter>
+        <se:SvgParameter name="fill">#808080</se:SvgParameter>
       </se:Fill>
       <se:Stroke>
-        <se:SvgParameter name="stroke">#008000</se:SvgParameter>
+        <se:SvgParameter name="stroke">#000000</se:SvgParameter>
         <se:SvgParameter name="stroke-width">1</se:SvgParameter>
       </se:Stroke>
     </se:PolygonSymbolizer>
@@ -48,7 +48,7 @@
         <ogc:PropertyName>ps:geometry</ogc:PropertyName>
       </se:Geometry>
       <se:Stroke>
-        <se:SvgParameter name="stroke">#008000</se:SvgParameter>
+        <se:SvgParameter name="stroke">#000000</se:SvgParameter>
         <se:SvgParameter name="stroke-width">1</se:SvgParameter>
       </se:Stroke>
     </se:LineSymbolizer>
@@ -73,10 +73,10 @@
         <se:Mark>
           <se:WellKnownName>square</se:WellKnownName>
           <se:Fill>
-            <se:SvgParameter name="fill">#800080</se:SvgParameter>
+            <se:SvgParameter name="fill">#808080</se:SvgParameter>
           </se:Fill>
           <se:Stroke>
-            <se:SvgParameter name="stroke">#008000</se:SvgParameter>
+            <se:SvgParameter name="stroke">#000000</se:SvgParameter>
             <se:SvgParameter name="stroke-width">1</se:SvgParameter>
           </se:Stroke>
         </se:Mark>


### PR DESCRIPTION
Take back colour change in INSPIRE PS 5.0 style to original/correct colour as the test to verify that the correct SE file is selected when using the corresponding schema (see previous commit) was successful.

SVC-2136