### PR TITLE
Adding se files customised for INSPIRE 5.0 schema and the corresponding adaptation of the configuration files

### DIFF
--- a/config.style
+++ b/config.style
@@ -172,6 +172,15 @@ Layer {
 	Styles: HY_N_WatercourseLink
 }
 Layer {
+	id: "HY_Network_WatercourseLink_v5"
+	registry-id:""
+	tags: inspire production
+	Name: "HY.Network.WatercourseLink"
+	Title: en "Hydrographic network - WatercourseLink", de "Hydrografisches Netzwerk- WatercourseLink"
+	SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/hy-n/5.0:WatercourseLink
+	Styles: HY_N_WatercourseLink_v5
+}
+Layer {
 	id: "HY_Network_HydroNode"
 	registry-id:""
 	tags: inspire production
@@ -179,6 +188,15 @@ Layer {
 	Title: en "Hydrographic network - HydroNode", de "Hydrografisches Netzwerk- HydroNode"
 	SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/hy-n/4.0:HydroNode
 	Styles: HY_N_HydroNode
+}
+Layer {
+	id: "HY_Network_HydroNode_v5"
+	registry-id:""
+	tags: inspire production
+	Name: "HY.Network.HydroNode"
+	Title: en "Hydrographic network - HydroNode", de "Hydrografisches Netzwerk- HydroNode"
+	SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/hy-n/5.0:HydroNode
+	Styles: HY_N_HydroNode_v5
 }
 Layer {
 	id: "HY_Physica"
@@ -190,6 +208,15 @@ Layer {
 	, http://inspire.ec.europa.eu/schemas/hy-p/4.0:RiverBasin Styles: HY_P_DrainageBasin , HY_P_RiverBasin
 }
 Layer {
+	id: "HY_Physica_v5"
+	registry-id:"http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.Catchments"
+	tags: inspire production
+	Name: "HY.PhysicalWaters.Catchments"
+	Title: en "Catchment", de "Einzugsgebiete"
+	SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/hy-p/5.0:DrainageBasin
+	, http://inspire.ec.europa.eu/schemas/hy-p/5.0:RiverBasin Styles: HY_P_DrainageBasin_v5 , HY_P_RiverBasin_v5
+}
+Layer {
 	id: "HY_Physica_1"
 	registry-id:"http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.HydroPointOfInterest"
 	tags: inspire production
@@ -197,6 +224,15 @@ Layer {
 	Title: en "Hydro Point of Interest", de "Interessante hydrologische Punkte"
 	SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/hy-p/4.0:Rapids
 	, http://inspire.ec.europa.eu/schemas/hy-p/4.0:Falls Styles: HY_P_Rapids , HY_P_Falls
+}
+Layer {
+	id: "HY_Physica_1_v5"
+	registry-id:"http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.HydroPointOfInterest"
+	tags: inspire production
+	Name: "HY.PhysicalWaters.HydroPointOfInterest"
+	Title: en "Hydro Point of Interest", de "Interessante hydrologische Punkte"
+	SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/hy-p/5.0:Rapids
+	, http://inspire.ec.europa.eu/schemas/hy-p/5.0:Falls Styles: HY_P_Rapids_v5 , HY_P_Falls_v5
 }
 Layer {
 	id: "HY_Physica_2"
@@ -208,6 +244,15 @@ Layer {
 	Styles: HY_P_LandWaterBoundary
 }
 Layer {
+	id: "HY_Physica_2_v5"
+	registry-id:"http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.LandWaterBoundary"
+	tags: inspire production
+	Name: "HY.PhysicalWaters.LandWaterBoundary"
+	Title: en "Land water boundary", de "Uferlinien"
+	SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/hy-p/5.0:LandWaterBoundary
+	Styles: HY_P_LandWaterBoundary_v5
+}
+Layer {
 	id: "HY_Physica_4"
 	registry-id:"http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.ManMadeObject"
 	tags: inspire production
@@ -215,6 +260,15 @@ Layer {
 	Title: en "Man-made Object", de "Bauwerke an Gewässern"
 	SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/hy-p/4.0:Crossing
 	, http://inspire.ec.europa.eu/schemas/hy-p/4.0:DamOrWeir , http://inspire.ec.europa.eu/schemas/hy-p/4.0:ShorelineConstruction , http://inspire.ec.europa.eu/schemas/hy-p/4.0:Ford , http://inspire.ec.europa.eu/schemas/hy-p/4.0:Lock Styles: HY_P_Crossing , HY_P_DamOrWeir , HY_P_ShoreLineConstruction , HY_P_Ford , HY_P_Lock
+}
+Layer {
+	id: "HY_Physica_4_v5"
+	registry-id:"http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.ManMadeObject"
+	tags: inspire production
+	Name: "HY.PhysicalWaters.ManMadeObject"
+	Title: en "Man-made Object", de "Bauwerke an Gewässern"
+	SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/hy-p/4.0:Crossing
+	, http://inspire.ec.europa.eu/schemas/hy-p/5.0:DamOrWeir , http://inspire.ec.europa.eu/schemas/hy-p/5.0:ShorelineConstruction , http://inspire.ec.europa.eu/schemas/hy-p/5.0:Ford , http://inspire.ec.europa.eu/schemas/hy-p/5.0:Lock Styles: HY_P_Crossing_v5 , HY_P_DamOrWeir_v5 , HY_P_ShoreLineConstruction_v5 , HY_P_Ford_v5 , HY_P_Lock_v5
 }
 Layer {
 	id: "HY_PhysicalWaters_Shore"
@@ -226,6 +280,15 @@ Layer {
 	Styles: HY_P_Shore
 }
 Layer {
+	id: "HY_PhysicalWaters_Shore_v5"
+	registry-id:"http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.Shore"
+	tags: inspire production
+	Name: "HY.PhysicalWaters.Shore"
+	Title: en "Shores", de "Küsten"
+	SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/hy-p/5.0:Shore
+	Styles: HY_P_Shore_v5
+}
+Layer {
 	id: "HY_Physica_5"
 	registry-id:"http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.Waterbodies"
 	tags: inspire production
@@ -233,6 +296,15 @@ Layer {
 	Title: en "Waterbody", de "Wasserkörper"
 	SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/hy-p/4.0:Watercourse
 	, http://inspire.ec.europa.eu/schemas/hy-p/4.0:StandingWater Styles: HY_P_Watercourse , HY_P_StandingWater
+}
+Layer {
+	id: "HY_Physica_5_v5"
+	registry-id:"http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.Waterbodies"
+	tags: inspire production
+	Name: "HY.PhysicalWaters.Waterbodies"
+	Title: en "Waterbody", de "Wasserkörper"
+	SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/hy-p/5.0:Watercourse
+	, http://inspire.ec.europa.eu/schemas/hy-p/5.0:StandingWater Styles: HY_P_Watercourse_v5 , HY_P_StandingWater_v5
 }
 Layer {
 	id: "HY_Physica_6"
@@ -244,6 +316,15 @@ Layer {
 	, http://inspire.ec.europa.eu/schemas/hy-p/4.0:StandingWater Styles: HY_P_Watercourse_ManMade , HY_P_StandingWater_ManMade
 }
 Layer {
+	id: "HY_Physica_6_v5"
+	registry-id:""
+	tags: inspire production
+	Name: "HY.PhysicalWaters.Waterbodies.Man.Made"
+	Title: en "Man-made Object (Natural)"
+	SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/hy-p/5.0:Watercourse
+	, http://inspire.ec.europa.eu/schemas/hy-p/5.0:StandingWater Styles: HY_P_Watercourse_ManMade_v5 , HY_P_StandingWater_ManMade_v5
+}
+Layer {
 	id: "HY_Physica_7"
 	registry-id:""
 	tags: inspire production
@@ -251,6 +332,15 @@ Layer {
 	Title: en "Waterbody (Persistence)"
 	SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/hy-p/4.0:Watercourse
 	, http://inspire.ec.europa.eu/schemas/hy-p/4.0:StandingWater Styles: HY_P_WatercoursePersistence , HY_P_WaterbodiesPersistence
+}
+Layer {
+	id: "HY_Physica_7_v5"
+	registry-id:""
+	tags: inspire production
+	Name: "HY.PhysicalWaters.Waterbodies.Persistence"
+	Title: en "Waterbody (Persistence)"
+	SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/hy-p/5.0:Watercourse
+	, http://inspire.ec.europa.eu/schemas/hy-p/5.0:StandingWater Styles: HY_P_WatercoursePersistence_v5 , HY_P_WaterbodiesPersistence_v5
 }
 Layer {
 	id: "HY_PhysicalWaters_Wetland"
@@ -262,6 +352,15 @@ Layer {
 	Styles: HY_P_Wetland
 }
 Layer {
+	id: "HY_PhysicalWaters_Wetland_v5"
+	registry-id:"http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.Wetland"
+	tags: inspire production
+	Name: "HY.PhysicalWaters.Wetland"
+	Title: en "Wetlands", de "Feuchtgebiete"
+	SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/hy-p/5.0:Wetland
+	Styles: HY_P_Wetland_v5
+}
+Layer {
 	id: "PS_ProtectedSite"
 	registry-id:"http://inspire.ec.europa.eu/layer/PS.ProtectedSite"
 	tags: inspire production
@@ -269,6 +368,15 @@ Layer {
 	Title: en "Protected Sites", de "Schutzgebiete"
 	SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/ps/4.0:ProtectedSite
 	Styles: PS_ProtectedSite
+}
+Layer {
+	id: "PS_ProtectedSite_v5"
+	registry-id:"http://inspire.ec.europa.eu/layer/PS.ProtectedSite"
+	tags: inspire production
+	Name: "PS.ProtectedSite"
+	Title: en "Protected Sites", de "Schutzgebiete"
+	SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/ps/5.0:ProtectedSite
+	Styles: PS_ProtectedSite_v5
 }
 Layer {
 	id: "PS_ProtectedSite_v5"
@@ -289,6 +397,15 @@ Layer {
 	Styles: TN_A_AerodromeArea
 }
 Layer {
+	id: "TN_AirTran_v5"
+	registry-id:"http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.AerodromeArea"
+	tags: inspire production
+	Name: "TN.AirTransportNetwork.AerodromeArea"
+	Title: en "Aerodrome Area Default Style", de "Flugplatzgelände"
+	SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-a/5.0:AerodromeArea
+	Styles: TN_A_AerodromeArea_v5
+}
+Layer {
 	id: "TN_AirTran_1"
 	registry-id:"http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.AirLink"
 	tags: inspire production
@@ -296,6 +413,15 @@ Layer {
 	Title: en "Air Link Default Style", de "Luftverbindung"
 	SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-a/4.0:ProcedureLink
 	, http://inspire.ec.europa.eu/schemas/tn-a/4.0:AirRouteLink Styles: TN_A_ProcedureLink , TN_A_AirRouteLink
+}
+Layer {
+	id: "TN_AirTran_1_v5"
+	registry-id:"http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.AirLink"
+	tags: inspire production
+	Name: "TN.AirTransportNetwork.AirLink"
+	Title: en "Air Link Default Style", de "Luftverbindung"
+	SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-a/5.0:ProcedureLink
+	, http://inspire.ec.europa.eu/schemas/tn-a/5.0:AirRouteLink Styles: TN_A_ProcedureLink_v5 , TN_A_AirRouteLink_v5
 }
 Layer {
 	id: "TN_AirTran_2"
@@ -307,6 +433,15 @@ Layer {
 	Styles: TN_A_AirspaceArea
 }
 Layer {
+	id: "TN_AirTran_2_v5"
+	registry-id:"http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.AirspaceArea"
+	tags: inspire production
+	Name: "TN.AirTransportNetwork.AirSpaceArea"
+	Title: en "Air Space Area Default Style", de "Luftraumbereich"
+	SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-a/5.0:AirspaceArea
+	Styles: TN_A_AirspaceArea_v5
+}
+Layer {
 	id: "TN_AirTran_3"
 	registry-id:"http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.ApronArea"
 	tags: inspire production
@@ -314,6 +449,15 @@ Layer {
 	Title: en "Apron Area Default Style", de "Vorfeldgelände"
 	SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-a/4.0:ApronArea
 	Styles: TN_A_ApronArea
+}
+Layer {
+	id: "TN_AirTran_3_v5"
+	registry-id:"http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.ApronArea"
+	tags: inspire production
+	Name: "TN.AirTransportNetwork.ApronArea"
+	Title: en "Apron Area Default Style", de "Vorfeldgelände"
+	SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-a/5.0:ApronArea
+	Styles: TN_A_ApronArea_v5
 }
 Layer {
 	id: "TN_AirTran_4"
@@ -325,6 +469,15 @@ Layer {
 	Styles: TN_A_RunwayArea
 }
 Layer {
+	id: "TN_AirTran_4_v5"
+	registry-id:"http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.RunwayArea"
+	tags: inspire production
+	Name: "TN.AirTransportNetwork.RunwayArea"
+	Title: en "Runway Area Default Style", de "Landebahngelände"
+	SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-a/5.0:RunwayArea
+	Styles: TN_A_RunwayArea_v5
+}
+Layer {
 	id: "TN_AirTran_5"
 	registry-id:"http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.TaxiwayArea"
 	tags: inspire production
@@ -332,6 +485,15 @@ Layer {
 	Title: en "Taxiway Area Default Style", de "Rollfeld"
 	SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-a/4.0:TaxiwayArea
 	Styles: TN_A_TaxiwayArea
+}
+Layer {
+	id: "TN_AirTran_5_v5"
+	registry-id:"http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.TaxiwayArea"
+	tags: inspire production
+	Name: "TN.AirTransportNetwork.TaxiwayArea"
+	Title: en "Taxiway Area Default Style", de "Rollfeld"
+	SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-a/5.0:TaxiwayArea
+	Styles: TN_A_TaxiwayArea_v5
 }
 Layer {
 	id: "TN_AirTran_6"
@@ -343,6 +505,15 @@ Layer {
 	Styles: TN_A_DesignatedPoint
 }
 Layer {
+	id: "TN_AirTran_6_v5"
+	registry-id:""
+	tags: inspire production
+	Name: "TN.AirTransportNetwork.DesignatedPoint"
+	Title: en "Designated Point Default Style", de "Designierter Punkt"
+	SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-a/5.0:DesignatedPoint
+	Styles: TN_A_DesignatedPoint_v5
+}
+Layer {
 	id: "TN_AirTran_7"
 	registry-id:""
 	tags: inspire production
@@ -350,6 +521,15 @@ Layer {
 	Title: en "Aerodrome Node Default Style", de "Flugplatzknotenpunkt"
 	SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-a/4.0:AerodromeNode
 	Styles: TN_A_AerodromeNode
+}
+Layer {
+	id: "TN_AirTran_7_v5"
+	registry-id:""
+	tags: inspire production
+	Name: "TN.AirTransportNetwork.AerodromeNode"
+	Title: en "Aerodrome Node Default Style", de "Flugplatzknotenpunkt"
+	SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-a/5.0:AerodromeNode
+	Styles: TN_A_AerodromeNode_v5
 }
 Layer {
 	id: "TN_AirTran_8"
@@ -361,6 +541,15 @@ Layer {
 	Styles: TN_A_TouchDownLiftOff
 }
 Layer {
+	id: "TN_AirTran_8_v5"
+	registry-id:""
+	tags: inspire production
+	Name: "TN.AirTransportNetwork.TouchDownLiftOff"
+	Title: en "Touch Down Lift Off Area Default Style", de "Start- und Landebereich für Hubschrauber"
+	SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-a/5.0:TouchDownLiftOff
+	Styles: TN_A_TouchDownLiftOff_v5
+}
+Layer {
 	id: "TN_AirTran_9"
 	registry-id:""
 	tags: inspire production
@@ -368,6 +557,15 @@ Layer {
 	Title: en "Navaid Default Style", de "Navigationshilfe"
 	SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-a/4.0:Navaid
 	Styles: TN_A_Navaid
+}
+Layer {
+	id: "TN_AirTran_9_v5"
+	registry-id:""
+	tags: inspire production
+	Name: "TN.AirTransportNetwork.Navaid"
+	Title: en "Navaid Default Style", de "Navigationshilfe"
+	SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-a/5.0:Navaid
+	Styles: TN_A_Navaid_v5
 }
 Layer {
 	id: "TN_AirTran_10"
@@ -379,6 +577,15 @@ Layer {
 	Styles: TN_A_RunwayCentrelinePoint
 }
 Layer {
+	id: "TN_AirTran_10_v5"
+	registry-id:""
+	tags: inspire production
+	Name: "TN.AirTransportNetwork.RunwayCentrelinePoint"
+	Title: en "Runway Centreline Point Default Style", de "Mittellinienpunkt der Landebahn"
+	SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-a/5.0:RunwayCentrelinePoint
+	Styles: TN_A_RunwayCentrelinePoint_v5
+}
+Layer {
 	id: "TN_CableTr"
 	registry-id:"http://inspire.ec.europa.eu/layer/TN.CableTransportNetwork.CablewayLink"
 	tags: inspire production
@@ -386,6 +593,15 @@ Layer {
 	Title: en "Cableway Link Default Style", de "Seilbahnverbindung"
 	SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-c/4.0:CablewayLink
 	Styles: TN_C_CablewayLink
+}
+Layer {
+	id: "TN_CableTr_v5"
+	registry-id:"http://inspire.ec.europa.eu/layer/TN.CableTransportNetwork.CablewayLink"
+	tags: inspire production
+	Name: "TN.CableTransportNetwork.CablewayLink"
+	Title: en "Cableway Link Default Style", de "Seilbahnverbindung"
+	SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-c/5.0:CablewayLink
+	Styles: TN_C_CablewayLink_v5
 }
 Layer {
 	id: "TN_CommonT"
@@ -397,6 +613,15 @@ Layer {
 	Styles: TN_TransportArea
 }
 Layer {
+	id: "TN_CommonT_v5"
+	registry-id:"http://inspire.ec.europa.eu/layer/TN.CommonTransportElements.TransportArea"
+	tags: inspire production
+	Name: "TN.CommonTransportElements.TransportArea"
+	Title: en "Generic Transport Area Default Style", de "Generischer Verkehrsbereich"
+	SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn/5.0:TransportArea
+	Styles: TN_TransportArea_v5
+}
+Layer {
 	id: "TN_CommonT_1"
 	registry-id:"http://inspire.ec.europa.eu/layer/TN.CommonTransportElements.TransportLink"
 	tags: inspire production
@@ -404,6 +629,15 @@ Layer {
 	Title: en "Generic Transport Link Default Style", de "Generisches Verkehrssegment"
 	SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn/4.0:TransportLink
 	Styles: TN_TransportLink
+}
+Layer {
+	id: "TN_CommonT_1_v5"
+	registry-id:"http://inspire.ec.europa.eu/layer/TN.CommonTransportElements.TransportLink"
+	tags: inspire production
+	Name: "TN.CommonTransportElements.TransportLink"
+	Title: en "Generic Transport Link Default Style", de "Generisches Verkehrssegment"
+	SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn/5.0:TransportLink
+	Styles: TN_TransportLink_v5
 }
 Layer {
 	id: "TN_CommonT_2"
@@ -415,6 +649,15 @@ Layer {
 	Styles: TN_TransportNode
 }
 Layer {
+	id: "TN_CommonT_2_v5"
+	registry-id:"http://inspire.ec.europa.eu/layer/TN.CommonTransportElements.TransportNode"
+	tags: inspire production
+	Name: "TN.CommonTransportElements.TransportNode"
+	Title: en "Generic Transport Node Default Style", de "Generischer Verkehrsknotenpunkt"
+	SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn/5.0:TransportNode
+	Styles: TN_TransportNode_v5
+}
+Layer {
 	id: "TN_RailTra"
 	registry-id:"http://inspire.ec.europa.eu/layer/TN.RailTransportNetwork.RailwayArea"
 	tags: inspire production
@@ -422,6 +665,15 @@ Layer {
 	Title: en "Railway Area Default Style", de "Bahngelände"
 	SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-ra/4.0:RailwayArea
 	Styles: TN_RA_RailwayArea
+}
+Layer {
+	id: "TN_RailTra_v5"
+	registry-id:"http://inspire.ec.europa.eu/layer/TN.RailTransportNetwork.RailwayArea"
+	tags: inspire production
+	Name: "TN.RailTransportNetwork.RailwayArea"
+	Title: en "Railway Area Default Style", de "Bahngelände"
+	SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-ra/5.0:RailwayArea
+	Styles: TN_RA_RailwayArea_v5
 }
 Layer {
 	id: "TN_RailTra_1"
@@ -433,6 +685,15 @@ Layer {
 	Styles: TN_RA_RailwayLink
 }
 Layer {
+	id: "TN_RailTra_1_v5"
+	registry-id:"http://inspire.ec.europa.eu/layer/TN.RailTransportNetwork.RailwayLink"
+	tags: inspire production
+	Name: "TN.RailTransportNetwork.RailwayLink"
+	Title: en "Railway Link Default Style", de "Eisenbahnverbindung"
+	SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-ra/5.0:RailwayLink
+	Styles: TN_RA_RailwayLink_v5
+}
+Layer {
 	id: "TN_RailTra_2"
 	registry-id:"http://inspire.ec.europa.eu/layer/TN.RailTransportNetwork.RailwayStationArea"
 	tags: inspire production
@@ -440,6 +701,15 @@ Layer {
 	Title: en "Railway Station Area Default Style", de "Bahnhofsgelände"
 	SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-ra/4.0:RailwayStationArea
 	Styles: TN_RA_RailwayStationArea
+}
+Layer {
+	id: "TN_RailTra_2_v5"
+	registry-id:"http://inspire.ec.europa.eu/layer/TN.RailTransportNetwork.RailwayStationArea"
+	tags: inspire production
+	Name: "TN.RailTransportNetwork.RailwayStationArea"
+	Title: en "Railway Station Area Default Style", de "Bahnhofsgelände"
+	SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-ra/5.0:RailwayStationArea
+	Styles: TN_RA_RailwayStationArea_v5
 }
 Layer {
 	id: "TN_RailTra_3"
@@ -451,6 +721,15 @@ Layer {
 	Styles: TN_RA_RailwayYardArea
 }
 Layer {
+	id: "TN_RailTra_3_v5"
+	registry-id:"http://inspire.ec.europa.eu/layer/TN.RailTransportNetwork.RailwayYardArea"
+	tags: inspire production
+	Name: "TN.RailTransportNetwork.RailwayYardArea"
+	Title: en "Railway Yard Area Default Style", de "Rangierbahnhofsgelände"
+	SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-ra/5.0:RailwayYardArea
+	Styles: TN_RA_RailwayYardArea_v5
+}
+Layer {
 	id: "TN_RoadTra"
 	registry-id:"http://inspire.ec.europa.eu/layer/TN.RoadTransportNetwork.RoadArea"
 	tags: inspire production
@@ -458,6 +737,15 @@ Layer {
 	Title: en "Road Area Default Style", de "Straßenfläche"
 	SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-ro/4.0:RoadArea
 	Styles: TN_RO_RoadArea
+}
+Layer {
+	id: "TN_RoadTra_v5"
+	registry-id:"http://inspire.ec.europa.eu/layer/TN.RoadTransportNetwork.RoadArea"
+	tags: inspire production
+	Name: "TN.RoadTransportNetwork.RoadArea"
+	Title: en "Road Area Default Style", de "Straßenfläche"
+	SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-ro/5.0:RoadArea
+	Styles: TN_RO_RoadArea_v5
 }
 Layer {
 	id: "TN_RoadTra_1"
@@ -469,6 +757,15 @@ Layer {
 	Styles: TN_RO_RoadLink
 }
 Layer {
+	id: "TN_RoadTra_1_v5"
+	registry-id:"http://inspire.ec.europa.eu/layer/TN.RoadTransportNetwork.RoadLink"
+	tags: inspire production
+	Name: "TN.RoadTransportNetwork.RoadLink"
+	Title: en "Road Link Default Style", de "Straßensegment"
+	SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-ro/5.0:RoadLink
+	Styles: TN_RO_RoadLink_v5
+}
+Layer {
 	id: "TN_RoadTra_2"
 	registry-id:"http://inspire.ec.europa.eu/layer/TN.RoadTransportNetwork.RoadServiceArea"
 	tags: inspire production
@@ -476,6 +773,15 @@ Layer {
 	Title: en "Road Service Area Default Style", de "Servicebereich"
 	SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-ro/4.0:RoadServiceArea
 	Styles: TN_RO_RoadServiceArea
+}
+Layer {
+	id: "TN_RoadTra_2_v5"
+	registry-id:"http://inspire.ec.europa.eu/layer/TN.RoadTransportNetwork.RoadServiceArea"
+	tags: inspire production
+	Name: "TN.RoadTransportNetwork.RoadServiceArea"
+	Title: en "Road Service Area Default Style", de "Servicebereich"
+	SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-ro/5.0:RoadServiceArea
+	Styles: TN_RO_RoadServiceArea_v5
 }
 Layer {
 	id: "TN_RoadTra_3"
@@ -487,6 +793,15 @@ Layer {
 	Styles: TN_RO_VehicleTrafficArea
 }
 Layer {
+	id: "TN_RoadTra_3_v5"
+	registry-id:"http://inspire.ec.europa.eu/layer/TN.RoadTransportNetwork.VehicleTrafficArea"
+	tags: inspire production
+	Name: "TN.RoadTransportNetwork.VehicleTrafficArea"
+	Title: en "Vehicle traffic Area Default Style", de "Verkehrsfläche"
+	SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-ro/5.0:VehicleTrafficArea
+	Styles: TN_RO_VehicleTrafficArea_v5
+}
+Layer {
 	id: "TN_WaterTr"
 	registry-id:"http://inspire.ec.europa.eu/layer/TN.WaterTransportNetwork.FairwayArea"
 	tags: inspire production
@@ -494,6 +809,15 @@ Layer {
 	Title: en "Fairway Area Default Style", de "Fahrrinnenbereich"
 	SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-w/4.0:FairwayArea
 	Styles: TN_W_FairwayArea
+}
+Layer {
+	id: "TN_WaterTr_v5"
+	registry-id:"http://inspire.ec.europa.eu/layer/TN.WaterTransportNetwork.FairwayArea"
+	tags: inspire production
+	Name: "TN.WaterTransportNetwork.FairwayArea"
+	Title: en "Fairway Area Default Style", de "Fahrrinnenbereich"
+	SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-w/5.0:FairwayArea
+	Styles: TN_W_FairwayArea_v5
 }
 Layer {
 	id: "TN_WaterTr_1"
@@ -505,6 +829,15 @@ Layer {
 	Styles: TN_W_PortArea
 }
 Layer {
+	id: "TN_WaterTr_1_v5"
+	registry-id:"http://inspire.ec.europa.eu/layer/TN.WaterTransportNetwork.PortArea"
+	tags: inspire production
+	Name: "TN.WaterTransportNetwork.PortArea"
+	Title: en "Port Area Default Style", de "Hafengelände"
+	SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-w/5.0:PortArea
+	Styles: TN_W_PortArea_v5
+}
+Layer {
 	id: "TN_WaterTr_2"
 	registry-id:"http://inspire.ec.europa.eu/layer/TN.WaterTransportNetwork.WaterwayLink"
 	tags: inspire production
@@ -512,6 +845,15 @@ Layer {
 	Title: en "Waterway Link Default Style", de "Wasserstraßenverbindung"
 	SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-w/4.0:WaterwayLink
 	Styles: TN_W_WaterwayLink
+}
+Layer {
+	id: "TN_WaterTr_2_v5"
+	registry-id:"http://inspire.ec.europa.eu/layer/TN.WaterTransportNetwork.WaterwayLink"
+	tags: inspire production
+	Name: "TN.WaterTransportNetwork.WaterwayLink"
+	Title: en "Waterway Link Default Style", de "Wasserstraßenverbindung"
+	SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-w/5.0:WaterwayLink
+	Styles: TN_W_WaterwayLink_v5
 }
 Layer {
 	id:"LC_LandCoverSurfaces"
@@ -523,6 +865,15 @@ Layer {
 	Styles: LC_LandCoverSurfaces
 }
 Layer {
+	id: "LC_LandCoverSurfaces_v5"
+	registry-id:"http://inspire.ec.europa.eu/layer/LC.LandCoverSurfaces"
+	tags: production inspire
+	Name: "LC.LandCoverSurfaces"
+	Title: en "Land Cover Surfaces", de "Bodenbedeckungsflächen"
+	SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/lcv/5.0:LandCoverUnit
+	Styles: LC_LandCoverSurfaces_v5
+}
+Layer {
 	id:"LC_LandCoverPoints"
 	registry-id:"http://inspire.ec.europa.eu/layer/LC.LandCoverPoints"
 	tags: production inspire
@@ -530,6 +881,15 @@ Layer {
 	Title: en "Land Cover Points", de "Bodenbedeckungspunkte"
 	SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/lcv/4.0:LandCoverUnit
 	Styles: LC_LandCoverPoints
+}
+Layer {
+	id: "LC_LandCoverPoints_v5"
+	registry-id:"http://inspire.ec.europa.eu/layer/LC.LandCoverPoints"
+	tags: production inspire
+	Name: "LC.LandCoverPoints"
+	Title: en "Land Cover Points", de "Bodenbedeckungspunkte"
+	SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/lcv/5.0:LandCoverUnit
+	Styles: LC_LandCoverPoints_v5
 }
 Layer {
 	id: "BU_Building"
@@ -593,6 +953,15 @@ Layer{
 	Title: en "Governmental Service", de "Staatlicher Dienst"
 	SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/us-govserv/4.0:GovernmentalService
 	Styles: US_GovernmentalService
+}
+Layer {
+	id: "US_GovernmentalService_v5"
+	registry-id:""
+	tags: inspire
+	Name: "US.GovernmentalService"
+	Title: en "Governmental Service", de "Staatlicher Dienst"
+	SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/us-govserv/5.0:GovernmentalService
+	Styles: US_GovernmentalService_v5
 }
 Layer{
 	id:"AM_AirQualityManagementZone"
@@ -774,6 +1143,15 @@ Layer{
 	SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/us-emf/4.0:EnvironmentalManagementFacility
 	Styles: US_EnvironmentalManagementFacility
 }
+Layer {
+	id: "US_EnvironmentalManagementFacility_v5"
+	registry-id: "https://inspire.ec.europa.eu/layer/US.EnvironmentalManagementFacility"
+	tags: inspire production
+	Name: "US.EnvironmentalManagementFacility"
+	Title: en "Environmental Management Facility", de "Umweltmanagementeinrichtungen"
+	SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/us-emf/5.0:EnvironmentalManagementFacility
+	Styles: US_EnvironmentalManagementFacility_v5
+}
 Layer{
 	id: "US_UtilityNetworkAppurtenance"
 	registry-id: ""
@@ -783,6 +1161,15 @@ Layer{
 	SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/us-net-common/4.0:Appurtenance
 	Styles: US_UtilityNetworkAppurtenance
 }
+Layer {
+	id: "US_UtilityNetworkAppurtenance_v5"
+	registry-id: ""
+	tags: inspire production
+	Name: "US.UtilityNetworkAppurtenance"
+	Title: en "Appurtenance", de "Zubehörteil"
+	SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/us-net-common/5.0:Appurtenance
+	Styles: US_UtilityNetworkAppurtenance_v5
+}
 Layer{
 	id: "US_UtilityNetworkLink"
 	registry-id: ""
@@ -791,6 +1178,15 @@ Layer{
 	Title: en "Utility Link", de "Versorgungsverbindung"
 	SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/us-net-common/4.0:UtilityLink
 	Styles: US_UtilityNetworkLink
+}
+Layer {
+	id: "US_UtilityNetworkLink_v5"
+	registry-id: ""
+	tags: inspire production
+	Name: "US.UtilityNetworkLink"
+	Title: en "Utility Link", de "Versorgungsverbindung"
+	SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/us-net-common/5.0:UtilityLink
+	Styles: US_UtilityNetworkLink_v5
 }
 Layer{
 	id: "EF_EnvironmentalMonitoringFacilities"
@@ -864,6 +1260,15 @@ Layer{
 	SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn/4.0:MarkerPost
 	Styles: TN_MarkerPost
 }
+Layer {
+	id: "TN_MarkerPost_v5"
+	registry-id:""
+	tags: inspire production //wetransform custom
+	Name: "TN.CommonTransportElements.MarkerPost"
+	Title: en "Marker Post", de "Stationszeichen"
+	SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn/5.0:MarkerPost
+	Styles: TN_MarkerPost_v5
+}
 Layer{
 	id: "TN_W_Beacon"
 	registry-id: ""
@@ -872,6 +1277,15 @@ Layer{
 	Title: en "Beacon", de "Leuchtfeuer"
 	SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-w/4.0:Beacon
 	Styles: TN_W_Beacon
+}
+Layer {
+	id: "TN_W_Beacon_v5"
+	registry-id: ""
+	tags: inspire production //wetransform custom
+	Name:"TN.WaterTransportNetwork.Beacon"
+	Title: en "Beacon", de "Leuchtfeuer"
+	SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-w/5.0:Beacon
+	Styles: TN_W_Beacon_v5
 }
 Layer{
 	id: "TN_W_Buoy"
@@ -882,6 +1296,15 @@ Layer{
 	SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-w/4.0:Buoy
 	Styles: TN_W_Buoy
 }
+Layer {
+	id: "TN_W_Buoy_v5"
+	registry-id: ""
+	tags: inspire production //wetransform custom
+	Name: "TN.WaterTransportNetwork.Buoy"
+	Title: en "Buoy", de "Tonne"
+	SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-w/5.0:Buoy
+	Styles: TN_W_Buoy_v5
+}
 Layer{
 	id: "TN_W_TrafficSeparationSchemeCrossing"
 	registry-id:""
@@ -891,6 +1314,15 @@ Layer{
 	SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-w/4.0:TrafficSeparationSchemeCrossing
 	Styles: TN_W_TrafficSeparationSchemeCrossing
 }
+Layer {
+	id: "TN_W_TrafficSeparationSchemeCrossing_v5"
+	registry-id:""
+	tags: inspire production //wetransform custom
+	Name: "TN.WaterTransportNetwork.TrafficSeparationSchemeCrossing"
+	Title: en "Traffic Separation Scheme Crossing", de "Kreuzung eines Verkehrstrennungsgebiets"
+	SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-w/5.0:TrafficSeparationSchemeCrossing
+	Styles: TN_W_TrafficSeparationSchemeCrossing_v5
+}
 Layer{
 	id: "TN_W_TrafficSeparationSchemeSeparator"
 	registry-id:""
@@ -899,6 +1331,15 @@ Layer{
 	Title: en "Traffic Separation Scheme Separator", de "Übergangszone eines Verkehrstrennungsgebiets"
 	SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-w/4.0:TrafficSeparationSchemeSeparator
 	Styles: TN_W_TrafficSeparationSchemeSeparator
+}
+Layer {
+	id: "TN_W_TrafficSeparationSchemeSeparator_v5"
+	registry-id:""
+	tags: inspire production //wetransform custom
+	Name: "TN.WaterTransportNetwork.TrafficSeparationSchemeSeparator"
+	Title: en "Traffic Separation Scheme Separator", de "Übergangszone eines Verkehrstrennungsgebiets"
+	SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-w/5.0:TrafficSeparationSchemeSeparator
+	Styles: TN_W_TrafficSeparationSchemeSeparator_v5
 }
 Layer{
 	id: "PF_ProductionFacility"
@@ -1044,6 +1485,15 @@ Layer{
 	SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/hh/4.0:EnvHealthDeterminantMeasure
 	Styles: HH_HealthDeterminantMeasure
 }
+Layer {
+	id: "HH_HealthDeterminantMeasure_v5"
+	registry-id: "http://inspire.ec.europa.eu/layer/HH.HealthDeterminantMeasure"
+	tags: inspire production
+	Name: "HH.HealthDeterminantMeasure"
+	Title: en "Health determinant measure", de "Messwerte für Gesundheitsfaktoren"
+	SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/hh/5.0:EnvHealthDeterminantMeasure
+	Styles: HH_HealthDeterminantMeasure_v5
+}
 Layer{
 	id: "EL_BreakLine"
 	registry-id: "http://inspire.ec.europa.eu/layer/EL.BreakLine"
@@ -1125,6 +1575,15 @@ Layer{
 	SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-ro/4.0:RoadNode
 	Styles: TN_RO_RoadNode
 }
+Layer {
+	id: "TN_RO_RoadNode_v5"
+	registry-id:""
+	tags: inspire production
+	Name: "TN.RoadNode"
+	Title: en "Road Node", de "Strassenknotenpunkt"
+	SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-ro/5.0:RoadNode
+	Styles: TN_RO_RoadNode_v5
+}
 Layer{
 	id: "SF_SpatialSamplingFeature"
 	registry-id:""
@@ -1149,10 +1608,24 @@ Style {
 	}
 }
 Style {
+	id: "US_UtilityNetworkAppurtenance_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/us-net-common/5.0:Appurtenance
+		URL: "feature-styles/US_UtilityNetworkAppurtenance_v5_0.se"
+	}
+}
+Style {
 	id: "US_UtilityNetworkLink"
 	Remote {
 		FeatureType: http://inspire.ec.europa.eu/schemas/us-net-common/4.0:UtilityLink
 		URL: "feature-styles/US_UtilityNetworkLink.se"
+	}
+}
+Style {
+	id: "US_UtilityNetworkLink_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/us-net-common/5.0:UtilityLink
+		URL: "feature-styles/US_UtilityNetworkLink_v5_0.se"
 	}
 }
 Style {
@@ -1163,10 +1636,24 @@ Style {
 	}
 }
 Style {
+	id: "US_EnvironmentalManagementFacility_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/us-emf/5.0:EnvironmentalManagementFacility
+		URL: "feature-styles/US_EnvironmentalManagementFacility_v5_0.se"
+	}
+}
+Style {
 	id: "TN_A_DesignatedPoint"
 	Remote {
 		FeatureType: http://inspire.ec.europa.eu/schemas/tn-a/4.0:DesignatedPoint
 		URL: "feature-styles/TN_A_DesignatedPoint.se"
+	}
+}
+Style {
+	id: "TN_A_DesignatedPoint_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/tn-a/5.0:DesignatedPoint
+		URL: "feature-styles/TN_A_DesignatedPoint_v5_0.se"
 	}
 }
 Style {
@@ -1177,10 +1664,24 @@ Style {
 	}
 }
 Style {
+	id: "TN_A_Navaid_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/tn-a/5.0:Navaid
+		URL: "feature-styles/TN_A_Navaid_v5_0.se"
+	}
+}
+Style {
 	id: "TN_A_RunwayCentrelinePoint"
 	Remote {
 		FeatureType: http://inspire.ec.europa.eu/schemas/tn-a/4.0:RunwayCentrelinePoint
 		URL: "feature-styles/TN_A_RunwayCentrelinePoint.se"
+	}
+}
+Style {
+	id: "TN_A_RunwayCentrelinePoint_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/tn-a/5.0:RunwayCentrelinePoint
+		URL: "feature-styles/TN_A_RunwayCentrelinePoint_v5_0.se"
 	}
 }
 Style {
@@ -1191,10 +1692,24 @@ Style {
 	}
 }
 Style {
+	id: "TN_A_AerodromeNode_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/tn-a/5.0:AerodromeNode
+		URL: "feature-styles/TN_A_AerodromeNode_v5_0.se"
+	}
+}
+Style {
 	id: "TN_A_TouchDownLiftOff"
 	Remote {
 		FeatureType: http://inspire.ec.europa.eu/schemas/tn-a/4.0:TouchDownLiftOff
 		URL: "feature-styles/TN_A_TouchDownLiftOff.se"
+	}
+}
+Style {
+	id: "TN_A_TouchDownLiftOff_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/tn-a/5.0:TouchDownLiftOff
+		URL: "feature-styles/TN_A_TouchDownLiftOff_v5_0.se"
 	}
 }
 Style{
@@ -1202,6 +1717,13 @@ Style{
 	Remote{
 		FeatureType: http://inspire.ec.europa.eu/schemas/tn-ro/4.0:RoadNode
 		URL: "feature-styles/TN_RO_RoadNode.se"
+	}
+}
+Style {
+	id: "TN_RO_RoadNode_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/tn-ro/5.0:RoadNode
+		URL: "feature-styles/TN_RO_RoadNode_v5_0.se"
 	}
 }
 Style{
@@ -1265,6 +1787,13 @@ Style{
 	Remote{
 		FeatureType: http://inspire.ec.europa.eu/schemas/hh/4.0:EnvHealthDeterminantMeasure
 		URL: "feature-styles/HH_HealthDeterminantMeasure.se"
+	}
+}
+Style {
+	id: "HH_HealthDeterminantMeasure_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/hh/5.0:EnvHealthDeterminantMeasure
+		URL: "feature-styles/HH_HealthDeterminantMeasure_v5_0.se"
 	}
 }
 Style{
@@ -1372,11 +1901,25 @@ Style{
 		URL:"feature-styles/TN_W_TrafficSeparationSchemeSeparator.se"
 	}
 }
+Style {
+	id: "TN_W_TrafficSeparationSchemeSeparator_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/tn-w/5.0:TrafficSeparationSchemeSeparator
+		URL: "feature-styles/TN_W_TrafficSeparationSchemeSeparator_v5_0.se"
+	}
+}
 Style{
 	id: "TN_W_TrafficSeparationSchemeCrossing"
 	Remote{
 		FeatureType: http://inspire.ec.europa.eu/schemas/tn-w/4.0:TrafficSeparationSchemeCrossing
 		URL: "feature-styles/TN_W_TrafficSeparationSchemeCrossing.se"
+	}
+}
+Style {
+	id: "TN_W_TrafficSeparationSchemeCrossing_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/tn-w/5.0:TrafficSeparationSchemeCrossing
+		URL: "feature-styles/TN_W_TrafficSeparationSchemeCrossing_v5_0.se"
 	}
 }
 Style{
@@ -1386,6 +1929,13 @@ Style{
 		URL: "feature-styles/TN_W_Buoy.se"
 	}
 }
+Style {
+	id: "TN_W_Buoy_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/tn-w/5.0:Buoy
+		URL: "feature-styles/TN_W_Buoy_v5_0.se"
+	}
+}
 Style{
 	id: "TN_W_Beacon"
 	Remote{
@@ -1393,11 +1943,25 @@ Style{
 		URL: "feature-styles/TN_W_Beacon.se"
 	}
 }
+Style {
+	id: "TN_W_Beacon_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/tn-w/5.0:Beacon
+		URL: "feature-styles/TN_W_Beacon_v5_0.se"
+	}
+}
 Style{
 	id: "TN_MarkerPost"
 	Remote{
 		FeatureType: http://inspire.ec.europa.eu/schemas/tn/4.0:MarkerPost
 		URL: "feature-styles/TN_MarkerPost.se"
+	}
+}
+Style {
+	id: "TN_MarkerPost_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/tn/5.0:MarkerPost
+		URL: "feature-styles/TN_MarkerPost_v5_0.se"
 	}
 }
 Style{
@@ -1589,6 +2153,13 @@ Style{
 		URL: "feature-styles/US_GovernmentalService.se"
 	}
 }
+Style {
+	id: "US_GovernmentalService_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/us-govserv/5.0:GovernmentalService
+		URL: "feature-styles/US_GovernmentalService_v5_0.se"
+	}
+}
 Style{
 	id:"LU_SupplementaryRegulation"
 	Remote{
@@ -1751,10 +2322,24 @@ Style {
 	}
 }
 Style {
+	id: "HY_N_WatercourseLink_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/hy-n/5.0:WatercourseLink
+		URL: "feature-styles/HY_N_WatercourseLink_v5_0.se"
+	}
+}
+Style {
 	id: "HY_N_HydroNode"
 	Remote {
 		FeatureType: http://inspire.ec.europa.eu/schemas/hy-n/4.0:HydroNode
 		URL: "feature-styles/HY_N_HydroNode.se"
+	}
+}
+Style {
+	id: "HY_N_HydroNode_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/hy-n/5.0:HydroNode
+		URL: "feature-styles/HY_N_HydroNode_v5_0.se"
 	}
 }
 Style {
@@ -1765,10 +2350,24 @@ Style {
 	}
 }
 Style {
+	id: "HY_P_DrainageBasin_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/hy-p/5.0:DrainageBasin
+		URL: "feature-styles/HY_P_DrainageBasin_v5_0.se"
+	}
+}
+Style {
 	id: "HY_P_RiverBasin"
 	Remote {
 		FeatureType: http://inspire.ec.europa.eu/schemas/hy-p/4.0:RiverBasin
 		URL: "feature-styles/HY_P_RiverBasin.se"
+	}
+}
+Style {
+	id: "HY_P_RiverBasin_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/hy-p/5.0:RiverBasin
+		URL: "feature-styles/HY_P_RiverBasin_v5_0.se"
 	}
 }
 Style {
@@ -1779,10 +2378,24 @@ Style {
 	}
 }
 Style {
+	id: "HY_P_Rapids_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/hy-p/5.0:Rapids
+		URL: "feature-styles/HY_P_Rapids_v5_0.se"
+	}
+}
+Style {
 	id: "HY_P_Falls"
 	Remote {
 		FeatureType: http://inspire.ec.europa.eu/schemas/hy-p/4.0:Falls
 		URL: "feature-styles/HY_P_Falls.se"
+	}
+}
+Style {
+	id: "HY_P_Falls_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/hy-p/5.0:Falls
+		URL: "feature-styles/HY_P_Falls_v5_0.se"
 	}
 }
 Style {
@@ -1793,10 +2406,24 @@ Style {
 	}
 }
 Style {
+	id: "HY_P_LandWaterBoundary_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/hy-p/5.0:LandWaterBoundary
+		URL: "feature-styles/HY_P_LandWaterBoundary_v5_0.se"
+	}
+}
+Style {
 	id: "HY_P_Crossing"
 	Remote {
 		FeatureType: http://inspire.ec.europa.eu/schemas/hy-p/4.0:Crossing
 		URL: "feature-styles/HY_P_Crossing.se"
+	}
+}
+Style {
+	id: "HY_P_Crossing_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/hy-p/5.0:Crossing
+		URL: "feature-styles/HY_P_Crossing_v5_0.se"
 	}
 }
 Style {
@@ -1807,10 +2434,24 @@ Style {
 	}
 }
 Style {
+	id: "HY_P_DamOrWeir_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/hy-p/5.0:DamOrWeir
+		URL: "feature-styles/HY_P_DamOrWeir_v5_0.se"
+	}
+}
+Style {
 	id: "HY_P_ShoreLineConstruction"
 	Remote {
 		FeatureType: http://inspire.ec.europa.eu/schemas/hy-p/4.0:ShorelineConstruction
 		URL: "feature-styles/HY_P_ShoreLineConstruction.se"
+	}
+}
+Style {
+	id: "HY_P_ShoreLineConstruction_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/hy-p/5.0:ShorelineConstruction
+		URL: "feature-styles/HY_P_ShoreLineConstruction_v5_0.se"
 	}
 }
 Style {
@@ -1821,10 +2462,24 @@ Style {
 	}
 }
 Style {
+	id: "HY_P_Ford_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/hy-p/5.0:Ford
+		URL: "feature-styles/HY_P_Ford_v5_0.se"
+	}
+}
+Style {
 	id: "HY_P_Lock"
 	Remote {
 		FeatureType: http://inspire.ec.europa.eu/schemas/hy-p/4.0:Lock
 		URL: "feature-styles/HY_P_Lock.se"
+	}
+}
+Style {
+	id: "HY_P_Lock_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/hy-p/5.0:Lock
+		URL: "feature-styles/HY_P_Lock_v5_0.se"
 	}
 }
 Style {
@@ -1835,10 +2490,24 @@ Style {
 	}
 }
 Style {
+	id: "HY_P_Shore_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/hy-p/5.0:Shore
+		URL: "feature-styles/HY_P_Shore_v5_0.se"
+	}
+}
+Style {
 	id: "HY_P_Watercourse"
 	Remote {
 		FeatureType: http://inspire.ec.europa.eu/schemas/hy-p/4.0:Watercourse
 		URL: "feature-styles/HY_P_Watercourse.se"
+	}
+}
+Style {
+	id: "HY_P_Watercourse_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/hy-p/5.0:Watercourse
+		URL: "feature-styles/HY_P_Watercourse_v5_0.se"
 	}
 }
 Style {
@@ -1849,10 +2518,24 @@ Style {
 	}
 }
 Style {
+	id: "HY_P_StandingWater_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/hy-p/5.0:StandingWater
+		URL: "feature-styles/HY_P_StandingWater_v5_0.se"
+	}
+}
+Style {
 	id: "HY_P_Watercourse_ManMade"
 	Remote {
 		FeatureType: http://inspire.ec.europa.eu/schemas/hy-p/4.0:Watercourse
 		URL: "feature-styles/HY_P_Watercourse_ManMade.se"
+	}
+}
+Style {
+	id: "HY_P_Watercourse_ManMade_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/hy-p/5.0:Watercourse
+		URL: "feature-styles/HY_P_Watercourse_ManMade_v5_0.se"
 	}
 }
 Style {
@@ -1863,10 +2546,24 @@ Style {
 	}
 }
 Style {
+	id: "HY_P_StandingWater_ManMade_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/hy-p/5.0:StandingWater
+		URL: "feature-styles/HY_P_StandingWater_ManMade_v5_0.se"
+	}
+}
+Style {
 	id: "HY_P_WatercoursePersistence"
 	Remote {
 		FeatureType: http://inspire.ec.europa.eu/schemas/hy-p/4.0:Watercourse
 		URL: "feature-styles/HY_P_WatercoursePersistence.se"
+	}
+}
+Style {
+	id: "HY_P_WatercoursePersistence_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/hy-p/5.0:Watercourse
+		URL: "feature-styles/HY_P_WatercoursePersistence_v5_0.se"
 	}
 }
 Style {
@@ -1877,10 +2574,24 @@ Style {
 	}
 }
 Style {
+	id: "HY_P_WaterbodiesPersistence_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/hy-p/5.0:StandingWater
+		URL: "feature-styles/HY_P_WaterbodiesPersistence_v5_0.se"
+	}
+}
+Style {
 	id: "HY_P_Wetland"
 	Remote {
 		FeatureType: http://inspire.ec.europa.eu/schemas/hy-p/4.0:Wetland
 		URL: "feature-styles/HY_P_Wetland.se"
+	}
+}
+Style {
+	id: "HY_P_Wetland_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/hy-p/5.0:Wetland
+		URL: "feature-styles/HY_P_Wetland_v5_0.se"
 	}
 }
 
@@ -1889,6 +2600,13 @@ Style {
 	Remote {
 		FeatureType: http://inspire.ec.europa.eu/schemas/ps/4.0:ProtectedSite
 		URL: "feature-styles/PS_ProtectedSites.se"
+	}
+}
+Style {
+	id: "PS_ProtectedSite_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/ps/5.0:ProtectedSite
+		URL: "feature-styles/PS_ProtectedSites_v5_0.se"
 	}
 }
 Style {
@@ -1905,12 +2623,26 @@ Style {
 		URL: "feature-styles/TN_A_AerodromeArea.se"
 	}
 }
+Style {
+	id: "TN_A_AerodromeArea_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/tn-a/5.0:AerodromeArea
+		URL: "feature-styles/TN_A_AerodromeArea_v5_0.se"
+	}
+}
 
 Style {
 	id: "TN_A_ProcedureLink"
 	Remote {
 		FeatureType: http://inspire.ec.europa.eu/schemas/tn-a/4.0:ProcedureLink
 		URL: "feature-styles/TN_A_ProcedureLink.se"
+	}
+}
+Style {
+	id: "TN_A_ProcedureLink_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/tn-a/5.0:ProcedureLink
+		URL: "feature-styles/TN_A_ProcedureLink_v5_0.se"
 	}
 }
 Style {
@@ -1921,10 +2653,24 @@ Style {
 	}
 }
 Style {
+	id: "TN_A_AirRouteLink_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/tn-a/5.0:AirRouteLink
+		URL: "feature-styles/TN_A_AirRouteLink_v5_0.se"
+	}
+}
+Style {
 	id: "TN_A_AirspaceArea"
 	Remote {
 		FeatureType: http://inspire.ec.europa.eu/schemas/tn-a/4.0:AirspaceArea
 		URL: "feature-styles/TN_A_AirspaceArea.se"
+	}
+}
+Style {
+	id: "TN_A_AirspaceArea_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/tn-a/5.0:AirspaceArea
+		URL: "feature-styles/TN_A_AirspaceArea_v5_0.se"
 	}
 }
 Style {
@@ -1935,10 +2681,24 @@ Style {
 	}
 }
 Style {
+	id: "TN_A_ApronArea_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/tn-a/5.0:ApronArea
+		URL: "feature-styles/TN_A_ApronArea_v5_0.se"
+	}
+}
+Style {
 	id: "TN_A_RunwayArea"
 	Remote {
 		FeatureType: http://inspire.ec.europa.eu/schemas/tn-a/4.0:RunwayArea
 		URL: "feature-styles/TN_A_RunwayArea.se"
+	}
+}
+Style {
+	id: "TN_A_RunwayArea_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/tn-a/5.0:RunwayArea
+		URL: "feature-styles/TN_A_RunwayArea_v5_0.se"
 	}
 }
 Style {
@@ -1949,10 +2709,24 @@ Style {
 	}
 }
 Style {
+	id: "TN_A_TaxiwayArea_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/tn-a/5.0:TaxiwayArea
+		URL: "feature-styles/TN_A_TaxiwayArea_v5_0.se"
+	}
+}
+Style {
 	id: "TN_C_CablewayLink"
 	Remote {
 		FeatureType: http://inspire.ec.europa.eu/schemas/tn-c/4.0:CablewayLink
 		URL: "feature-styles/TN_C_CablewayLink.se"
+	}
+}
+Style {
+	id: "TN_C_CablewayLink_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/tn-c/5.0:CablewayLink
+		URL: "feature-styles/TN_C_CablewayLink_v5_0.se"
 	}
 }
 Style {
@@ -1963,10 +2737,24 @@ Style {
 	}
 }
 Style {
+	id: "TN_TransportArea_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/tn/5.0:TransportArea
+		URL: "feature-styles/TN_TransportArea_v5_0.se"
+	}
+}
+Style {
 	id: "TN_TransportLink"
 	Remote {
 		FeatureType: http://inspire.ec.europa.eu/schemas/tn/4.0:TransportLink
 		URL: "feature-styles/TN_TransportLink.se"
+	}
+}
+Style {
+	id: "TN_TransportLink_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/tn/5.0:TransportLink
+		URL: "feature-styles/TN_TransportLink_v5_0.se"
 	}
 }
 Style {
@@ -1977,10 +2765,24 @@ Style {
 	}
 }
 Style {
+	id: "TN_TransportNode_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/tn/5.0:TransportNode
+		URL: "feature-styles/TN_TransportNode_v5_0.se"
+	}
+}
+Style {
 	id: "TN_RA_RailwayArea"
 	Remote {
 		FeatureType: http://inspire.ec.europa.eu/schemas/tn-ra/4.0:RailwayArea
 		URL: "feature-styles/TN_RA_RailwayArea.se"
+	}
+}
+Style {
+	id: "TN_RA_RailwayArea_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/tn-ra/5.0:RailwayArea
+		URL: "feature-styles/TN_RA_RailwayArea_v5_0.se"
 	}
 }
 Style {
@@ -1991,10 +2793,24 @@ Style {
 	}
 }
 Style {
+	id: "TN_RA_RailwayLink_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/tn-ra/5.0:RailwayLink
+		URL: "feature-styles/TN_RA_RailwayLink_v5_0.se"
+	}
+}
+Style {
 	id: "TN_RA_RailwayStationArea"
 	Remote {
 		FeatureType: http://inspire.ec.europa.eu/schemas/tn-ra/4.0:RailwayStationArea
 		URL: "feature-styles/TN_RA_RailwayStationArea.se"
+	}
+}
+Style {
+	id: "TN_RA_RailwayStationArea_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/tn-ra/5.0:RailwayStationArea
+		URL: "feature-styles/TN_RA_RailwayStationArea_v5_0.se"
 	}
 }
 Style {
@@ -2005,10 +2821,24 @@ Style {
 	}
 }
 Style {
+	id: "TN_RA_RailwayYardArea_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/tn-ra/5.0:RailwayYardArea
+		URL: "feature-styles/TN_RA_RailwayYardArea_v5_0.se"
+	}
+}
+Style {
 	id: "TN_RO_RoadArea"
 	Remote {
 		FeatureType: http://inspire.ec.europa.eu/schemas/tn-ro/4.0:RoadArea
 		URL: "feature-styles/TN_RO_RoadArea.se"
+	}
+}
+Style {
+	id: "TN_RO_RoadArea_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/tn-ro/5.0:RoadArea
+		URL: "feature-styles/TN_RO_RoadArea_v5_0.se"
 	}
 }
 Style {
@@ -2019,10 +2849,24 @@ Style {
 	}
 }
 Style {
+	id: "TN_RO_RoadLink_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/tn-ro/5.0:RoadLink
+		URL: "feature-styles/TN_RO_RoadLink_v5_0.se"
+	}
+}
+Style {
 	id: "TN_RO_RoadServiceArea"
 	Remote {
 		FeatureType: http://inspire.ec.europa.eu/schemas/tn-ro/4.0:RoadServiceArea
 		URL: "feature-styles/TN_RO_RoadServiceArea.se"
+	}
+}
+Style {
+	id: "TN_RO_RoadServiceArea_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/tn-ro/5.0:RoadServiceArea
+		URL: "feature-styles/TN_RO_RoadServiceArea_v5_0.se"
 	}
 }
 Style {
@@ -2033,10 +2877,24 @@ Style {
 	}
 }
 Style {
+	id: "TN_RO_VehicleTrafficArea_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/tn-ro/5.0:VehicleTrafficArea
+		URL: "feature-styles/TN_RO_VehicleTrafficArea_v5_0.se"
+	}
+}
+Style {
 	id: "TN_W_FairwayArea"
 	Remote {
 		FeatureType: http://inspire.ec.europa.eu/schemas/tn-w/4.0:FairwayArea
 		URL: "feature-styles/TN_W_FairwayArea.se"
+	}
+}
+Style {
+	id: "TN_W_FairwayArea_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/tn-w/5.0:FairwayArea
+		URL: "feature-styles/TN_W_FairwayArea_v5_0.se"
 	}
 }
 Style {
@@ -2047,10 +2905,24 @@ Style {
 	}
 }
 Style {
+	id: "TN_W_PortArea_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/tn-w/5.0:PortArea
+		URL: "feature-styles/TN_W_PortArea_v5_0.se"
+	}
+}
+Style {
 	id: "TN_W_WaterwayLink"
 	Remote {
 		FeatureType: http://inspire.ec.europa.eu/schemas/tn-w/4.0:WaterwayLink
 		URL: "feature-styles/TN_W_WaterwayLink.se"
+	}
+}
+Style {
+	id: "TN_W_WaterwayLink_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/tn-w/5.0:WaterwayLink
+		URL: "feature-styles/TN_W_WaterwayLink_v5_0.se"
 	}
 }
 Style {
@@ -2061,10 +2933,24 @@ Style {
 	}
 }
 Style {
+	id: "LC_LandCoverSurfaces_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/lcv/5.0:LandCoverUnit
+		URL: "feature-styles/LC_LandCoverSurfaces_v5_0.se"
+	}
+}
+Style {
 	id: "LC_LandCoverPoints"
 	Remote {
 		FeatureType: http://inspire.ec.europa.eu/schemas/lcv/4.0:LandCoverUnit
 		URL: "feature-styles/LC_LandCoverPoints.se"
+	}
+}
+Style {
+	id: "LC_LandCoverPoints_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/lcv/5.0:LandCoverUnit
+		URL: "feature-styles/LC_LandCoverPoints_v5_0.se"
 	}
 }
 Style {

--- a/config.xmi
+++ b/config.xmi
@@ -1,123 +1,150 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<styleconfig:StyleModel xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:ad_4.0="http://inspire.ec.europa.eu/schemas/ad/4.0" xmlns:am_4.0="http://inspire.ec.europa.eu/schemas/am/4.0" xmlns:au_4.0="http://inspire.ec.europa.eu/schemas/au/4.0" xmlns:br_4.0="http://inspire.ec.europa.eu/schemas/br/4.0" xmlns:bu-core2d_4.0="http://inspire.ec.europa.eu/schemas/bu-core2d/4.0" xmlns:cp_4.0="http://inspire.ec.europa.eu/schemas/cp/4.0" xmlns:ef_4.0="http://inspire.ec.europa.eu/schemas/ef/4.0" xmlns:el-tin_4.0="http://inspire.ec.europa.eu/schemas/el-tin/4.0" xmlns:el-vec_4.0="http://inspire.ec.europa.eu/schemas/el-vec/4.0" xmlns:elu_4.0="http://inspire.ec.europa.eu/schemas/elu/4.0" xmlns:er-v_4.0="http://inspire.ec.europa.eu/schemas/er-v/4.0" xmlns:ge-core_4.0="http://inspire.ec.europa.eu/schemas/ge-core/4.0" xmlns:gn_4.0="http://inspire.ec.europa.eu/schemas/gn/4.0" xmlns:hh_4.0="http://inspire.ec.europa.eu/schemas/hh/4.0" xmlns:hy-n_4.0="http://inspire.ec.europa.eu/schemas/hy-n/4.0" xmlns:hy-p_4.0="http://inspire.ec.europa.eu/schemas/hy-p/4.0" xmlns:lcv_4.0="http://inspire.ec.europa.eu/schemas/lcv/4.0" xmlns:mu_3.0="http://inspire.ec.europa.eu/schemas/mu/3.0" xmlns:nz-core_4.0="http://inspire.ec.europa.eu/schemas/nz-core/4.0" xmlns:pf_4.0="http://inspire.ec.europa.eu/schemas/pf/4.0" xmlns:plu_4.0="http://inspire.ec.europa.eu/schemas/plu/4.0" xmlns:ps_4.0="http://inspire.ec.europa.eu/schemas/ps/4.0" xmlns:ps_5.0="http://inspire.ec.europa.eu/schemas/ps/5.0" xmlns:samplingSpatial_2.0="http://www.opengis.net/samplingSpatial/2.0" xmlns:sd_4.0="http://inspire.ec.europa.eu/schemas/sd/4.0" xmlns:styleconfig="http://to.wetf.styling.models/model/styles" xmlns:su-grid_4.0="https://inspire.ec.europa.eu/schemas/su-grid/4.0" xmlns:su-vector_4.0="http://inspire.ec.europa.eu/schemas/su-vector/4.0" xmlns:tn-a_4.0="http://inspire.ec.europa.eu/schemas/tn-a/4.0" xmlns:tn-c_4.0="http://inspire.ec.europa.eu/schemas/tn-c/4.0" xmlns:tn-ra_4.0="http://inspire.ec.europa.eu/schemas/tn-ra/4.0" xmlns:tn-ro_4.0="http://inspire.ec.europa.eu/schemas/tn-ro/4.0" xmlns:tn-w_4.0="http://inspire.ec.europa.eu/schemas/tn-w/4.0" xmlns:tn_4.0="http://inspire.ec.europa.eu/schemas/tn/4.0" xmlns:us-emf_4.0="http://inspire.ec.europa.eu/schemas/us-emf/4.0" xmlns:us-govserv_4.0="http://inspire.ec.europa.eu/schemas/us-govserv/4.0" xmlns:us-net-common_4.0="http://inspire.ec.europa.eu/schemas/us-net-common/4.0">
+<styleconfig:StyleModel xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:ad_4.0="http://inspire.ec.europa.eu/schemas/ad/4.0" xmlns:am_4.0="http://inspire.ec.europa.eu/schemas/am/4.0" xmlns:au_4.0="http://inspire.ec.europa.eu/schemas/au/4.0" xmlns:br_4.0="http://inspire.ec.europa.eu/schemas/br/4.0" xmlns:bu-core2d_4.0="http://inspire.ec.europa.eu/schemas/bu-core2d/4.0" xmlns:cp_4.0="http://inspire.ec.europa.eu/schemas/cp/4.0" xmlns:ef_4.0="http://inspire.ec.europa.eu/schemas/ef/4.0" xmlns:el-tin_4.0="http://inspire.ec.europa.eu/schemas/el-tin/4.0" xmlns:el-vec_4.0="http://inspire.ec.europa.eu/schemas/el-vec/4.0" xmlns:elu_4.0="http://inspire.ec.europa.eu/schemas/elu/4.0" xmlns:er-v_4.0="http://inspire.ec.europa.eu/schemas/er-v/4.0" xmlns:ge-core_4.0="http://inspire.ec.europa.eu/schemas/ge-core/4.0" xmlns:gn_4.0="http://inspire.ec.europa.eu/schemas/gn/4.0" xmlns:hh_4.0="http://inspire.ec.europa.eu/schemas/hh/4.0" xmlns:hh_5.0="http://inspire.ec.europa.eu/schemas/hh/5.0" xmlns:hy-n_4.0="http://inspire.ec.europa.eu/schemas/hy-n/4.0" xmlns:hy-n_5.0="http://inspire.ec.europa.eu/schemas/hy-n/5.0" xmlns:hy-p_4.0="http://inspire.ec.europa.eu/schemas/hy-p/4.0" xmlns:hy-p_5.0="http://inspire.ec.europa.eu/schemas/hy-p/5.0" xmlns:lcv_4.0="http://inspire.ec.europa.eu/schemas/lcv/4.0" xmlns:lcv_5.0="http://inspire.ec.europa.eu/schemas/lcv/5.0" xmlns:mu_3.0="http://inspire.ec.europa.eu/schemas/mu/3.0" xmlns:nz-core_4.0="http://inspire.ec.europa.eu/schemas/nz-core/4.0" xmlns:pf_4.0="http://inspire.ec.europa.eu/schemas/pf/4.0" xmlns:plu_4.0="http://inspire.ec.europa.eu/schemas/plu/4.0" xmlns:ps_4.0="http://inspire.ec.europa.eu/schemas/ps/4.0" xmlns:ps_5.0="http://inspire.ec.europa.eu/schemas/ps/5.0" xmlns:samplingSpatial_2.0="http://www.opengis.net/samplingSpatial/2.0" xmlns:sd_4.0="http://inspire.ec.europa.eu/schemas/sd/4.0" xmlns:styleconfig="http://to.wetf.styling.models/model/styles" xmlns:su-grid_4.0="https://inspire.ec.europa.eu/schemas/su-grid/4.0" xmlns:su-vector_4.0="http://inspire.ec.europa.eu/schemas/su-vector/4.0" xmlns:tn-a_4.0="http://inspire.ec.europa.eu/schemas/tn-a/4.0" xmlns:tn-a_5.0="http://inspire.ec.europa.eu/schemas/tn-a/5.0" xmlns:tn-c_4.0="http://inspire.ec.europa.eu/schemas/tn-c/4.0" xmlns:tn-c_5.0="http://inspire.ec.europa.eu/schemas/tn-c/5.0" xmlns:tn-ra_4.0="http://inspire.ec.europa.eu/schemas/tn-ra/4.0" xmlns:tn-ra_5.0="http://inspire.ec.europa.eu/schemas/tn-ra/5.0" xmlns:tn-ro_4.0="http://inspire.ec.europa.eu/schemas/tn-ro/4.0" xmlns:tn-ro_5.0="http://inspire.ec.europa.eu/schemas/tn-ro/5.0" xmlns:tn-w_4.0="http://inspire.ec.europa.eu/schemas/tn-w/4.0" xmlns:tn-w_5.0="http://inspire.ec.europa.eu/schemas/tn-w/5.0" xmlns:tn_4.0="http://inspire.ec.europa.eu/schemas/tn/4.0" xmlns:tn_5.0="http://inspire.ec.europa.eu/schemas/tn/5.0" xmlns:us-emf_4.0="http://inspire.ec.europa.eu/schemas/us-emf/4.0" xmlns:us-emf_5.0="http://inspire.ec.europa.eu/schemas/us-emf/5.0" xmlns:us-govserv_4.0="http://inspire.ec.europa.eu/schemas/us-govserv/4.0" xmlns:us-govserv_5.0="http://inspire.ec.europa.eu/schemas/us-govserv/5.0" xmlns:us-net-common_4.0="http://inspire.ec.europa.eu/schemas/us-net-common/4.0" xmlns:us-net-common_5.0="http://inspire.ec.europa.eu/schemas/us-net-common/5.0">
   <tags name="inspire"/>
   <tags name="inspire_wetransform"/>
   <tags name="production"/>
-  <layerConfig name="AD_Address" registryId="http://inspire.ec.europa.eu/layer/AD.Address" tags="//@tags.0 //@tags.2" layerName="AD.Address" styleConfig="//@styleConfig.67">
+  <layerConfig name="AD_Address" registryId="http://inspire.ec.europa.eu/layer/AD.Address" tags="//@tags.0 //@tags.2" layerName="AD.Address" styleConfig="//@styleConfig.83">
     <title lang="en" text="Addresses"/>
     <title text="Addressen"/>
     <objectType>ad_4.0:Address</objectType>
   </layerConfig>
-  <layerConfig name="AU_AdministrativeBoundary" registryId="http://inspire.ec.europa.eu/layer/AU.AdministrativeBoundary" tags="//@tags.2 //@tags.0" layerName="AU.AdministrativeBoundary" styleConfig="//@styleConfig.68">
+  <layerConfig name="AU_AdministrativeBoundary" registryId="http://inspire.ec.europa.eu/layer/AU.AdministrativeBoundary" tags="//@tags.2 //@tags.0" layerName="AU.AdministrativeBoundary" styleConfig="//@styleConfig.84">
     <title lang="en" text="Administrative boundary"/>
     <title text="Verwaltungsgrenze"/>
     <objectType>au_4.0:AdministrativeBoundary</objectType>
   </layerConfig>
-  <layerConfig name="AU_AdministrativeUnit" registryId="http://inspire.ec.europa.eu/layer/AU.AdministrativeUnit" tags="//@tags.2 //@tags.0" layerName="AU.AdministrativeUnit" styleConfig="//@styleConfig.69">
+  <layerConfig name="AU_AdministrativeUnit" registryId="http://inspire.ec.europa.eu/layer/AU.AdministrativeUnit" tags="//@tags.2 //@tags.0" layerName="AU.AdministrativeUnit" styleConfig="//@styleConfig.85">
     <title lang="en" text="Administrative unit"/>
     <title text="Verwaltungseinheit"/>
     <objectType>au_4.0:AdministrativeUnit</objectType>
   </layerConfig>
-  <layerConfig name="AU_Baseline" registryId="http://inspire.ec.europa.eu/layer/AU.Baseline" layerName="AU.Baseline" styleConfig="//@styleConfig.70">
+  <layerConfig name="AU_Baseline" registryId="http://inspire.ec.europa.eu/layer/AU.Baseline" layerName="AU.Baseline" styleConfig="//@styleConfig.86">
     <title lang="en" text="Baseline"/>
     <title text="Basislinie"/>
     <objectType>mu_3.0:Baseline</objectType>
   </layerConfig>
-  <layerConfig name="AU_Condominium" registryId="http://inspire.ec.europa.eu/layer/AU.Condominium" layerName="AU.Condominium" styleConfig="//@styleConfig.71">
+  <layerConfig name="AU_Condominium" registryId="http://inspire.ec.europa.eu/layer/AU.Condominium" layerName="AU.Condominium" styleConfig="//@styleConfig.87">
     <title lang="en" text="Condominium"/>
     <title text="Kondominium"/>
     <objectType>au_4.0:Condominium</objectType>
   </layerConfig>
-  <layerConfig name="AU_ContiguousZone" registryId="http://inspire.ec.europa.eu/layer/AU.ContiguousZone" layerName="AU.ContiguousZone" styleConfig="//@styleConfig.72">
+  <layerConfig name="AU_ContiguousZone" registryId="http://inspire.ec.europa.eu/layer/AU.ContiguousZone" layerName="AU.ContiguousZone" styleConfig="//@styleConfig.88">
     <title lang="en" text="Contiguous zone"/>
     <title text="Anschlusszone"/>
     <objectType>mu_3.0:ContiguousZone</objectType>
   </layerConfig>
-  <layerConfig name="AU_ContinentalShelf" registryId="http://inspire.ec.europa.eu/layer/AU.ContinentalShelf" layerName="AU.ContinentalShelf" styleConfig="//@styleConfig.73">
+  <layerConfig name="AU_ContinentalShelf" registryId="http://inspire.ec.europa.eu/layer/AU.ContinentalShelf" layerName="AU.ContinentalShelf" styleConfig="//@styleConfig.89">
     <title lang="en" text="Continental shelf"/>
     <title text="Festlandsockel"/>
     <objectType>mu_3.0:ContinentalShelf</objectType>
   </layerConfig>
-  <layerConfig name="AU_ExclusiveEconomicZone" registryId="http://inspire.ec.europa.eu/layer/AU.ExclusiveEconomicZone" layerName="AU.ExclusiveEconomicZone" styleConfig="//@styleConfig.74">
+  <layerConfig name="AU_ExclusiveEconomicZone" registryId="http://inspire.ec.europa.eu/layer/AU.ExclusiveEconomicZone" layerName="AU.ExclusiveEconomicZone" styleConfig="//@styleConfig.90">
     <title lang="en" text="Exclusive economic zone"/>
     <title text="Ausschließliche Wirtschaftszone"/>
     <objectType>mu_3.0:ExclusiveEconomicZone</objectType>
   </layerConfig>
-  <layerConfig name="AU_InternalWaters" registryId="http://inspire.ec.europa.eu/layer/AU.InternalWaters" layerName="AU.InternalWaters" styleConfig="//@styleConfig.75">
+  <layerConfig name="AU_InternalWaters" registryId="http://inspire.ec.europa.eu/layer/AU.InternalWaters" layerName="AU.InternalWaters" styleConfig="//@styleConfig.91">
     <title lang="en" text="Internal waters"/>
     <title text="Innere Gewässer"/>
     <objectType>mu_3.0:InternalWaters</objectType>
   </layerConfig>
-  <layerConfig name="AU_MaritimeBoundary" registryId="http://inspire.ec.europa.eu/layer/AU.MaritimeBoundary" layerName="AU.MaritimeBoundary" styleConfig="//@styleConfig.76">
+  <layerConfig name="AU_MaritimeBoundary" registryId="http://inspire.ec.europa.eu/layer/AU.MaritimeBoundary" layerName="AU.MaritimeBoundary" styleConfig="//@styleConfig.92">
     <title lang="en" text="Maritime boundary"/>
     <title text="Seegrenze"/>
     <objectType>mu_3.0:MaritimeBoundary</objectType>
   </layerConfig>
-  <layerConfig name="AU_TerritorialSea" registryId="http://inspire.ec.europa.eu/layer/AU.TerritorialSea" layerName="AU.TerritorialSea" styleConfig="//@styleConfig.77">
+  <layerConfig name="AU_TerritorialSea" registryId="http://inspire.ec.europa.eu/layer/AU.TerritorialSea" layerName="AU.TerritorialSea" styleConfig="//@styleConfig.93">
     <title lang="en" text="Territorial sea"/>
     <title text="Küstenmeer"/>
     <objectType>mu_3.0:TerritorialSea</objectType>
   </layerConfig>
-  <layerConfig name="CP_CadastralBoundary" registryId="http://inspire.ec.europa.eu/layer/CP.CadastralBoundary" tags="//@tags.2 //@tags.0" layerName="CP.CadastralBoundary" styleConfig="//@styleConfig.78">
+  <layerConfig name="CP_CadastralBoundary" registryId="http://inspire.ec.europa.eu/layer/CP.CadastralBoundary" tags="//@tags.2 //@tags.0" layerName="CP.CadastralBoundary" styleConfig="//@styleConfig.94">
     <title lang="en" text="Cadastral Boundary"/>
     <title text="Flurstücksgrenze"/>
     <objectType>cp_4.0:CadastralBoundary</objectType>
   </layerConfig>
-  <layerConfig name="CP_Cadastr" registryId="http://inspire.ec.europa.eu/layer/CP.CadastralParcel" tags="//@tags.2 //@tags.0" layerName="CP.CadastralParcel.BoundariesOnly" styleConfig="//@styleConfig.79">
+  <layerConfig name="CP_Cadastr" registryId="http://inspire.ec.europa.eu/layer/CP.CadastralParcel" tags="//@tags.2 //@tags.0" layerName="CP.CadastralParcel.BoundariesOnly" styleConfig="//@styleConfig.95">
     <title lang="en" text="Cadastral Parcel (Boundary only)"/>
     <objectType>cp_4.0:CadastralParcel</objectType>
   </layerConfig>
-  <layerConfig name="CP_CadastralParcel" registryId="http://inspire.ec.europa.eu/layer/CP.CadastralParcel" tags="//@tags.2 //@tags.0" layerName="CP.CadastralParcel" styleConfig="//@styleConfig.80">
+  <layerConfig name="CP_CadastralParcel" registryId="http://inspire.ec.europa.eu/layer/CP.CadastralParcel" tags="//@tags.2 //@tags.0" layerName="CP.CadastralParcel" styleConfig="//@styleConfig.96">
     <title lang="en" text="Cadastral Parcel"/>
     <title text="Flurstück"/>
     <objectType>cp_4.0:CadastralParcel</objectType>
   </layerConfig>
-  <layerConfig name="CP_Cadastr_1" registryId="http://inspire.ec.europa.eu/layer/CP.CadastralParcel" tags="//@tags.2 //@tags.0" layerName="CP.CadastralParcel.LabelOnReferencePoint" styleConfig="//@styleConfig.81">
+  <layerConfig name="CP_Cadastr_1" registryId="http://inspire.ec.europa.eu/layer/CP.CadastralParcel" tags="//@tags.2 //@tags.0" layerName="CP.CadastralParcel.LabelOnReferencePoint" styleConfig="//@styleConfig.97">
     <title lang="en" text="Cadastral Parcel (LabelOnReferencePoint)"/>
     <objectType>cp_4.0:CadastralParcel</objectType>
   </layerConfig>
-  <layerConfig name="CP_Cadastr_2" registryId="http://inspire.ec.europa.eu/layer/CP.CadastralParcel" tags="//@tags.2 //@tags.0" layerName="CP.CadastralParcel.ReferencePointOnly" styleConfig="//@styleConfig.82">
+  <layerConfig name="CP_Cadastr_2" registryId="http://inspire.ec.europa.eu/layer/CP.CadastralParcel" tags="//@tags.2 //@tags.0" layerName="CP.CadastralParcel.ReferencePointOnly" styleConfig="//@styleConfig.98">
     <title lang="en" text="Cadastral Parcel (ReferencePointOnly)"/>
     <objectType>cp_4.0:CadastralParcel</objectType>
   </layerConfig>
-  <layerConfig name="CP_CadastralZoning" registryId="http://inspire.ec.europa.eu/layer/CP.CadastralZoning" tags="//@tags.2 //@tags.0" layerName="CP.CadastralZoning" styleConfig="//@styleConfig.83">
+  <layerConfig name="CP_CadastralZoning" registryId="http://inspire.ec.europa.eu/layer/CP.CadastralZoning" tags="//@tags.2 //@tags.0" layerName="CP.CadastralZoning" styleConfig="//@styleConfig.99">
     <title lang="en" text="Cadastral Zoning"/>
     <title text="Katasterbezirk"/>
     <objectType>cp_4.0:CadastralZoning</objectType>
   </layerConfig>
-  <layerConfig name="GN_GeographicalNames" registryId="http://inspire.ec.europa.eu/layer/GN.GeographicalNames" tags="//@tags.0 //@tags.2" layerName="GN.GeographicalNames" styleConfig="//@styleConfig.84">
+  <layerConfig name="GN_GeographicalNames" registryId="http://inspire.ec.europa.eu/layer/GN.GeographicalNames" tags="//@tags.0 //@tags.2" layerName="GN.GeographicalNames" styleConfig="//@styleConfig.100">
     <title lang="en" text="Geographical Names"/>
     <title text="Geografische Bezeichnungen"/>
     <objectType>gn_4.0:NamedPlace</objectType>
   </layerConfig>
-  <layerConfig name="HY_Network_WatercourseLink" registryId="" tags="//@tags.0 //@tags.2" layerName="HY.Network.WatercourseLink" styleConfig="//@styleConfig.85">
+  <layerConfig name="HY_Network_WatercourseLink" registryId="" tags="//@tags.0 //@tags.2" layerName="HY.Network.WatercourseLink" styleConfig="//@styleConfig.101">
     <title lang="en" text="Hydrographic network - WatercourseLink"/>
     <title text="Hydrografisches Netzwerk- WatercourseLink"/>
     <objectType>hy-n_4.0:WatercourseLink</objectType>
   </layerConfig>
-  <layerConfig name="HY_Network_HydroNode" registryId="" tags="//@tags.0 //@tags.2" layerName="HY.Network.HydroNode" styleConfig="//@styleConfig.86">
+  <layerConfig name="HY_Network_WatercourseLink_v5" registryId="" tags="//@tags.0 //@tags.2" layerName="HY.Network.WatercourseLink" styleConfig="//@styleConfig.102">
+    <title lang="en" text="Hydrographic network - WatercourseLink"/>
+    <title text="Hydrografisches Netzwerk- WatercourseLink"/>
+    <objectType>hy-n_5.0:WatercourseLink</objectType>
+  </layerConfig>
+  <layerConfig name="HY_Network_HydroNode" registryId="" tags="//@tags.0 //@tags.2" layerName="HY.Network.HydroNode" styleConfig="//@styleConfig.103">
     <title lang="en" text="Hydrographic network - HydroNode"/>
     <title text="Hydrografisches Netzwerk- HydroNode"/>
     <objectType>hy-n_4.0:HydroNode</objectType>
   </layerConfig>
-  <layerConfig name="HY_Physica" registryId="http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.Catchments" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.Catchments" styleConfig="//@styleConfig.87 //@styleConfig.88">
+  <layerConfig name="HY_Network_HydroNode_v5" registryId="" tags="//@tags.0 //@tags.2" layerName="HY.Network.HydroNode" styleConfig="//@styleConfig.104">
+    <title lang="en" text="Hydrographic network - HydroNode"/>
+    <title text="Hydrografisches Netzwerk- HydroNode"/>
+    <objectType>hy-n_5.0:HydroNode</objectType>
+  </layerConfig>
+  <layerConfig name="HY_Physica" registryId="http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.Catchments" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.Catchments" styleConfig="//@styleConfig.105 //@styleConfig.107">
     <title lang="en" text="Catchment"/>
     <title text="Einzugsgebiete"/>
     <objectType>hy-p_4.0:DrainageBasin</objectType>
     <objectType>hy-p_4.0:RiverBasin</objectType>
   </layerConfig>
-  <layerConfig name="HY_Physica_1" registryId="http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.HydroPointOfInterest" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.HydroPointOfInterest" styleConfig="//@styleConfig.89 //@styleConfig.90">
+  <layerConfig name="HY_Physica_v5" registryId="http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.Catchments" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.Catchments" styleConfig="//@styleConfig.106 //@styleConfig.108">
+    <title lang="en" text="Catchment"/>
+    <title text="Einzugsgebiete"/>
+    <objectType>hy-p_5.0:DrainageBasin</objectType>
+    <objectType>hy-p_5.0:RiverBasin</objectType>
+  </layerConfig>
+  <layerConfig name="HY_Physica_1" registryId="http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.HydroPointOfInterest" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.HydroPointOfInterest" styleConfig="//@styleConfig.109 //@styleConfig.111">
     <title lang="en" text="Hydro Point of Interest"/>
     <title text="Interessante hydrologische Punkte"/>
     <objectType>hy-p_4.0:Rapids</objectType>
     <objectType>hy-p_4.0:Falls</objectType>
   </layerConfig>
-  <layerConfig name="HY_Physica_2" registryId="http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.LandWaterBoundary" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.LandWaterBoundary" styleConfig="//@styleConfig.91">
+  <layerConfig name="HY_Physica_1_v5" registryId="http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.HydroPointOfInterest" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.HydroPointOfInterest" styleConfig="//@styleConfig.110 //@styleConfig.112">
+    <title lang="en" text="Hydro Point of Interest"/>
+    <title text="Interessante hydrologische Punkte"/>
+    <objectType>hy-p_5.0:Rapids</objectType>
+    <objectType>hy-p_5.0:Falls</objectType>
+  </layerConfig>
+  <layerConfig name="HY_Physica_2" registryId="http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.LandWaterBoundary" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.LandWaterBoundary" styleConfig="//@styleConfig.113">
     <title lang="en" text="Land water boundary"/>
     <title text="Uferlinien"/>
     <objectType>hy-p_4.0:LandWaterBoundary</objectType>
   </layerConfig>
-  <layerConfig name="HY_Physica_4" registryId="http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.ManMadeObject" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.ManMadeObject" styleConfig="//@styleConfig.92 //@styleConfig.93 //@styleConfig.94 //@styleConfig.95 //@styleConfig.96">
+  <layerConfig name="HY_Physica_2_v5" registryId="http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.LandWaterBoundary" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.LandWaterBoundary" styleConfig="//@styleConfig.114">
+    <title lang="en" text="Land water boundary"/>
+    <title text="Uferlinien"/>
+    <objectType>hy-p_5.0:LandWaterBoundary</objectType>
+  </layerConfig>
+  <layerConfig name="HY_Physica_4" registryId="http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.ManMadeObject" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.ManMadeObject" styleConfig="//@styleConfig.115 //@styleConfig.117 //@styleConfig.119 //@styleConfig.121 //@styleConfig.123">
     <title lang="en" text="Man-made Object"/>
     <title text="Bauwerke an Gewässern"/>
     <objectType>hy-p_4.0:Crossing</objectType>
@@ -126,502 +153,738 @@
     <objectType>hy-p_4.0:Ford</objectType>
     <objectType>hy-p_4.0:Lock</objectType>
   </layerConfig>
-  <layerConfig name="HY_PhysicalWaters_Shore" registryId="http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.Shore" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.Shore" styleConfig="//@styleConfig.97">
+  <layerConfig name="HY_Physica_4_v5" registryId="http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.ManMadeObject" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.ManMadeObject" styleConfig="//@styleConfig.116 //@styleConfig.118 //@styleConfig.120 //@styleConfig.122 //@styleConfig.124">
+    <title lang="en" text="Man-made Object"/>
+    <title text="Bauwerke an Gewässern"/>
+    <objectType>hy-p_4.0:Crossing</objectType>
+    <objectType>hy-p_5.0:DamOrWeir</objectType>
+    <objectType>hy-p_5.0:ShorelineConstruction</objectType>
+    <objectType>hy-p_5.0:Ford</objectType>
+    <objectType>hy-p_5.0:Lock</objectType>
+  </layerConfig>
+  <layerConfig name="HY_PhysicalWaters_Shore" registryId="http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.Shore" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.Shore" styleConfig="//@styleConfig.125">
     <title lang="en" text="Shores"/>
     <title text="Küsten"/>
     <objectType>hy-p_4.0:Shore</objectType>
   </layerConfig>
-  <layerConfig name="HY_Physica_5" registryId="http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.Waterbodies" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.Waterbodies" styleConfig="//@styleConfig.98 //@styleConfig.99">
+  <layerConfig name="HY_PhysicalWaters_Shore_v5" registryId="http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.Shore" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.Shore" styleConfig="//@styleConfig.126">
+    <title lang="en" text="Shores"/>
+    <title text="Küsten"/>
+    <objectType>hy-p_5.0:Shore</objectType>
+  </layerConfig>
+  <layerConfig name="HY_Physica_5" registryId="http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.Waterbodies" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.Waterbodies" styleConfig="//@styleConfig.127 //@styleConfig.129">
     <title lang="en" text="Waterbody"/>
     <title text="Wasserkörper"/>
     <objectType>hy-p_4.0:Watercourse</objectType>
     <objectType>hy-p_4.0:StandingWater</objectType>
   </layerConfig>
-  <layerConfig name="HY_Physica_6" registryId="" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.Waterbodies.Man.Made" styleConfig="//@styleConfig.100 //@styleConfig.101">
+  <layerConfig name="HY_Physica_5_v5" registryId="http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.Waterbodies" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.Waterbodies" styleConfig="//@styleConfig.128 //@styleConfig.130">
+    <title lang="en" text="Waterbody"/>
+    <title text="Wasserkörper"/>
+    <objectType>hy-p_5.0:Watercourse</objectType>
+    <objectType>hy-p_5.0:StandingWater</objectType>
+  </layerConfig>
+  <layerConfig name="HY_Physica_6" registryId="" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.Waterbodies.Man.Made" styleConfig="//@styleConfig.131 //@styleConfig.133">
     <title lang="en" text="Man-made Object (Natural)"/>
     <objectType>hy-p_4.0:Watercourse</objectType>
     <objectType>hy-p_4.0:StandingWater</objectType>
   </layerConfig>
-  <layerConfig name="HY_Physica_7" registryId="" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.Waterbodies.Persistence" styleConfig="//@styleConfig.102 //@styleConfig.103">
+  <layerConfig name="HY_Physica_6_v5" registryId="" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.Waterbodies.Man.Made" styleConfig="//@styleConfig.132 //@styleConfig.134">
+    <title lang="en" text="Man-made Object (Natural)"/>
+    <objectType>hy-p_5.0:Watercourse</objectType>
+    <objectType>hy-p_5.0:StandingWater</objectType>
+  </layerConfig>
+  <layerConfig name="HY_Physica_7" registryId="" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.Waterbodies.Persistence" styleConfig="//@styleConfig.135 //@styleConfig.137">
     <title lang="en" text="Waterbody (Persistence)"/>
     <objectType>hy-p_4.0:Watercourse</objectType>
     <objectType>hy-p_4.0:StandingWater</objectType>
   </layerConfig>
-  <layerConfig name="HY_PhysicalWaters_Wetland" registryId="http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.Wetland" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.Wetland" styleConfig="//@styleConfig.104">
+  <layerConfig name="HY_Physica_7_v5" registryId="" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.Waterbodies.Persistence" styleConfig="//@styleConfig.136 //@styleConfig.138">
+    <title lang="en" text="Waterbody (Persistence)"/>
+    <objectType>hy-p_5.0:Watercourse</objectType>
+    <objectType>hy-p_5.0:StandingWater</objectType>
+  </layerConfig>
+  <layerConfig name="HY_PhysicalWaters_Wetland" registryId="http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.Wetland" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.Wetland" styleConfig="//@styleConfig.139">
     <title lang="en" text="Wetlands"/>
     <title text="Feuchtgebiete"/>
     <objectType>hy-p_4.0:Wetland</objectType>
   </layerConfig>
-  <layerConfig name="PS_ProtectedSite" registryId="http://inspire.ec.europa.eu/layer/PS.ProtectedSite" tags="//@tags.0 //@tags.2" layerName="PS.ProtectedSite" styleConfig="//@styleConfig.105">
+  <layerConfig name="HY_PhysicalWaters_Wetland_v5" registryId="http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.Wetland" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.Wetland" styleConfig="//@styleConfig.140">
+    <title lang="en" text="Wetlands"/>
+    <title text="Feuchtgebiete"/>
+    <objectType>hy-p_5.0:Wetland</objectType>
+  </layerConfig>
+  <layerConfig name="PS_ProtectedSite" registryId="http://inspire.ec.europa.eu/layer/PS.ProtectedSite" tags="//@tags.0 //@tags.2" layerName="PS.ProtectedSite" styleConfig="//@styleConfig.141">
     <title lang="en" text="Protected Sites"/>
     <title text="Schutzgebiete"/>
     <objectType>ps_4.0:ProtectedSite</objectType>
   </layerConfig>
-  <layerConfig name="PS_ProtectedSite_v5" registryId="http://inspire.ec.europa.eu/layer/PS.ProtectedSite" tags="//@tags.0 //@tags.2" layerName="PS.ProtectedSite_v5" styleConfig="//@styleConfig.106">
+  <layerConfig name="PS_ProtectedSite_v5" registryId="http://inspire.ec.europa.eu/layer/PS.ProtectedSite" tags="//@tags.0 //@tags.2" layerName="PS.ProtectedSite" styleConfig="//@styleConfig.142">
     <title lang="en" text="Protected Sites"/>
     <title text="Schutzgebiete"/>
     <objectType>ps_5.0:ProtectedSite</objectType>
   </layerConfig>
-  <layerConfig name="TN_AirTran" registryId="http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.AerodromeArea" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.AerodromeArea" styleConfig="//@styleConfig.107">
+  <layerConfig name="PS_ProtectedSite_v5" registryId="http://inspire.ec.europa.eu/layer/PS.ProtectedSite" tags="//@tags.0 //@tags.2" layerName="PS.ProtectedSite_v5" styleConfig="//@styleConfig.142">
+    <title lang="en" text="Protected Sites"/>
+    <title text="Schutzgebiete"/>
+    <objectType>ps_5.0:ProtectedSite</objectType>
+  </layerConfig>
+  <layerConfig name="TN_AirTran" registryId="http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.AerodromeArea" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.AerodromeArea" styleConfig="//@styleConfig.144">
     <title lang="en" text="Aerodrome Area Default Style"/>
     <title text="Flugplatzgelände"/>
     <objectType>tn-a_4.0:AerodromeArea</objectType>
   </layerConfig>
-  <layerConfig name="TN_AirTran_1" registryId="http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.AirLink" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.AirLink" styleConfig="//@styleConfig.108 //@styleConfig.109">
+  <layerConfig name="TN_AirTran_v5" registryId="http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.AerodromeArea" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.AerodromeArea" styleConfig="//@styleConfig.145">
+    <title lang="en" text="Aerodrome Area Default Style"/>
+    <title text="Flugplatzgelände"/>
+    <objectType>tn-a_5.0:AerodromeArea</objectType>
+  </layerConfig>
+  <layerConfig name="TN_AirTran_1" registryId="http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.AirLink" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.AirLink" styleConfig="//@styleConfig.146 //@styleConfig.148">
     <title lang="en" text="Air Link Default Style"/>
     <title text="Luftverbindung"/>
     <objectType>tn-a_4.0:ProcedureLink</objectType>
     <objectType>tn-a_4.0:AirRouteLink</objectType>
   </layerConfig>
-  <layerConfig name="TN_AirTran_2" registryId="http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.AirspaceArea" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.AirSpaceArea" styleConfig="//@styleConfig.110">
+  <layerConfig name="TN_AirTran_1_v5" registryId="http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.AirLink" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.AirLink" styleConfig="//@styleConfig.147 //@styleConfig.149">
+    <title lang="en" text="Air Link Default Style"/>
+    <title text="Luftverbindung"/>
+    <objectType>tn-a_5.0:ProcedureLink</objectType>
+    <objectType>tn-a_5.0:AirRouteLink</objectType>
+  </layerConfig>
+  <layerConfig name="TN_AirTran_2" registryId="http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.AirspaceArea" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.AirSpaceArea" styleConfig="//@styleConfig.150">
     <title lang="en" text="Air Space Area Default Style"/>
     <title text="Luftraumbereich"/>
     <objectType>tn-a_4.0:AirspaceArea</objectType>
   </layerConfig>
-  <layerConfig name="TN_AirTran_3" registryId="http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.ApronArea" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.ApronArea" styleConfig="//@styleConfig.111">
+  <layerConfig name="TN_AirTran_2_v5" registryId="http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.AirspaceArea" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.AirSpaceArea" styleConfig="//@styleConfig.151">
+    <title lang="en" text="Air Space Area Default Style"/>
+    <title text="Luftraumbereich"/>
+    <objectType>tn-a_5.0:AirspaceArea</objectType>
+  </layerConfig>
+  <layerConfig name="TN_AirTran_3" registryId="http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.ApronArea" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.ApronArea" styleConfig="//@styleConfig.152">
     <title lang="en" text="Apron Area Default Style"/>
     <title text="Vorfeldgelände"/>
     <objectType>tn-a_4.0:ApronArea</objectType>
   </layerConfig>
-  <layerConfig name="TN_AirTran_4" registryId="http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.RunwayArea" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.RunwayArea" styleConfig="//@styleConfig.112">
+  <layerConfig name="TN_AirTran_3_v5" registryId="http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.ApronArea" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.ApronArea" styleConfig="//@styleConfig.153">
+    <title lang="en" text="Apron Area Default Style"/>
+    <title text="Vorfeldgelände"/>
+    <objectType>tn-a_5.0:ApronArea</objectType>
+  </layerConfig>
+  <layerConfig name="TN_AirTran_4" registryId="http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.RunwayArea" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.RunwayArea" styleConfig="//@styleConfig.154">
     <title lang="en" text="Runway Area Default Style"/>
     <title text="Landebahngelände"/>
     <objectType>tn-a_4.0:RunwayArea</objectType>
   </layerConfig>
-  <layerConfig name="TN_AirTran_5" registryId="http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.TaxiwayArea" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.TaxiwayArea" styleConfig="//@styleConfig.113">
+  <layerConfig name="TN_AirTran_4_v5" registryId="http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.RunwayArea" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.RunwayArea" styleConfig="//@styleConfig.155">
+    <title lang="en" text="Runway Area Default Style"/>
+    <title text="Landebahngelände"/>
+    <objectType>tn-a_5.0:RunwayArea</objectType>
+  </layerConfig>
+  <layerConfig name="TN_AirTran_5" registryId="http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.TaxiwayArea" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.TaxiwayArea" styleConfig="//@styleConfig.156">
     <title lang="en" text="Taxiway Area Default Style"/>
     <title text="Rollfeld"/>
     <objectType>tn-a_4.0:TaxiwayArea</objectType>
   </layerConfig>
-  <layerConfig name="TN_AirTran_6" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.DesignatedPoint" styleConfig="//@styleConfig.4">
+  <layerConfig name="TN_AirTran_5_v5" registryId="http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.TaxiwayArea" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.TaxiwayArea" styleConfig="//@styleConfig.157">
+    <title lang="en" text="Taxiway Area Default Style"/>
+    <title text="Rollfeld"/>
+    <objectType>tn-a_5.0:TaxiwayArea</objectType>
+  </layerConfig>
+  <layerConfig name="TN_AirTran_6" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.DesignatedPoint" styleConfig="//@styleConfig.7">
     <title lang="en" text="Designated Point Default Style"/>
     <title text="Designierter Punkt"/>
     <objectType>tn-a_4.0:DesignatedPoint</objectType>
   </layerConfig>
-  <layerConfig name="TN_AirTran_7" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.AerodromeNode" styleConfig="//@styleConfig.7">
+  <layerConfig name="TN_AirTran_6_v5" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.DesignatedPoint" styleConfig="//@styleConfig.8">
+    <title lang="en" text="Designated Point Default Style"/>
+    <title text="Designierter Punkt"/>
+    <objectType>tn-a_5.0:DesignatedPoint</objectType>
+  </layerConfig>
+  <layerConfig name="TN_AirTran_7" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.AerodromeNode" styleConfig="//@styleConfig.13">
     <title lang="en" text="Aerodrome Node Default Style"/>
     <title text="Flugplatzknotenpunkt"/>
     <objectType>tn-a_4.0:AerodromeNode</objectType>
   </layerConfig>
-  <layerConfig name="TN_AirTran_8" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.TouchDownLiftOff" styleConfig="//@styleConfig.8">
+  <layerConfig name="TN_AirTran_7_v5" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.AerodromeNode" styleConfig="//@styleConfig.14">
+    <title lang="en" text="Aerodrome Node Default Style"/>
+    <title text="Flugplatzknotenpunkt"/>
+    <objectType>tn-a_5.0:AerodromeNode</objectType>
+  </layerConfig>
+  <layerConfig name="TN_AirTran_8" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.TouchDownLiftOff" styleConfig="//@styleConfig.15">
     <title lang="en" text="Touch Down Lift Off Area Default Style"/>
     <title text="Start- und Landebereich für Hubschrauber"/>
     <objectType>tn-a_4.0:TouchDownLiftOff</objectType>
   </layerConfig>
-  <layerConfig name="TN_AirTran_9" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.Navaid" styleConfig="//@styleConfig.5">
+  <layerConfig name="TN_AirTran_8_v5" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.TouchDownLiftOff" styleConfig="//@styleConfig.16">
+    <title lang="en" text="Touch Down Lift Off Area Default Style"/>
+    <title text="Start- und Landebereich für Hubschrauber"/>
+    <objectType>tn-a_5.0:TouchDownLiftOff</objectType>
+  </layerConfig>
+  <layerConfig name="TN_AirTran_9" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.Navaid" styleConfig="//@styleConfig.9">
     <title lang="en" text="Navaid Default Style"/>
     <title text="Navigationshilfe"/>
     <objectType>tn-a_4.0:Navaid</objectType>
   </layerConfig>
-  <layerConfig name="TN_AirTran_10" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.RunwayCentrelinePoint" styleConfig="//@styleConfig.6">
+  <layerConfig name="TN_AirTran_9_v5" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.Navaid" styleConfig="//@styleConfig.10">
+    <title lang="en" text="Navaid Default Style"/>
+    <title text="Navigationshilfe"/>
+    <objectType>tn-a_5.0:Navaid</objectType>
+  </layerConfig>
+  <layerConfig name="TN_AirTran_10" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.RunwayCentrelinePoint" styleConfig="//@styleConfig.11">
     <title lang="en" text="Runway Centreline Point Default Style"/>
     <title text="Mittellinienpunkt der Landebahn"/>
     <objectType>tn-a_4.0:RunwayCentrelinePoint</objectType>
   </layerConfig>
-  <layerConfig name="TN_CableTr" registryId="http://inspire.ec.europa.eu/layer/TN.CableTransportNetwork.CablewayLink" tags="//@tags.0 //@tags.2" layerName="TN.CableTransportNetwork.CablewayLink" styleConfig="//@styleConfig.114">
+  <layerConfig name="TN_AirTran_10_v5" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.RunwayCentrelinePoint" styleConfig="//@styleConfig.12">
+    <title lang="en" text="Runway Centreline Point Default Style"/>
+    <title text="Mittellinienpunkt der Landebahn"/>
+    <objectType>tn-a_5.0:RunwayCentrelinePoint</objectType>
+  </layerConfig>
+  <layerConfig name="TN_CableTr" registryId="http://inspire.ec.europa.eu/layer/TN.CableTransportNetwork.CablewayLink" tags="//@tags.0 //@tags.2" layerName="TN.CableTransportNetwork.CablewayLink" styleConfig="//@styleConfig.158">
     <title lang="en" text="Cableway Link Default Style"/>
     <title text="Seilbahnverbindung"/>
     <objectType>tn-c_4.0:CablewayLink</objectType>
   </layerConfig>
-  <layerConfig name="TN_CommonT" registryId="http://inspire.ec.europa.eu/layer/TN.CommonTransportElements.TransportArea" tags="//@tags.0 //@tags.2" layerName="TN.CommonTransportElements.TransportArea" styleConfig="//@styleConfig.115">
+  <layerConfig name="TN_CableTr_v5" registryId="http://inspire.ec.europa.eu/layer/TN.CableTransportNetwork.CablewayLink" tags="//@tags.0 //@tags.2" layerName="TN.CableTransportNetwork.CablewayLink" styleConfig="//@styleConfig.159">
+    <title lang="en" text="Cableway Link Default Style"/>
+    <title text="Seilbahnverbindung"/>
+    <objectType>tn-c_5.0:CablewayLink</objectType>
+  </layerConfig>
+  <layerConfig name="TN_CommonT" registryId="http://inspire.ec.europa.eu/layer/TN.CommonTransportElements.TransportArea" tags="//@tags.0 //@tags.2" layerName="TN.CommonTransportElements.TransportArea" styleConfig="//@styleConfig.160">
     <title lang="en" text="Generic Transport Area Default Style"/>
     <title text="Generischer Verkehrsbereich"/>
     <objectType>tn_4.0:TransportArea</objectType>
   </layerConfig>
-  <layerConfig name="TN_CommonT_1" registryId="http://inspire.ec.europa.eu/layer/TN.CommonTransportElements.TransportLink" tags="//@tags.0 //@tags.2" layerName="TN.CommonTransportElements.TransportLink" styleConfig="//@styleConfig.116">
+  <layerConfig name="TN_CommonT_v5" registryId="http://inspire.ec.europa.eu/layer/TN.CommonTransportElements.TransportArea" tags="//@tags.0 //@tags.2" layerName="TN.CommonTransportElements.TransportArea" styleConfig="//@styleConfig.161">
+    <title lang="en" text="Generic Transport Area Default Style"/>
+    <title text="Generischer Verkehrsbereich"/>
+    <objectType>tn_5.0:TransportArea</objectType>
+  </layerConfig>
+  <layerConfig name="TN_CommonT_1" registryId="http://inspire.ec.europa.eu/layer/TN.CommonTransportElements.TransportLink" tags="//@tags.0 //@tags.2" layerName="TN.CommonTransportElements.TransportLink" styleConfig="//@styleConfig.162">
     <title lang="en" text="Generic Transport Link Default Style"/>
     <title text="Generisches Verkehrssegment"/>
     <objectType>tn_4.0:TransportLink</objectType>
   </layerConfig>
-  <layerConfig name="TN_CommonT_2" registryId="http://inspire.ec.europa.eu/layer/TN.CommonTransportElements.TransportNode" tags="//@tags.0 //@tags.2" layerName="TN.CommonTransportElements.TransportNode" styleConfig="//@styleConfig.117">
+  <layerConfig name="TN_CommonT_1_v5" registryId="http://inspire.ec.europa.eu/layer/TN.CommonTransportElements.TransportLink" tags="//@tags.0 //@tags.2" layerName="TN.CommonTransportElements.TransportLink" styleConfig="//@styleConfig.163">
+    <title lang="en" text="Generic Transport Link Default Style"/>
+    <title text="Generisches Verkehrssegment"/>
+    <objectType>tn_5.0:TransportLink</objectType>
+  </layerConfig>
+  <layerConfig name="TN_CommonT_2" registryId="http://inspire.ec.europa.eu/layer/TN.CommonTransportElements.TransportNode" tags="//@tags.0 //@tags.2" layerName="TN.CommonTransportElements.TransportNode" styleConfig="//@styleConfig.164">
     <title lang="en" text="Generic Transport Node Default Style"/>
     <title text="Generischer Verkehrsknotenpunkt"/>
     <objectType>tn_4.0:TransportNode</objectType>
   </layerConfig>
-  <layerConfig name="TN_RailTra" registryId="http://inspire.ec.europa.eu/layer/TN.RailTransportNetwork.RailwayArea" tags="//@tags.0 //@tags.2" layerName="TN.RailTransportNetwork.RailwayArea" styleConfig="//@styleConfig.118">
+  <layerConfig name="TN_CommonT_2_v5" registryId="http://inspire.ec.europa.eu/layer/TN.CommonTransportElements.TransportNode" tags="//@tags.0 //@tags.2" layerName="TN.CommonTransportElements.TransportNode" styleConfig="//@styleConfig.165">
+    <title lang="en" text="Generic Transport Node Default Style"/>
+    <title text="Generischer Verkehrsknotenpunkt"/>
+    <objectType>tn_5.0:TransportNode</objectType>
+  </layerConfig>
+  <layerConfig name="TN_RailTra" registryId="http://inspire.ec.europa.eu/layer/TN.RailTransportNetwork.RailwayArea" tags="//@tags.0 //@tags.2" layerName="TN.RailTransportNetwork.RailwayArea" styleConfig="//@styleConfig.166">
     <title lang="en" text="Railway Area Default Style"/>
     <title text="Bahngelände"/>
     <objectType>tn-ra_4.0:RailwayArea</objectType>
   </layerConfig>
-  <layerConfig name="TN_RailTra_1" registryId="http://inspire.ec.europa.eu/layer/TN.RailTransportNetwork.RailwayLink" tags="//@tags.0 //@tags.2" layerName="TN.RailTransportNetwork.RailwayLink" styleConfig="//@styleConfig.119">
+  <layerConfig name="TN_RailTra_v5" registryId="http://inspire.ec.europa.eu/layer/TN.RailTransportNetwork.RailwayArea" tags="//@tags.0 //@tags.2" layerName="TN.RailTransportNetwork.RailwayArea" styleConfig="//@styleConfig.167">
+    <title lang="en" text="Railway Area Default Style"/>
+    <title text="Bahngelände"/>
+    <objectType>tn-ra_5.0:RailwayArea</objectType>
+  </layerConfig>
+  <layerConfig name="TN_RailTra_1" registryId="http://inspire.ec.europa.eu/layer/TN.RailTransportNetwork.RailwayLink" tags="//@tags.0 //@tags.2" layerName="TN.RailTransportNetwork.RailwayLink" styleConfig="//@styleConfig.168">
     <title lang="en" text="Railway Link Default Style"/>
     <title text="Eisenbahnverbindung"/>
     <objectType>tn-ra_4.0:RailwayLink</objectType>
   </layerConfig>
-  <layerConfig name="TN_RailTra_2" registryId="http://inspire.ec.europa.eu/layer/TN.RailTransportNetwork.RailwayStationArea" tags="//@tags.0 //@tags.2" layerName="TN.RailTransportNetwork.RailwayStationArea" styleConfig="//@styleConfig.120">
+  <layerConfig name="TN_RailTra_1_v5" registryId="http://inspire.ec.europa.eu/layer/TN.RailTransportNetwork.RailwayLink" tags="//@tags.0 //@tags.2" layerName="TN.RailTransportNetwork.RailwayLink" styleConfig="//@styleConfig.169">
+    <title lang="en" text="Railway Link Default Style"/>
+    <title text="Eisenbahnverbindung"/>
+    <objectType>tn-ra_5.0:RailwayLink</objectType>
+  </layerConfig>
+  <layerConfig name="TN_RailTra_2" registryId="http://inspire.ec.europa.eu/layer/TN.RailTransportNetwork.RailwayStationArea" tags="//@tags.0 //@tags.2" layerName="TN.RailTransportNetwork.RailwayStationArea" styleConfig="//@styleConfig.170">
     <title lang="en" text="Railway Station Area Default Style"/>
     <title text="Bahnhofsgelände"/>
     <objectType>tn-ra_4.0:RailwayStationArea</objectType>
   </layerConfig>
-  <layerConfig name="TN_RailTra_3" registryId="http://inspire.ec.europa.eu/layer/TN.RailTransportNetwork.RailwayYardArea" tags="//@tags.0 //@tags.2" layerName="TN.RailTransportNetwork.RailwayYardArea" styleConfig="//@styleConfig.121">
+  <layerConfig name="TN_RailTra_2_v5" registryId="http://inspire.ec.europa.eu/layer/TN.RailTransportNetwork.RailwayStationArea" tags="//@tags.0 //@tags.2" layerName="TN.RailTransportNetwork.RailwayStationArea" styleConfig="//@styleConfig.171">
+    <title lang="en" text="Railway Station Area Default Style"/>
+    <title text="Bahnhofsgelände"/>
+    <objectType>tn-ra_5.0:RailwayStationArea</objectType>
+  </layerConfig>
+  <layerConfig name="TN_RailTra_3" registryId="http://inspire.ec.europa.eu/layer/TN.RailTransportNetwork.RailwayYardArea" tags="//@tags.0 //@tags.2" layerName="TN.RailTransportNetwork.RailwayYardArea" styleConfig="//@styleConfig.172">
     <title lang="en" text="Railway Yard Area Default Style"/>
     <title text="Rangierbahnhofsgelände"/>
     <objectType>tn-ra_4.0:RailwayYardArea</objectType>
   </layerConfig>
-  <layerConfig name="TN_RoadTra" registryId="http://inspire.ec.europa.eu/layer/TN.RoadTransportNetwork.RoadArea" tags="//@tags.0 //@tags.2" layerName="TN.RoadTransportNetwork.RoadArea" styleConfig="//@styleConfig.122">
+  <layerConfig name="TN_RailTra_3_v5" registryId="http://inspire.ec.europa.eu/layer/TN.RailTransportNetwork.RailwayYardArea" tags="//@tags.0 //@tags.2" layerName="TN.RailTransportNetwork.RailwayYardArea" styleConfig="//@styleConfig.173">
+    <title lang="en" text="Railway Yard Area Default Style"/>
+    <title text="Rangierbahnhofsgelände"/>
+    <objectType>tn-ra_5.0:RailwayYardArea</objectType>
+  </layerConfig>
+  <layerConfig name="TN_RoadTra" registryId="http://inspire.ec.europa.eu/layer/TN.RoadTransportNetwork.RoadArea" tags="//@tags.0 //@tags.2" layerName="TN.RoadTransportNetwork.RoadArea" styleConfig="//@styleConfig.174">
     <title lang="en" text="Road Area Default Style"/>
     <title text="Straßenfläche"/>
     <objectType>tn-ro_4.0:RoadArea</objectType>
   </layerConfig>
-  <layerConfig name="TN_RoadTra_1" registryId="http://inspire.ec.europa.eu/layer/TN.RoadTransportNetwork.RoadLink" tags="//@tags.0 //@tags.2" layerName="TN.RoadTransportNetwork.RoadLink" styleConfig="//@styleConfig.123">
+  <layerConfig name="TN_RoadTra_v5" registryId="http://inspire.ec.europa.eu/layer/TN.RoadTransportNetwork.RoadArea" tags="//@tags.0 //@tags.2" layerName="TN.RoadTransportNetwork.RoadArea" styleConfig="//@styleConfig.175">
+    <title lang="en" text="Road Area Default Style"/>
+    <title text="Straßenfläche"/>
+    <objectType>tn-ro_5.0:RoadArea</objectType>
+  </layerConfig>
+  <layerConfig name="TN_RoadTra_1" registryId="http://inspire.ec.europa.eu/layer/TN.RoadTransportNetwork.RoadLink" tags="//@tags.0 //@tags.2" layerName="TN.RoadTransportNetwork.RoadLink" styleConfig="//@styleConfig.176">
     <title lang="en" text="Road Link Default Style"/>
     <title text="Straßensegment"/>
     <objectType>tn-ro_4.0:RoadLink</objectType>
   </layerConfig>
-  <layerConfig name="TN_RoadTra_2" registryId="http://inspire.ec.europa.eu/layer/TN.RoadTransportNetwork.RoadServiceArea" tags="//@tags.0 //@tags.2" layerName="TN.RoadTransportNetwork.RoadServiceArea" styleConfig="//@styleConfig.124">
+  <layerConfig name="TN_RoadTra_1_v5" registryId="http://inspire.ec.europa.eu/layer/TN.RoadTransportNetwork.RoadLink" tags="//@tags.0 //@tags.2" layerName="TN.RoadTransportNetwork.RoadLink" styleConfig="//@styleConfig.177">
+    <title lang="en" text="Road Link Default Style"/>
+    <title text="Straßensegment"/>
+    <objectType>tn-ro_5.0:RoadLink</objectType>
+  </layerConfig>
+  <layerConfig name="TN_RoadTra_2" registryId="http://inspire.ec.europa.eu/layer/TN.RoadTransportNetwork.RoadServiceArea" tags="//@tags.0 //@tags.2" layerName="TN.RoadTransportNetwork.RoadServiceArea" styleConfig="//@styleConfig.178">
     <title lang="en" text="Road Service Area Default Style"/>
     <title text="Servicebereich"/>
     <objectType>tn-ro_4.0:RoadServiceArea</objectType>
   </layerConfig>
-  <layerConfig name="TN_RoadTra_3" registryId="http://inspire.ec.europa.eu/layer/TN.RoadTransportNetwork.VehicleTrafficArea" tags="//@tags.0 //@tags.2" layerName="TN.RoadTransportNetwork.VehicleTrafficArea" styleConfig="//@styleConfig.125">
+  <layerConfig name="TN_RoadTra_2_v5" registryId="http://inspire.ec.europa.eu/layer/TN.RoadTransportNetwork.RoadServiceArea" tags="//@tags.0 //@tags.2" layerName="TN.RoadTransportNetwork.RoadServiceArea" styleConfig="//@styleConfig.179">
+    <title lang="en" text="Road Service Area Default Style"/>
+    <title text="Servicebereich"/>
+    <objectType>tn-ro_5.0:RoadServiceArea</objectType>
+  </layerConfig>
+  <layerConfig name="TN_RoadTra_3" registryId="http://inspire.ec.europa.eu/layer/TN.RoadTransportNetwork.VehicleTrafficArea" tags="//@tags.0 //@tags.2" layerName="TN.RoadTransportNetwork.VehicleTrafficArea" styleConfig="//@styleConfig.180">
     <title lang="en" text="Vehicle traffic Area Default Style"/>
     <title text="Verkehrsfläche"/>
     <objectType>tn-ro_4.0:VehicleTrafficArea</objectType>
   </layerConfig>
-  <layerConfig name="TN_WaterTr" registryId="http://inspire.ec.europa.eu/layer/TN.WaterTransportNetwork.FairwayArea" tags="//@tags.0 //@tags.2" layerName="TN.WaterTransportNetwork.FairwayArea" styleConfig="//@styleConfig.126">
+  <layerConfig name="TN_RoadTra_3_v5" registryId="http://inspire.ec.europa.eu/layer/TN.RoadTransportNetwork.VehicleTrafficArea" tags="//@tags.0 //@tags.2" layerName="TN.RoadTransportNetwork.VehicleTrafficArea" styleConfig="//@styleConfig.181">
+    <title lang="en" text="Vehicle traffic Area Default Style"/>
+    <title text="Verkehrsfläche"/>
+    <objectType>tn-ro_5.0:VehicleTrafficArea</objectType>
+  </layerConfig>
+  <layerConfig name="TN_WaterTr" registryId="http://inspire.ec.europa.eu/layer/TN.WaterTransportNetwork.FairwayArea" tags="//@tags.0 //@tags.2" layerName="TN.WaterTransportNetwork.FairwayArea" styleConfig="//@styleConfig.182">
     <title lang="en" text="Fairway Area Default Style"/>
     <title text="Fahrrinnenbereich"/>
     <objectType>tn-w_4.0:FairwayArea</objectType>
   </layerConfig>
-  <layerConfig name="TN_WaterTr_1" registryId="http://inspire.ec.europa.eu/layer/TN.WaterTransportNetwork.PortArea" tags="//@tags.0 //@tags.2" layerName="TN.WaterTransportNetwork.PortArea" styleConfig="//@styleConfig.127">
+  <layerConfig name="TN_WaterTr_v5" registryId="http://inspire.ec.europa.eu/layer/TN.WaterTransportNetwork.FairwayArea" tags="//@tags.0 //@tags.2" layerName="TN.WaterTransportNetwork.FairwayArea" styleConfig="//@styleConfig.183">
+    <title lang="en" text="Fairway Area Default Style"/>
+    <title text="Fahrrinnenbereich"/>
+    <objectType>tn-w_5.0:FairwayArea</objectType>
+  </layerConfig>
+  <layerConfig name="TN_WaterTr_1" registryId="http://inspire.ec.europa.eu/layer/TN.WaterTransportNetwork.PortArea" tags="//@tags.0 //@tags.2" layerName="TN.WaterTransportNetwork.PortArea" styleConfig="//@styleConfig.184">
     <title lang="en" text="Port Area Default Style"/>
     <title text="Hafengelände"/>
     <objectType>tn-w_4.0:PortArea</objectType>
   </layerConfig>
-  <layerConfig name="TN_WaterTr_2" registryId="http://inspire.ec.europa.eu/layer/TN.WaterTransportNetwork.WaterwayLink" tags="//@tags.0 //@tags.2" layerName="TN.WaterTransportNetwork.WaterwayLink" styleConfig="//@styleConfig.128">
+  <layerConfig name="TN_WaterTr_1_v5" registryId="http://inspire.ec.europa.eu/layer/TN.WaterTransportNetwork.PortArea" tags="//@tags.0 //@tags.2" layerName="TN.WaterTransportNetwork.PortArea" styleConfig="//@styleConfig.185">
+    <title lang="en" text="Port Area Default Style"/>
+    <title text="Hafengelände"/>
+    <objectType>tn-w_5.0:PortArea</objectType>
+  </layerConfig>
+  <layerConfig name="TN_WaterTr_2" registryId="http://inspire.ec.europa.eu/layer/TN.WaterTransportNetwork.WaterwayLink" tags="//@tags.0 //@tags.2" layerName="TN.WaterTransportNetwork.WaterwayLink" styleConfig="//@styleConfig.186">
     <title lang="en" text="Waterway Link Default Style"/>
     <title text="Wasserstraßenverbindung"/>
     <objectType>tn-w_4.0:WaterwayLink</objectType>
   </layerConfig>
-  <layerConfig name="LC_LandCoverSurfaces" registryId="http://inspire.ec.europa.eu/layer/LC.LandCoverSurfaces" tags="//@tags.2 //@tags.0" layerName="LC.LandCoverSurfaces" styleConfig="//@styleConfig.129">
+  <layerConfig name="TN_WaterTr_2_v5" registryId="http://inspire.ec.europa.eu/layer/TN.WaterTransportNetwork.WaterwayLink" tags="//@tags.0 //@tags.2" layerName="TN.WaterTransportNetwork.WaterwayLink" styleConfig="//@styleConfig.187">
+    <title lang="en" text="Waterway Link Default Style"/>
+    <title text="Wasserstraßenverbindung"/>
+    <objectType>tn-w_5.0:WaterwayLink</objectType>
+  </layerConfig>
+  <layerConfig name="LC_LandCoverSurfaces" registryId="http://inspire.ec.europa.eu/layer/LC.LandCoverSurfaces" tags="//@tags.2 //@tags.0" layerName="LC.LandCoverSurfaces" styleConfig="//@styleConfig.188">
     <title lang="en" text="Land Cover Surfaces"/>
     <title text="Bodenbedeckungsflächen"/>
     <objectType>lcv_4.0:LandCoverUnit</objectType>
   </layerConfig>
-  <layerConfig name="LC_LandCoverPoints" registryId="http://inspire.ec.europa.eu/layer/LC.LandCoverPoints" tags="//@tags.2 //@tags.0" layerName="LC.LandCoverPoints" styleConfig="//@styleConfig.130">
+  <layerConfig name="LC_LandCoverSurfaces_v5" registryId="http://inspire.ec.europa.eu/layer/LC.LandCoverSurfaces" tags="//@tags.2 //@tags.0" layerName="LC.LandCoverSurfaces" styleConfig="//@styleConfig.189">
+    <title lang="en" text="Land Cover Surfaces"/>
+    <title text="Bodenbedeckungsflächen"/>
+    <objectType>lcv_5.0:LandCoverUnit</objectType>
+  </layerConfig>
+  <layerConfig name="LC_LandCoverPoints" registryId="http://inspire.ec.europa.eu/layer/LC.LandCoverPoints" tags="//@tags.2 //@tags.0" layerName="LC.LandCoverPoints" styleConfig="//@styleConfig.190">
     <title lang="en" text="Land Cover Points"/>
     <title text="Bodenbedeckungspunkte"/>
     <objectType>lcv_4.0:LandCoverUnit</objectType>
   </layerConfig>
-  <layerConfig name="BU_Building" registryId="http://inspire.ec.europa.eu/layer/BU.Building" tags="//@tags.0 //@tags.2" layerName="BU.Building" styleConfig="//@styleConfig.131">
+  <layerConfig name="LC_LandCoverPoints_v5" registryId="http://inspire.ec.europa.eu/layer/LC.LandCoverPoints" tags="//@tags.2 //@tags.0" layerName="LC.LandCoverPoints" styleConfig="//@styleConfig.191">
+    <title lang="en" text="Land Cover Points"/>
+    <title text="Bodenbedeckungspunkte"/>
+    <objectType>lcv_5.0:LandCoverUnit</objectType>
+  </layerConfig>
+  <layerConfig name="BU_Building" registryId="http://inspire.ec.europa.eu/layer/BU.Building" tags="//@tags.0 //@tags.2" layerName="BU.Building" styleConfig="//@styleConfig.192">
     <title lang="en" text="Building"/>
     <title text="Gebäude"/>
     <objectType>bu-core2d_4.0:Building</objectType>
   </layerConfig>
-  <layerConfig name="BU_BuildingPart" registryId="http://inspire.ec.europa.eu/layer/BU.BuildingPart" tags="//@tags.0 //@tags.2" layerName="BU.BuildingPart" styleConfig="//@styleConfig.132">
+  <layerConfig name="BU_BuildingPart" registryId="http://inspire.ec.europa.eu/layer/BU.BuildingPart" tags="//@tags.0 //@tags.2" layerName="BU.BuildingPart" styleConfig="//@styleConfig.193">
     <title lang="en" text="BuildingPart"/>
     <title text="Gebäudeteile"/>
     <objectType>bu-core2d_4.0:BuildingPart</objectType>
   </layerConfig>
-  <layerConfig name="LU_ExistingLandUse" registryId="http://inspire.ec.europa.eu/layer/LU.ExistingLandUse" tags="//@tags.2 //@tags.0" layerName="LU.ExistingLandUse" styleConfig="//@styleConfig.66">
+  <layerConfig name="LU_ExistingLandUse" registryId="http://inspire.ec.europa.eu/layer/LU.ExistingLandUse" tags="//@tags.2 //@tags.0" layerName="LU.ExistingLandUse" styleConfig="//@styleConfig.82">
     <title lang="en" text="Existing Land Use"/>
     <title text="Existierende Bodennutzung"/>
     <objectType>elu_4.0:ExistingLandUseObject</objectType>
   </layerConfig>
-  <layerConfig name="LU_SpatialPlan" registryId="http://inspire.ec.europa.eu/layer/LU.SpatialPlan" tags="//@tags.2 //@tags.0" layerName="LU.SpatialPlan" styleConfig="//@styleConfig.65">
+  <layerConfig name="LU_SpatialPlan" registryId="http://inspire.ec.europa.eu/layer/LU.SpatialPlan" tags="//@tags.2 //@tags.0" layerName="LU.SpatialPlan" styleConfig="//@styleConfig.81">
     <title lang="en" text="Spatial Plan"/>
     <title text="Räumlicher Plan"/>
     <objectType>plu_4.0:SpatialPlan</objectType>
   </layerConfig>
-  <layerConfig name="LU_ZoningElement" registryId="http://inspire.ec.europa.eu/layer/LU.ZoningElement" tags="//@tags.2 //@tags.0" layerName="LU.ZoningElement" styleConfig="//@styleConfig.64">
+  <layerConfig name="LU_ZoningElement" registryId="http://inspire.ec.europa.eu/layer/LU.ZoningElement" tags="//@tags.2 //@tags.0" layerName="LU.ZoningElement" styleConfig="//@styleConfig.80">
     <title lang="en" text="Zoning Element"/>
     <title text="Zonierungselement"/>
     <objectType>plu_4.0:ZoningElement</objectType>
   </layerConfig>
-  <layerConfig name="LU_SupplementaryRegulation" registryId="http://inspire.ec.europa.eu/layer/LU.SupplementaryRegulation" tags="//@tags.2 //@tags.0" layerName="LU.SupplementaryRegulation" styleConfig="//@styleConfig.63">
+  <layerConfig name="LU_SupplementaryRegulation" registryId="http://inspire.ec.europa.eu/layer/LU.SupplementaryRegulation" tags="//@tags.2 //@tags.0" layerName="LU.SupplementaryRegulation" styleConfig="//@styleConfig.79">
     <title lang="en" text="Supplementary Regulation"/>
     <title text="Ergänzende Vorschrift"/>
     <objectType>plu_4.0:SupplementaryRegulation</objectType>
   </layerConfig>
-  <layerConfig name="US_GovernmentalService" registryId="" tags="//@tags.0" layerName="US.GovernmentalService" styleConfig="//@styleConfig.62">
+  <layerConfig name="US_GovernmentalService" registryId="" tags="//@tags.0" layerName="US.GovernmentalService" styleConfig="//@styleConfig.77">
     <title lang="en" text="Governmental Service"/>
     <title text="Staatlicher Dienst"/>
     <objectType>us-govserv_4.0:GovernmentalService</objectType>
   </layerConfig>
-  <layerConfig name="AM_AirQualityManagementZone" registryId="http://inspire.ec.europa.eu/layer/AM.AirQualityManagementZone" tags="//@tags.0 //@tags.2" layerName="AM.AirQualityManagementZone" styleConfig="//@styleConfig.60">
+  <layerConfig name="US_GovernmentalService_v5" registryId="" tags="//@tags.0" layerName="US.GovernmentalService" styleConfig="//@styleConfig.78">
+    <title lang="en" text="Governmental Service"/>
+    <title text="Staatlicher Dienst"/>
+    <objectType>us-govserv_5.0:GovernmentalService</objectType>
+  </layerConfig>
+  <layerConfig name="AM_AirQualityManagementZone" registryId="http://inspire.ec.europa.eu/layer/AM.AirQualityManagementZone" tags="//@tags.0 //@tags.2" layerName="AM.AirQualityManagementZone" styleConfig="//@styleConfig.75">
     <title lang="en" text="Air Quality Management Zone"/>
     <title text="Luftqualitäts-Kontrollgebiet"/>
     <objectType>am_4.0:ManagementRestrictionOrRegulationZone</objectType>
   </layerConfig>
-  <layerConfig name="AM_AnimalHealthRestrictionZone" registryId="http://inspire.ec.europa.eu/layer/AM.AnimalHealthRestrictionZone" tags="//@tags.0 //@tags.2" layerName="AM.AnimalHealthRestrictionZone" styleConfig="//@styleConfig.61">
+  <layerConfig name="AM_AnimalHealthRestrictionZone" registryId="http://inspire.ec.europa.eu/layer/AM.AnimalHealthRestrictionZone" tags="//@tags.0 //@tags.2" layerName="AM.AnimalHealthRestrictionZone" styleConfig="//@styleConfig.76">
     <title lang="en" text="Animal Health Restriction Zone"/>
     <title text="Tiergesundheits-Schutzgebiet"/>
     <objectType>am_4.0:ManagementRestrictionOrRegulationZone</objectType>
   </layerConfig>
-  <layerConfig name="AM_AreaForDisposalOfWaste" registryId="http://inspire.ec.europa.eu/layer/AM.AreaForDisposalOfWaste" tags="//@tags.0 //@tags.2" layerName="AM.AreaForDisposalOfWaste" styleConfig="//@styleConfig.59">
+  <layerConfig name="AM_AreaForDisposalOfWaste" registryId="http://inspire.ec.europa.eu/layer/AM.AreaForDisposalOfWaste" tags="//@tags.0 //@tags.2" layerName="AM.AreaForDisposalOfWaste" styleConfig="//@styleConfig.74">
     <title lang="en" text="Area For Disposal Of Waste"/>
     <title text="Abfallentsorgungsgebiet"/>
     <objectType>am_4.0:ManagementRestrictionOrRegulationZone</objectType>
   </layerConfig>
-  <layerConfig name="AM_BathingWaters" registryId="http://inspire.ec.europa.eu/layer/AM.BathingWaters" tags="//@tags.0 //@tags.2" layerName="AM.BathingWaters" styleConfig="//@styleConfig.58">
+  <layerConfig name="AM_BathingWaters" registryId="http://inspire.ec.europa.eu/layer/AM.BathingWaters" tags="//@tags.0 //@tags.2" layerName="AM.BathingWaters" styleConfig="//@styleConfig.73">
     <title lang="en" text="Bathing Waters"/>
     <title text="Badegewässer"/>
     <objectType>am_4.0:ManagementRestrictionOrRegulationZone</objectType>
   </layerConfig>
-  <layerConfig name="AM_CoastalZoneManagementArea" registryId="http://inspire.ec.europa.eu/layer/AM.CoastalZoneManagementArea" tags="//@tags.0 //@tags.2" layerName="AM.CoastalZoneManagementArea" styleConfig="//@styleConfig.57">
+  <layerConfig name="AM_CoastalZoneManagementArea" registryId="http://inspire.ec.europa.eu/layer/AM.CoastalZoneManagementArea" tags="//@tags.0 //@tags.2" layerName="AM.CoastalZoneManagementArea" styleConfig="//@styleConfig.72">
     <title lang="en" text="Coastal Zone Management Area"/>
     <title text="Gebiete des Küstenzonenmanagements"/>
     <objectType>am_4.0:ManagementRestrictionOrRegulationZone</objectType>
   </layerConfig>
-  <layerConfig name="AM_DesignatedWaters" registryId="http://inspire.ec.europa.eu/layer/AM.DesignatedWaters" tags="//@tags.0 //@tags.2" layerName="AM.DesignatedWaters" styleConfig="//@styleConfig.56">
+  <layerConfig name="AM_DesignatedWaters" registryId="http://inspire.ec.europa.eu/layer/AM.DesignatedWaters" tags="//@tags.0 //@tags.2" layerName="AM.DesignatedWaters" styleConfig="//@styleConfig.71">
     <title lang="en" text="Designated Waters"/>
     <title text="Bezeichnetes Gewässer"/>
     <objectType>am_4.0:ManagementRestrictionOrRegulationZone</objectType>
   </layerConfig>
-  <layerConfig name="AM_DrinkingWaterProtectionArea" registryId="http://inspire.ec.europa.eu/layer/AM.DrinkingWaterProtectionArea" tags="//@tags.0 //@tags.2" layerName="AM.DrinkingWaterProtectionArea" styleConfig="//@styleConfig.55">
+  <layerConfig name="AM_DrinkingWaterProtectionArea" registryId="http://inspire.ec.europa.eu/layer/AM.DrinkingWaterProtectionArea" tags="//@tags.0 //@tags.2" layerName="AM.DrinkingWaterProtectionArea" styleConfig="//@styleConfig.70">
     <title lang="en" text="Drinking Water Protection Area"/>
     <title text="Trinkwasserschutzgebiet"/>
     <objectType>am_4.0:ManagementRestrictionOrRegulationZone</objectType>
   </layerConfig>
-  <layerConfig name="AM_FloodUnitOfManagement" registryId="http://inspire.ec.europa.eu/layer/AM.FloodUnitOfManagement" tags="//@tags.0 //@tags.2" layerName="AM.FloodUnitOfManagement" styleConfig="//@styleConfig.54">
+  <layerConfig name="AM_FloodUnitOfManagement" registryId="http://inspire.ec.europa.eu/layer/AM.FloodUnitOfManagement" tags="//@tags.0 //@tags.2" layerName="AM.FloodUnitOfManagement" styleConfig="//@styleConfig.69">
     <title lang="en" text="Flood Unit Of Management"/>
     <title text="Bewirtschaftungseinheit für Hochwasserrisiken"/>
     <objectType>am_4.0:ManagementRestrictionOrRegulationZone</objectType>
   </layerConfig>
-  <layerConfig name="AM_ForestManagementArea" registryId="http://inspire.ec.europa.eu/layer/AM.ForestManagementArea" tags="//@tags.0 //@tags.2" layerName="AM.ForestManagementArea" styleConfig="//@styleConfig.53">
+  <layerConfig name="AM_ForestManagementArea" registryId="http://inspire.ec.europa.eu/layer/AM.ForestManagementArea" tags="//@tags.0 //@tags.2" layerName="AM.ForestManagementArea" styleConfig="//@styleConfig.68">
     <title lang="en" text="Forest Management Area"/>
     <title text="Waldbewirtschaftungsgebiet"/>
     <objectType>am_4.0:ManagementRestrictionOrRegulationZone</objectType>
   </layerConfig>
-  <layerConfig name="AM_MarineRegion" registryId="http://inspire.ec.europa.eu/layer/AM.MarineRegion" tags="//@tags.0 //@tags.2" layerName="AM.MarineRegion" styleConfig="//@styleConfig.52">
+  <layerConfig name="AM_MarineRegion" registryId="http://inspire.ec.europa.eu/layer/AM.MarineRegion" tags="//@tags.0 //@tags.2" layerName="AM.MarineRegion" styleConfig="//@styleConfig.67">
     <title lang="en" text="Marine Region"/>
     <title text="Meeresregion"/>
     <objectType>am_4.0:ManagementRestrictionOrRegulationZone</objectType>
   </layerConfig>
-  <layerConfig name="AM_NitrateVulnerableZone" registryId="http://inspire.ec.europa.eu/layer/AM.NitrateVulnerableZone" tags="//@tags.0 //@tags.2" layerName="AM.NitrateVulnerableZone" styleConfig="//@styleConfig.51">
+  <layerConfig name="AM_NitrateVulnerableZone" registryId="http://inspire.ec.europa.eu/layer/AM.NitrateVulnerableZone" tags="//@tags.0 //@tags.2" layerName="AM.NitrateVulnerableZone" styleConfig="//@styleConfig.66">
     <title lang="en" text="Nitrate Vulnerable Zone"/>
     <title text="Nitratgefährdetes Gebiet"/>
     <objectType>am_4.0:ManagementRestrictionOrRegulationZone</objectType>
   </layerConfig>
-  <layerConfig name="AM_NoiseRestrictionZone" registryId="http://inspire.ec.europa.eu/layer/AM.NoiseRestrictionZone" tags="//@tags.0 //@tags.2" layerName="AM.NoiseRestrictionZone" styleConfig="//@styleConfig.50">
+  <layerConfig name="AM_NoiseRestrictionZone" registryId="http://inspire.ec.europa.eu/layer/AM.NoiseRestrictionZone" tags="//@tags.0 //@tags.2" layerName="AM.NoiseRestrictionZone" styleConfig="//@styleConfig.65">
     <title lang="en" text="Noise Restriction Zone"/>
     <title text="Lärmschutzgebiet"/>
     <objectType>am_4.0:ManagementRestrictionOrRegulationZone</objectType>
   </layerConfig>
-  <layerConfig name="AM_PlantHealthProtectionZone" registryId="http://inspire.ec.europa.eu/layer/AM.PlantHealthProtectionZone" tags="//@tags.0 //@tags.2" layerName="AM.PlantHealthProtectionZone" styleConfig="//@styleConfig.49">
+  <layerConfig name="AM_PlantHealthProtectionZone" registryId="http://inspire.ec.europa.eu/layer/AM.PlantHealthProtectionZone" tags="//@tags.0 //@tags.2" layerName="AM.PlantHealthProtectionZone" styleConfig="//@styleConfig.64">
     <title lang="en" text="Plant Health Protection Zone"/>
     <title text="Pflanzengesundheitliches Schutzgebiet"/>
     <objectType>am_4.0:ManagementRestrictionOrRegulationZone</objectType>
   </layerConfig>
-  <layerConfig name="AM_ProspectingAndMiningPermitArea" registryId="http://inspire.ec.europa.eu/layer/AM.ProspectingAndMiningPermitArea" tags="//@tags.0 //@tags.2" layerName="AM.ProspectingAndMiningPermitArea" styleConfig="//@styleConfig.48">
+  <layerConfig name="AM_ProspectingAndMiningPermitArea" registryId="http://inspire.ec.europa.eu/layer/AM.ProspectingAndMiningPermitArea" tags="//@tags.0 //@tags.2" layerName="AM.ProspectingAndMiningPermitArea" styleConfig="//@styleConfig.63">
     <title lang="en" text="Prospecting And Mining Permit Area"/>
     <title text="Für Prospektion und Bergbau ausgewiesenes Gebiet"/>
     <objectType>am_4.0:ManagementRestrictionOrRegulationZone</objectType>
   </layerConfig>
-  <layerConfig name="AM_RegulatedFairwayAtSeaOrLargeInlandWater" registryId="http://inspire.ec.europa.eu/layer/AM.RegulatedFairwayAtSeaOrLargeInlandWater" tags="//@tags.0 //@tags.2" layerName="AM.RegulatedFairwayAtSeaOrLargeInlandWater" styleConfig="//@styleConfig.47">
+  <layerConfig name="AM_RegulatedFairwayAtSeaOrLargeInlandWater" registryId="http://inspire.ec.europa.eu/layer/AM.RegulatedFairwayAtSeaOrLargeInlandWater" tags="//@tags.0 //@tags.2" layerName="AM.RegulatedFairwayAtSeaOrLargeInlandWater" styleConfig="//@styleConfig.62">
     <title lang="en" text="Regulated Fairway At Sea Or Large Inland Water"/>
     <title text="Geregeltes Fahrwasser auf See oder auf großen Binnengewässern"/>
     <objectType>am_4.0:ManagementRestrictionOrRegulationZone</objectType>
   </layerConfig>
-  <layerConfig name="AM_RestrictedZonesAroundContaminatedSites" registryId="http://inspire.ec.europa.eu/layer/AM.RestrictedZonesAroundContaminatedSites" tags="//@tags.0 //@tags.2" layerName="AM.RestrictedZonesAroundContaminatedSites" styleConfig="//@styleConfig.46">
+  <layerConfig name="AM_RestrictedZonesAroundContaminatedSites" registryId="http://inspire.ec.europa.eu/layer/AM.RestrictedZonesAroundContaminatedSites" tags="//@tags.0 //@tags.2" layerName="AM.RestrictedZonesAroundContaminatedSites" styleConfig="//@styleConfig.61">
     <title lang="en" text="Restricted Zones Around Contaminated Sites"/>
     <title text="Schutzgebiete um kontaminierte Standorte (Altlasten)"/>
     <objectType>am_4.0:ManagementRestrictionOrRegulationZone</objectType>
   </layerConfig>
-  <layerConfig name="AM_RiverBasinDistrict" registryId="http://inspire.ec.europa.eu/layer/AM.RiverBasinDistrict" tags="//@tags.0 //@tags.2" layerName="AM.RiverBasinDistrict" styleConfig="//@styleConfig.45">
+  <layerConfig name="AM_RiverBasinDistrict" registryId="http://inspire.ec.europa.eu/layer/AM.RiverBasinDistrict" tags="//@tags.0 //@tags.2" layerName="AM.RiverBasinDistrict" styleConfig="//@styleConfig.60">
     <title lang="en" text="River Basin District"/>
     <title text="Flussgebietseinheit"/>
     <objectType>am_4.0:ManagementRestrictionOrRegulationZone</objectType>
   </layerConfig>
-  <layerConfig name="AM_SensitiveArea" registryId="http://inspire.ec.europa.eu/layer/AM.SensitiveArea" tags="//@tags.0 //@tags.2" layerName="AM.SensitiveArea" styleConfig="//@styleConfig.44">
+  <layerConfig name="AM_SensitiveArea" registryId="http://inspire.ec.europa.eu/layer/AM.SensitiveArea" tags="//@tags.0 //@tags.2" layerName="AM.SensitiveArea" styleConfig="//@styleConfig.59">
     <title lang="en" text="Sensitive Area"/>
     <title text="Empfindliches Gebiet"/>
     <objectType>am_4.0:ManagementRestrictionOrRegulationZone</objectType>
   </layerConfig>
-  <layerConfig name="AM_WaterBodyForWFD" registryId="http://inspire.ec.europa.eu/layer/AM.WaterBodyForWFD" tags="//@tags.0 //@tags.2" layerName="AM.WaterBodyForWFD" styleConfig="//@styleConfig.43">
+  <layerConfig name="AM_WaterBodyForWFD" registryId="http://inspire.ec.europa.eu/layer/AM.WaterBodyForWFD" tags="//@tags.0 //@tags.2" layerName="AM.WaterBodyForWFD" styleConfig="//@styleConfig.58">
     <title lang="en" text="WaterBodyForWFD"/>
     <title text="Wasserkörper gemäß der Wasserrahmenrichtlinie (2000/60/EG)"/>
     <objectType>am_4.0:ManagementRestrictionOrRegulationZone</objectType>
   </layerConfig>
-  <layerConfig name="US_EnvironmentalManagementFacility" registryId="https://inspire.ec.europa.eu/layer/US.EnvironmentalManagementFacility" tags="//@tags.0 //@tags.2" layerName="US.EnvironmentalManagementFacility" styleConfig="//@styleConfig.3">
+  <layerConfig name="US_EnvironmentalManagementFacility" registryId="https://inspire.ec.europa.eu/layer/US.EnvironmentalManagementFacility" tags="//@tags.0 //@tags.2" layerName="US.EnvironmentalManagementFacility" styleConfig="//@styleConfig.5">
     <title lang="en" text="Environmental Management Facility"/>
     <title text="Umweltmanagementeinrichtungen"/>
     <objectType>us-emf_4.0:EnvironmentalManagementFacility</objectType>
+  </layerConfig>
+  <layerConfig name="US_EnvironmentalManagementFacility_v5" registryId="https://inspire.ec.europa.eu/layer/US.EnvironmentalManagementFacility" tags="//@tags.0 //@tags.2" layerName="US.EnvironmentalManagementFacility" styleConfig="//@styleConfig.6">
+    <title lang="en" text="Environmental Management Facility"/>
+    <title text="Umweltmanagementeinrichtungen"/>
+    <objectType>us-emf_5.0:EnvironmentalManagementFacility</objectType>
   </layerConfig>
   <layerConfig name="US_UtilityNetworkAppurtenance" registryId="" tags="//@tags.0 //@tags.2" layerName="US.UtilityNetworkAppurtenance" styleConfig="//@styleConfig.1">
     <title lang="en" text="Appurtenance"/>
     <title text="Zubehörteil"/>
     <objectType>us-net-common_4.0:Appurtenance</objectType>
   </layerConfig>
-  <layerConfig name="US_UtilityNetworkLink" registryId="" tags="//@tags.0 //@tags.2" layerName="US.UtilityNetworkLink" styleConfig="//@styleConfig.2">
+  <layerConfig name="US_UtilityNetworkAppurtenance_v5" registryId="" tags="//@tags.0 //@tags.2" layerName="US.UtilityNetworkAppurtenance" styleConfig="//@styleConfig.2">
+    <title lang="en" text="Appurtenance"/>
+    <title text="Zubehörteil"/>
+    <objectType>us-net-common_5.0:Appurtenance</objectType>
+  </layerConfig>
+  <layerConfig name="US_UtilityNetworkLink" registryId="" tags="//@tags.0 //@tags.2" layerName="US.UtilityNetworkLink" styleConfig="//@styleConfig.3">
     <title lang="en" text="Utility Link"/>
     <title text="Versorgungsverbindung"/>
     <objectType>us-net-common_4.0:UtilityLink</objectType>
   </layerConfig>
-  <layerConfig name="EF_EnvironmentalMonitoringFacilities" registryId="http://inspire.ec.europa.eu/layer/EF.EnvironmentalMonitoringFacilities" tags="//@tags.0 //@tags.2" layerName="EF.EnvironmentalMonitoringFacilities" styleConfig="//@styleConfig.42">
+  <layerConfig name="US_UtilityNetworkLink_v5" registryId="" tags="//@tags.0 //@tags.2" layerName="US.UtilityNetworkLink" styleConfig="//@styleConfig.4">
+    <title lang="en" text="Utility Link"/>
+    <title text="Versorgungsverbindung"/>
+    <objectType>us-net-common_5.0:UtilityLink</objectType>
+  </layerConfig>
+  <layerConfig name="EF_EnvironmentalMonitoringFacilities" registryId="http://inspire.ec.europa.eu/layer/EF.EnvironmentalMonitoringFacilities" tags="//@tags.0 //@tags.2" layerName="EF.EnvironmentalMonitoringFacilities" styleConfig="//@styleConfig.57">
     <title lang="en" text="Environmental Monitoring Facilities"/>
     <title text="Umweltüberwachungseinrichtungen"/>
     <objectType>ef_4.0:EnvironmentalMonitoringFacility</objectType>
   </layerConfig>
-  <layerConfig name="EF_EnvironmentalMonitoringNetworks" registryId="http://inspire.ec.europa.eu/layer/EF.EnvironmentalMonitoringNetworks" tags="//@tags.0 //@tags.2" layerName="EF.EnvironmentalMonitoringNetworks" styleConfig="//@styleConfig.41">
+  <layerConfig name="EF_EnvironmentalMonitoringNetworks" registryId="http://inspire.ec.europa.eu/layer/EF.EnvironmentalMonitoringNetworks" tags="//@tags.0 //@tags.2" layerName="EF.EnvironmentalMonitoringNetworks" styleConfig="//@styleConfig.56">
     <title lang="en" text="Environmental Monitoring Networks"/>
     <title text="Umweltüberwachungsnetzwerke"/>
     <objectType>ef_4.0:EnvironmentalMonitoringNetwork</objectType>
   </layerConfig>
-  <layerConfig name="EF_EnvironmentalMonitoringProgrammes" registryId="http://inspire.ec.europa.eu/layer/EF.EnvironmentalMonitoringProgrammes" tags="//@tags.0 //@tags.2" layerName="EF.EnvironmentalMonitoringProgrammes" styleConfig="//@styleConfig.40">
+  <layerConfig name="EF_EnvironmentalMonitoringProgrammes" registryId="http://inspire.ec.europa.eu/layer/EF.EnvironmentalMonitoringProgrammes" tags="//@tags.0 //@tags.2" layerName="EF.EnvironmentalMonitoringProgrammes" styleConfig="//@styleConfig.55">
     <title lang="en" text="Environmental Monitoring Programmes"/>
     <title text="Umweltüberwachungsprogramme"/>
     <objectType>ef_4.0:EnvironmentalMonitoringProgramme</objectType>
   </layerConfig>
-  <layerConfig name="NZ_RiskZone" registryId="" tags="//@tags.0 //@tags.2" layerName="NZ.RiskZone" styleConfig="//@styleConfig.39">
+  <layerConfig name="NZ_RiskZone" registryId="" tags="//@tags.0 //@tags.2" layerName="NZ.RiskZone" styleConfig="//@styleConfig.54">
     <title lang="en" text="Risk Zones"/>
     <title text="Risikogebiet"/>
     <objectType>nz-core_4.0:RiskZone</objectType>
   </layerConfig>
-  <layerConfig name="NZ_HazardArea" registryId="" tags="//@tags.0 //@tags.2" layerName="NZ.HazardArea" styleConfig="//@styleConfig.38">
+  <layerConfig name="NZ_HazardArea" registryId="" tags="//@tags.0 //@tags.2" layerName="NZ.HazardArea" styleConfig="//@styleConfig.53">
     <title lang="en" text="Hazard Area"/>
     <title text="Gefahrengebiet"/>
     <objectType>nz-core_4.0:HazardArea</objectType>
   </layerConfig>
-  <layerConfig name="NZ_ExposedElement" registryId="http://inspire.ec.europa.eu/layer/NZ.ExposedElement" tags="//@tags.0 //@tags.2" layerName="NZ.ExposedElement" styleConfig="//@styleConfig.37">
+  <layerConfig name="NZ_ExposedElement" registryId="http://inspire.ec.europa.eu/layer/NZ.ExposedElement" tags="//@tags.0 //@tags.2" layerName="NZ.ExposedElement" styleConfig="//@styleConfig.52">
     <title lang="en" text="Exposed Elements"/>
     <title text="Gefährdetes Element"/>
     <objectType>nz-core_4.0:ExposedElement</objectType>
   </layerConfig>
-  <layerConfig name="NZ_ObservedEvent" registryId="" tags="//@tags.0" layerName="NZ.ObservedEvent" styleConfig="//@styleConfig.36">
+  <layerConfig name="NZ_ObservedEvent" registryId="" tags="//@tags.0" layerName="NZ.ObservedEvent" styleConfig="//@styleConfig.51">
     <title lang="en" text="Observed Event"/>
     <title text="Beobachtetes Ereignis"/>
     <objectType>nz-core_4.0:ObservedEvent</objectType>
   </layerConfig>
-  <layerConfig name="TN_MarkerPost" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.CommonTransportElements.MarkerPost" styleConfig="//@styleConfig.35">
+  <layerConfig name="TN_MarkerPost" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.CommonTransportElements.MarkerPost" styleConfig="//@styleConfig.49">
     <title lang="en" text="Marker Post"/>
     <title text="Stationszeichen"/>
     <objectType>tn_4.0:MarkerPost</objectType>
   </layerConfig>
-  <layerConfig name="TN_W_Beacon" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.WaterTransportNetwork.Beacon" styleConfig="//@styleConfig.34">
+  <layerConfig name="TN_MarkerPost_v5" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.CommonTransportElements.MarkerPost" styleConfig="//@styleConfig.50">
+    <title lang="en" text="Marker Post"/>
+    <title text="Stationszeichen"/>
+    <objectType>tn_5.0:MarkerPost</objectType>
+  </layerConfig>
+  <layerConfig name="TN_W_Beacon" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.WaterTransportNetwork.Beacon" styleConfig="//@styleConfig.47">
     <title lang="en" text="Beacon"/>
     <title text="Leuchtfeuer"/>
     <objectType>tn-w_4.0:Beacon</objectType>
   </layerConfig>
-  <layerConfig name="TN_W_Buoy" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.WaterTransportNetwork.Buoy" styleConfig="//@styleConfig.33">
+  <layerConfig name="TN_W_Beacon_v5" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.WaterTransportNetwork.Beacon" styleConfig="//@styleConfig.48">
+    <title lang="en" text="Beacon"/>
+    <title text="Leuchtfeuer"/>
+    <objectType>tn-w_5.0:Beacon</objectType>
+  </layerConfig>
+  <layerConfig name="TN_W_Buoy" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.WaterTransportNetwork.Buoy" styleConfig="//@styleConfig.45">
     <title lang="en" text="Buoy"/>
     <title text="Tonne"/>
     <objectType>tn-w_4.0:Buoy</objectType>
   </layerConfig>
-  <layerConfig name="TN_W_TrafficSeparationSchemeCrossing" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.WaterTransportNetwork.TrafficSeparationSchemeCrossing" styleConfig="//@styleConfig.32">
+  <layerConfig name="TN_W_Buoy_v5" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.WaterTransportNetwork.Buoy" styleConfig="//@styleConfig.46">
+    <title lang="en" text="Buoy"/>
+    <title text="Tonne"/>
+    <objectType>tn-w_5.0:Buoy</objectType>
+  </layerConfig>
+  <layerConfig name="TN_W_TrafficSeparationSchemeCrossing" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.WaterTransportNetwork.TrafficSeparationSchemeCrossing" styleConfig="//@styleConfig.43">
     <title lang="en" text="Traffic Separation Scheme Crossing"/>
     <title text="Kreuzung eines Verkehrstrennungsgebiets"/>
     <objectType>tn-w_4.0:TrafficSeparationSchemeCrossing</objectType>
   </layerConfig>
-  <layerConfig name="TN_W_TrafficSeparationSchemeSeparator" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.WaterTransportNetwork.TrafficSeparationSchemeSeparator" styleConfig="//@styleConfig.31">
+  <layerConfig name="TN_W_TrafficSeparationSchemeCrossing_v5" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.WaterTransportNetwork.TrafficSeparationSchemeCrossing" styleConfig="//@styleConfig.44">
+    <title lang="en" text="Traffic Separation Scheme Crossing"/>
+    <title text="Kreuzung eines Verkehrstrennungsgebiets"/>
+    <objectType>tn-w_5.0:TrafficSeparationSchemeCrossing</objectType>
+  </layerConfig>
+  <layerConfig name="TN_W_TrafficSeparationSchemeSeparator" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.WaterTransportNetwork.TrafficSeparationSchemeSeparator" styleConfig="//@styleConfig.41">
     <title lang="en" text="Traffic Separation Scheme Separator"/>
     <title text="Übergangszone eines Verkehrstrennungsgebiets"/>
     <objectType>tn-w_4.0:TrafficSeparationSchemeSeparator</objectType>
   </layerConfig>
-  <layerConfig name="PF_ProductionFacility" registryId="" tags="//@tags.0" layerName="PF.ProductionFacility" styleConfig="//@styleConfig.30">
+  <layerConfig name="TN_W_TrafficSeparationSchemeSeparator_v5" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.WaterTransportNetwork.TrafficSeparationSchemeSeparator" styleConfig="//@styleConfig.42">
+    <title lang="en" text="Traffic Separation Scheme Separator"/>
+    <title text="Übergangszone eines Verkehrstrennungsgebiets"/>
+    <objectType>tn-w_5.0:TrafficSeparationSchemeSeparator</objectType>
+  </layerConfig>
+  <layerConfig name="PF_ProductionFacility" registryId="" tags="//@tags.0" layerName="PF.ProductionFacility" styleConfig="//@styleConfig.40">
     <title lang="en" text="Production Facility"/>
     <title text="Produktionsstätte"/>
     <objectType>pf_4.0:ProductionFacility</objectType>
   </layerConfig>
-  <layerConfig name="PF_ProductionBuilding" registryId="http://inspire.ec.europa.eu/layer/PF.ProductionBuilding" tags="//@tags.0 //@tags.2" layerName="PF.ProductionBuilding" styleConfig="//@styleConfig.29">
+  <layerConfig name="PF_ProductionBuilding" registryId="http://inspire.ec.europa.eu/layer/PF.ProductionBuilding" tags="//@tags.0 //@tags.2" layerName="PF.ProductionBuilding" styleConfig="//@styleConfig.39">
     <title lang="en" text="Production And Industrial Building"/>
     <title text="Produktions- und Industriegebäude"/>
     <objectType>pf_4.0:ProductionBuilding</objectType>
   </layerConfig>
-  <layerConfig name="PF_ProductionInstallation" registryId="http://inspire.ec.europa.eu/layer/PF.ProductionInstallation" tags="//@tags.0 //@tags.2" layerName="PF.ProductionInstallation" styleConfig="//@styleConfig.28">
+  <layerConfig name="PF_ProductionInstallation" registryId="http://inspire.ec.europa.eu/layer/PF.ProductionInstallation" tags="//@tags.0 //@tags.2" layerName="PF.ProductionInstallation" styleConfig="//@styleConfig.38">
     <title lang="en" text="Production And Industrial Installation"/>
     <title text="Produktions- und Industrieanlage"/>
     <objectType>pf_4.0:ProductionInstallation</objectType>
   </layerConfig>
-  <layerConfig name="PF_ProductionInstallationPart" registryId="http://inspire.ec.europa.eu/layer/PF.ProductionInstallationPart" tags="//@tags.0 //@tags.2" layerName="PF.ProductionInstallationPart" styleConfig="//@styleConfig.27">
+  <layerConfig name="PF_ProductionInstallationPart" registryId="http://inspire.ec.europa.eu/layer/PF.ProductionInstallationPart" tags="//@tags.0 //@tags.2" layerName="PF.ProductionInstallationPart" styleConfig="//@styleConfig.37">
     <title lang="en" text="Production And Industrial Installation Part"/>
     <title text="Produktions- und Industrieanlagenteil"/>
     <objectType>pf_4.0:ProductionInstallationPart</objectType>
   </layerConfig>
-  <layerConfig name="PF_ProductionPlot" registryId="http://inspire.ec.europa.eu/layer/PF.ProductionPlot" tags="//@tags.0 //@tags.2" layerName="PF.ProductionPlot" styleConfig="//@styleConfig.26">
+  <layerConfig name="PF_ProductionPlot" registryId="http://inspire.ec.europa.eu/layer/PF.ProductionPlot" tags="//@tags.0 //@tags.2" layerName="PF.ProductionPlot" styleConfig="//@styleConfig.36">
     <title lang="en" text="Production And Industrial Plot"/>
     <title text="Produktions- und Industriegelände"/>
     <objectType>pf_4.0:ProductionPlot</objectType>
   </layerConfig>
-  <layerConfig name="PF_ProductionSite" registryId="http://inspire.ec.europa.eu/layer/PF.ProductionSite" tags="//@tags.0 //@tags.2" layerName="PF.ProductionSite" styleConfig="//@styleConfig.25">
+  <layerConfig name="PF_ProductionSite" registryId="http://inspire.ec.europa.eu/layer/PF.ProductionSite" tags="//@tags.0 //@tags.2" layerName="PF.ProductionSite" styleConfig="//@styleConfig.35">
     <title lang="en" text="Production And Industrial Site"/>
     <title text="Produktions- und Industriestandort"/>
     <objectType>pf_4.0:ProductionSite</objectType>
   </layerConfig>
-  <layerConfig name="ER_RenewableAndWasteResource" registryId="http://inspire.ec.europa.eu/layer/ER.RenewableAndWasteResource" tags="//@tags.0" layerName="ER.RenewableAndWasteResource" styleConfig="//@styleConfig.24">
+  <layerConfig name="ER_RenewableAndWasteResource" registryId="http://inspire.ec.europa.eu/layer/ER.RenewableAndWasteResource" tags="//@tags.0" layerName="ER.RenewableAndWasteResource" styleConfig="//@styleConfig.34">
     <title lang="en" text="Renewable And Waste Resource"/>
     <title text="Ressourcen erneuerbarer Energien und Abfallressourcen"/>
     <objectType>er-v_4.0:RenewableAndWasteResource</objectType>
   </layerConfig>
-  <layerConfig name="GE_GeologicUnit_AgeOfRocks" registryId="http://inspire.ec.europa.eu/layer/GE.GeologicUnit" tags="//@tags.0 //@tags.2" layerName="GE.GeologicUnit.AgeOfRocks" styleConfig="//@styleConfig.23">
+  <layerConfig name="GE_GeologicUnit_AgeOfRocks" registryId="http://inspire.ec.europa.eu/layer/GE.GeologicUnit" tags="//@tags.0 //@tags.2" layerName="GE.GeologicUnit.AgeOfRocks" styleConfig="//@styleConfig.33">
     <title lang="en" text="Geologic Units"/>
     <title text="Geologische Einheiten"/>
     <objectType>ge-core_4.0:MappedFeature</objectType>
   </layerConfig>
-  <layerConfig name="GE_Borehole" registryId="http://inspire.ec.europa.eu/layer/GE.Borehole" tags="//@tags.0 //@tags.2" layerName="GE.Borehole" styleConfig="//@styleConfig.133">
+  <layerConfig name="GE_Borehole" registryId="http://inspire.ec.europa.eu/layer/GE.Borehole" tags="//@tags.0 //@tags.2" layerName="GE.Borehole" styleConfig="//@styleConfig.194">
     <title lang="en" text="Boreholes"/>
     <title text="Bohrlöcher"/>
     <objectType>ge-core_4.0:Borehole</objectType>
   </layerConfig>
-  <layerConfig name="BR_BiogeographicalRegion" registryId="http://inspire.ec.europa.eu/layer/BR.Bio-geographicalRegion" tags="//@tags.0 //@tags.2" layerName="BR.Bio-geographicalRegion" styleConfig="//@styleConfig.22">
+  <layerConfig name="BR_BiogeographicalRegion" registryId="http://inspire.ec.europa.eu/layer/BR.Bio-geographicalRegion" tags="//@tags.0 //@tags.2" layerName="BR.Bio-geographicalRegion" styleConfig="//@styleConfig.32">
     <title lang="en" text="Bio-geographical regions"/>
     <title text="Biogeografische Regionen"/>
     <objectType>br_4.0:Bio-geographicalRegion</objectType>
   </layerConfig>
-  <layerConfig name="BR_Natura2000andEmeraldBiogeographicalRegion" registryId="" tags="//@tags.0 //@tags.2" layerName="BR.Natura2000andEmeraldBio-geographicalRegion" styleConfig="//@styleConfig.21">
+  <layerConfig name="BR_Natura2000andEmeraldBiogeographicalRegion" registryId="" tags="//@tags.0 //@tags.2" layerName="BR.Natura2000andEmeraldBio-geographicalRegion" styleConfig="//@styleConfig.31">
     <title lang="en" text="Bio-geographical regions"/>
     <title text="Biogeografische Regionen"/>
     <objectType>br_4.0:Bio-geographicalRegion</objectType>
   </layerConfig>
-  <layerConfig name="SU_VectorStatisticalUnit" registryId="http://inspire.ec.europa.eu/layer/SU.VectorStatisticalUnit" tags="//@tags.0 //@tags.2" layerName="SU.VectorStatisticalUnit" styleConfig="//@styleConfig.19">
+  <layerConfig name="SU_VectorStatisticalUnit" registryId="http://inspire.ec.europa.eu/layer/SU.VectorStatisticalUnit" tags="//@tags.0 //@tags.2" layerName="SU.VectorStatisticalUnit" styleConfig="//@styleConfig.29">
     <title lang="en" text="Vector statistical units"/>
     <title text="Statistische Vektoreinheiten"/>
     <objectType>su-vector_4.0:VectorStatisticalUnit</objectType>
   </layerConfig>
-  <layerConfig name="SU_StatisticalGridCell" registryId="http://inspire.ec.europa.eu/layer/SU.StatisticalGridCell" tags="//@tags.0" layerName="SU.StatisticalGridCell" styleConfig="//@styleConfig.20">
+  <layerConfig name="SU_StatisticalGridCell" registryId="http://inspire.ec.europa.eu/layer/SU.StatisticalGridCell" tags="//@tags.0" layerName="SU.StatisticalGridCell" styleConfig="//@styleConfig.30">
     <title lang="en" text="Statistical grid cells"/>
     <title text="Statistische Vektoreinheiten"/>
     <objectType>su-grid_4.0:StatisticalGridCell</objectType>
   </layerConfig>
-  <layerConfig name="HH_HealthDeterminantMeasure" registryId="http://inspire.ec.europa.eu/layer/HH.HealthDeterminantMeasure" tags="//@tags.0 //@tags.2" layerName="HH.HealthDeterminantMeasure" styleConfig="//@styleConfig.18">
+  <layerConfig name="HH_HealthDeterminantMeasure" registryId="http://inspire.ec.europa.eu/layer/HH.HealthDeterminantMeasure" tags="//@tags.0 //@tags.2" layerName="HH.HealthDeterminantMeasure" styleConfig="//@styleConfig.27">
     <title lang="en" text="Health determinant measure"/>
     <title text="Messwerte für Gesundheitsfaktoren"/>
     <objectType>hh_4.0:EnvHealthDeterminantMeasure</objectType>
   </layerConfig>
-  <layerConfig name="EL_BreakLine" registryId="http://inspire.ec.europa.eu/layer/EL.BreakLine" tags="//@tags.0 //@tags.2" layerName="EL.BreakLine" styleConfig="//@styleConfig.17">
+  <layerConfig name="HH_HealthDeterminantMeasure_v5" registryId="http://inspire.ec.europa.eu/layer/HH.HealthDeterminantMeasure" tags="//@tags.0 //@tags.2" layerName="HH.HealthDeterminantMeasure" styleConfig="//@styleConfig.28">
+    <title lang="en" text="Health determinant measure"/>
+    <title text="Messwerte für Gesundheitsfaktoren"/>
+    <objectType>hh_5.0:EnvHealthDeterminantMeasure</objectType>
+  </layerConfig>
+  <layerConfig name="EL_BreakLine" registryId="http://inspire.ec.europa.eu/layer/EL.BreakLine" tags="//@tags.0 //@tags.2" layerName="EL.BreakLine" styleConfig="//@styleConfig.26">
     <title lang="en" text="Break Line"/>
     <title text="Bruchkante"/>
     <objectType>el-vec_4.0:BreakLine</objectType>
   </layerConfig>
-  <layerConfig name="EL_ContourLine" registryId="http://inspire.ec.europa.eu/layer/EL.ContourLine" tags="//@tags.0 //@tags.2" layerName="EL.ContourLine" styleConfig="//@styleConfig.16">
+  <layerConfig name="EL_ContourLine" registryId="http://inspire.ec.europa.eu/layer/EL.ContourLine" tags="//@tags.0 //@tags.2" layerName="EL.ContourLine" styleConfig="//@styleConfig.25">
     <title lang="en" text="Contour Line"/>
     <title text="Höhenlinie"/>
     <objectType>el-vec_4.0:ContourLine</objectType>
   </layerConfig>
-  <layerConfig name="EL_IsolatedArea" registryId="http://inspire.ec.europa.eu/layer/EL.IsolatedArea" tags="//@tags.0 //@tags.2" layerName="EL.IsolatedArea" styleConfig="//@styleConfig.15">
+  <layerConfig name="EL_IsolatedArea" registryId="http://inspire.ec.europa.eu/layer/EL.IsolatedArea" tags="//@tags.0 //@tags.2" layerName="EL.IsolatedArea" styleConfig="//@styleConfig.24">
     <title lang="en" text="Isolated Area"/>
     <title text="Abgesondertes Gebiet"/>
     <objectType>el-vec_4.0:IsolatedArea</objectType>
   </layerConfig>
-  <layerConfig name="EL_SpotElevation" registryId="http://inspire.ec.europa.eu/layer/EL.SpotElevation" tags="//@tags.0 //@tags.2" layerName="EL.SpotElevation" styleConfig="//@styleConfig.14">
+  <layerConfig name="EL_SpotElevation" registryId="http://inspire.ec.europa.eu/layer/EL.SpotElevation" tags="//@tags.0 //@tags.2" layerName="EL.SpotElevation" styleConfig="//@styleConfig.23">
     <title lang="en" text="Spot Elevation"/>
     <title text="Höhenlagenpunkt"/>
     <objectType>el-vec_4.0:SpotElevation</objectType>
   </layerConfig>
-  <layerConfig name="EL_VoidArea" registryId="http://inspire.ec.europa.eu/layer/EL.VoidArea" tags="//@tags.0 //@tags.2" layerName="EL.VoidArea" styleConfig="//@styleConfig.13">
+  <layerConfig name="EL_VoidArea" registryId="http://inspire.ec.europa.eu/layer/EL.VoidArea" tags="//@tags.0 //@tags.2" layerName="EL.VoidArea" styleConfig="//@styleConfig.22">
     <title lang="en" text="Void Area"/>
     <title text="Leeres Gebiet"/>
     <objectType>el-vec_4.0:VoidArea</objectType>
   </layerConfig>
-  <layerConfig name="EL_ContourLineType" registryId="" tags="//@tags.0 //@tags.2" layerName="EL.ContourLineType" styleConfig="//@styleConfig.12">
+  <layerConfig name="EL_ContourLineType" registryId="" tags="//@tags.0 //@tags.2" layerName="EL.ContourLineType" styleConfig="//@styleConfig.21">
     <title lang="en" text="Contour Line Type"/>
     <title text="Höhenlinie"/>
     <objectType>el-vec_4.0:ContourLine</objectType>
   </layerConfig>
-  <layerConfig name="EL_TIN" registryId="http://inspire.ec.europa.eu/layer/EL.ElevationTIN" tags="//@tags.0" layerName="EL.ElevationTIN" styleConfig="//@styleConfig.11">
+  <layerConfig name="EL_TIN" registryId="http://inspire.ec.europa.eu/layer/EL.ElevationTIN" tags="//@tags.0" layerName="EL.ElevationTIN" styleConfig="//@styleConfig.20">
     <title lang="en" text="Elevation TIN"/>
     <title text="Höhenlagenstruktur-TIN"/>
     <objectType>el-tin_4.0:ElevationTIN</objectType>
   </layerConfig>
-  <layerConfig name="SD_SpeciesDistribution" registryId="" tags="//@tags.0 //@tags.2" layerName="SD.SpeciesDistribution" styleConfig="//@styleConfig.10">
+  <layerConfig name="SD_SpeciesDistribution" registryId="" tags="//@tags.0 //@tags.2" layerName="SD.SpeciesDistribution" styleConfig="//@styleConfig.19">
     <title lang="en" text="Species Distribution"/>
     <title text="Verteilung der Arten"/>
     <objectType>sd_4.0:SpeciesDistributionUnit</objectType>
   </layerConfig>
-  <layerConfig name="TN_RO_RoadNode" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.RoadNode" styleConfig="//@styleConfig.9">
+  <layerConfig name="TN_RO_RoadNode" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.RoadNode" styleConfig="//@styleConfig.17">
     <title lang="en" text="Road Node"/>
     <title text="Strassenknotenpunkt"/>
     <objectType>tn-ro_4.0:RoadNode</objectType>
+  </layerConfig>
+  <layerConfig name="TN_RO_RoadNode_v5" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.RoadNode" styleConfig="//@styleConfig.18">
+    <title lang="en" text="Road Node"/>
+    <title text="Strassenknotenpunkt"/>
+    <objectType>tn-ro_5.0:RoadNode</objectType>
   </layerConfig>
   <layerConfig name="SF_SpatialSamplingFeature" registryId="" tags="//@tags.0 //@tags.2" layerName="SF.SpatialSamplingFeature" styleConfig="//@styleConfig.0">
     <title lang="en" text="Spatial Sampling Feature"/>
@@ -634,29 +897,56 @@
   <styleConfig name="US_UtilityNetworkAppurtenance">
     <remoteStyle featureTypeName="us-net-common_4.0:Appurtenance" url="feature-styles/US_UtilityNetworkAppurtenance.se"/>
   </styleConfig>
+  <styleConfig name="US_UtilityNetworkAppurtenance_v5">
+    <remoteStyle featureTypeName="us-net-common_5.0:Appurtenance" url="feature-styles/US_UtilityNetworkAppurtenance_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="US_UtilityNetworkLink">
     <remoteStyle featureTypeName="us-net-common_4.0:UtilityLink" url="feature-styles/US_UtilityNetworkLink.se"/>
+  </styleConfig>
+  <styleConfig name="US_UtilityNetworkLink_v5">
+    <remoteStyle featureTypeName="us-net-common_5.0:UtilityLink" url="feature-styles/US_UtilityNetworkLink_v5_0.se"/>
   </styleConfig>
   <styleConfig name="US_EnvironmentalManagementFacility">
     <remoteStyle featureTypeName="us-emf_4.0:EnvironmentalManagementFacility" url="feature-styles/US_EnvironmentalManagementFacility.se"/>
   </styleConfig>
+  <styleConfig name="US_EnvironmentalManagementFacility_v5">
+    <remoteStyle featureTypeName="us-emf_5.0:EnvironmentalManagementFacility" url="feature-styles/US_EnvironmentalManagementFacility_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="TN_A_DesignatedPoint">
     <remoteStyle featureTypeName="tn-a_4.0:DesignatedPoint" url="feature-styles/TN_A_DesignatedPoint.se"/>
+  </styleConfig>
+  <styleConfig name="TN_A_DesignatedPoint_v5">
+    <remoteStyle featureTypeName="tn-a_5.0:DesignatedPoint" url="feature-styles/TN_A_DesignatedPoint_v5_0.se"/>
   </styleConfig>
   <styleConfig name="TN_A_Navaid">
     <remoteStyle featureTypeName="tn-a_4.0:Navaid" url="feature-styles/TN_A_Navaid.se"/>
   </styleConfig>
+  <styleConfig name="TN_A_Navaid_v5">
+    <remoteStyle featureTypeName="tn-a_5.0:Navaid" url="feature-styles/TN_A_Navaid_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="TN_A_RunwayCentrelinePoint">
     <remoteStyle featureTypeName="tn-a_4.0:RunwayCentrelinePoint" url="feature-styles/TN_A_RunwayCentrelinePoint.se"/>
+  </styleConfig>
+  <styleConfig name="TN_A_RunwayCentrelinePoint_v5">
+    <remoteStyle featureTypeName="tn-a_5.0:RunwayCentrelinePoint" url="feature-styles/TN_A_RunwayCentrelinePoint_v5_0.se"/>
   </styleConfig>
   <styleConfig name="TN_A_AerodromeNode">
     <remoteStyle featureTypeName="tn-a_4.0:AerodromeNode" url="feature-styles/TN_A_AerodromeNode.se"/>
   </styleConfig>
+  <styleConfig name="TN_A_AerodromeNode_v5">
+    <remoteStyle featureTypeName="tn-a_5.0:AerodromeNode" url="feature-styles/TN_A_AerodromeNode_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="TN_A_TouchDownLiftOff">
     <remoteStyle featureTypeName="tn-a_4.0:TouchDownLiftOff" url="feature-styles/TN_A_TouchDownLiftOff.se"/>
   </styleConfig>
+  <styleConfig name="TN_A_TouchDownLiftOff_v5">
+    <remoteStyle featureTypeName="tn-a_5.0:TouchDownLiftOff" url="feature-styles/TN_A_TouchDownLiftOff_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="TN_RO_RoadNode">
     <remoteStyle featureTypeName="tn-ro_4.0:RoadNode" url="feature-styles/TN_RO_RoadNode.se"/>
+  </styleConfig>
+  <styleConfig name="TN_RO_RoadNode_v5">
+    <remoteStyle featureTypeName="tn-ro_5.0:RoadNode" url="feature-styles/TN_RO_RoadNode_v5_0.se"/>
   </styleConfig>
   <styleConfig name="SD_SpeciesDistribution">
     <remoteStyle featureTypeName="sd_4.0:SpeciesDistributionUnit" url="feature-styles/SD_SpeciesDistribution.se"/>
@@ -684,6 +974,9 @@
   </styleConfig>
   <styleConfig name="HH_HealthDeterminantMeasure">
     <remoteStyle featureTypeName="hh_4.0:EnvHealthDeterminantMeasure" url="feature-styles/HH_HealthDeterminantMeasure.se"/>
+  </styleConfig>
+  <styleConfig name="HH_HealthDeterminantMeasure_v5">
+    <remoteStyle featureTypeName="hh_5.0:EnvHealthDeterminantMeasure" url="feature-styles/HH_HealthDeterminantMeasure_v5_0.se"/>
   </styleConfig>
   <styleConfig name="SU_VectorStatisticalUnit">
     <remoteStyle featureTypeName="su-vector_4.0:VectorStatisticalUnit" url="feature-styles/SU_VectorStatisticalUnit.se"/>
@@ -724,17 +1017,32 @@
   <styleConfig name="TN_W_TrafficSeparationSchemeSeparator">
     <remoteStyle featureTypeName="tn-w_4.0:TrafficSeparationSchemeSeparator" url="feature-styles/TN_W_TrafficSeparationSchemeSeparator.se"/>
   </styleConfig>
+  <styleConfig name="TN_W_TrafficSeparationSchemeSeparator_v5">
+    <remoteStyle featureTypeName="tn-w_5.0:TrafficSeparationSchemeSeparator" url="feature-styles/TN_W_TrafficSeparationSchemeSeparator_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="TN_W_TrafficSeparationSchemeCrossing">
     <remoteStyle featureTypeName="tn-w_4.0:TrafficSeparationSchemeCrossing" url="feature-styles/TN_W_TrafficSeparationSchemeCrossing.se"/>
+  </styleConfig>
+  <styleConfig name="TN_W_TrafficSeparationSchemeCrossing_v5">
+    <remoteStyle featureTypeName="tn-w_5.0:TrafficSeparationSchemeCrossing" url="feature-styles/TN_W_TrafficSeparationSchemeCrossing_v5_0.se"/>
   </styleConfig>
   <styleConfig name="TN_W_Buoy">
     <remoteStyle featureTypeName="tn-w_4.0:Buoy" url="feature-styles/TN_W_Buoy.se"/>
   </styleConfig>
+  <styleConfig name="TN_W_Buoy_v5">
+    <remoteStyle featureTypeName="tn-w_5.0:Buoy" url="feature-styles/TN_W_Buoy_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="TN_W_Beacon">
     <remoteStyle featureTypeName="tn-w_4.0:Beacon" url="feature-styles/TN_W_Beacon.se"/>
   </styleConfig>
+  <styleConfig name="TN_W_Beacon_v5">
+    <remoteStyle featureTypeName="tn-w_5.0:Beacon" url="feature-styles/TN_W_Beacon_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="TN_MarkerPost">
     <remoteStyle featureTypeName="tn_4.0:MarkerPost" url="feature-styles/TN_MarkerPost.se"/>
+  </styleConfig>
+  <styleConfig name="TN_MarkerPost_v5">
+    <remoteStyle featureTypeName="tn_5.0:MarkerPost" url="feature-styles/TN_MarkerPost_v5_0.se"/>
   </styleConfig>
   <styleConfig name="NZ_ObservedEvent">
     <remoteStyle featureTypeName="nz-core_4.0:ObservedEvent" url="feature-styles/NZ_ObservedEvent.se"/>
@@ -817,6 +1125,9 @@
   <styleConfig name="US_GovernmentalService">
     <remoteStyle featureTypeName="us-govserv_4.0:GovernmentalService" url="feature-styles/US_GovernmentalService.se"/>
   </styleConfig>
+  <styleConfig name="US_GovernmentalService_v5">
+    <remoteStyle featureTypeName="us-govserv_5.0:GovernmentalService" url="feature-styles/US_GovernmentalService_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="LU_SupplementaryRegulation">
     <remoteStyle featureTypeName="plu_4.0:SupplementaryRegulation" url="feature-styles/LU_SupplementaryRegulation.se"/>
   </styleConfig>
@@ -886,65 +1197,128 @@
   <styleConfig name="HY_N_WatercourseLink">
     <remoteStyle featureTypeName="hy-n_4.0:WatercourseLink" url="feature-styles/HY_N_WatercourseLink.se"/>
   </styleConfig>
+  <styleConfig name="HY_N_WatercourseLink_v5">
+    <remoteStyle featureTypeName="hy-n_5.0:WatercourseLink" url="feature-styles/HY_N_WatercourseLink_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="HY_N_HydroNode">
     <remoteStyle featureTypeName="hy-n_4.0:HydroNode" url="feature-styles/HY_N_HydroNode.se"/>
+  </styleConfig>
+  <styleConfig name="HY_N_HydroNode_v5">
+    <remoteStyle featureTypeName="hy-n_5.0:HydroNode" url="feature-styles/HY_N_HydroNode_v5_0.se"/>
   </styleConfig>
   <styleConfig name="HY_P_DrainageBasin">
     <remoteStyle featureTypeName="hy-p_4.0:DrainageBasin" url="feature-styles/HY_P_DrainageBasin.se"/>
   </styleConfig>
+  <styleConfig name="HY_P_DrainageBasin_v5">
+    <remoteStyle featureTypeName="hy-p_5.0:DrainageBasin" url="feature-styles/HY_P_DrainageBasin_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="HY_P_RiverBasin">
     <remoteStyle featureTypeName="hy-p_4.0:RiverBasin" url="feature-styles/HY_P_RiverBasin.se"/>
+  </styleConfig>
+  <styleConfig name="HY_P_RiverBasin_v5">
+    <remoteStyle featureTypeName="hy-p_5.0:RiverBasin" url="feature-styles/HY_P_RiverBasin_v5_0.se"/>
   </styleConfig>
   <styleConfig name="HY_P_Rapids">
     <remoteStyle featureTypeName="hy-p_4.0:Rapids" url="feature-styles/HY_P_Rapids.se"/>
   </styleConfig>
+  <styleConfig name="HY_P_Rapids_v5">
+    <remoteStyle featureTypeName="hy-p_5.0:Rapids" url="feature-styles/HY_P_Rapids_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="HY_P_Falls">
     <remoteStyle featureTypeName="hy-p_4.0:Falls" url="feature-styles/HY_P_Falls.se"/>
+  </styleConfig>
+  <styleConfig name="HY_P_Falls_v5">
+    <remoteStyle featureTypeName="hy-p_5.0:Falls" url="feature-styles/HY_P_Falls_v5_0.se"/>
   </styleConfig>
   <styleConfig name="HY_P_LandWaterBoundary">
     <remoteStyle featureTypeName="hy-p_4.0:LandWaterBoundary" url="feature-styles/HY_P_LandWaterBoundary.se"/>
   </styleConfig>
+  <styleConfig name="HY_P_LandWaterBoundary_v5">
+    <remoteStyle featureTypeName="hy-p_5.0:LandWaterBoundary" url="feature-styles/HY_P_LandWaterBoundary_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="HY_P_Crossing">
     <remoteStyle featureTypeName="hy-p_4.0:Crossing" url="feature-styles/HY_P_Crossing.se"/>
+  </styleConfig>
+  <styleConfig name="HY_P_Crossing_v5">
+    <remoteStyle featureTypeName="hy-p_5.0:Crossing" url="feature-styles/HY_P_Crossing_v5_0.se"/>
   </styleConfig>
   <styleConfig name="HY_P_DamOrWeir">
     <remoteStyle featureTypeName="hy-p_4.0:DamOrWeir" url="feature-styles/HY_P_DamOrWeir.se"/>
   </styleConfig>
+  <styleConfig name="HY_P_DamOrWeir_v5">
+    <remoteStyle featureTypeName="hy-p_5.0:DamOrWeir" url="feature-styles/HY_P_DamOrWeir_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="HY_P_ShoreLineConstruction">
     <remoteStyle featureTypeName="hy-p_4.0:ShorelineConstruction" url="feature-styles/HY_P_ShoreLineConstruction.se"/>
+  </styleConfig>
+  <styleConfig name="HY_P_ShoreLineConstruction_v5">
+    <remoteStyle featureTypeName="hy-p_5.0:ShorelineConstruction" url="feature-styles/HY_P_ShoreLineConstruction_v5_0.se"/>
   </styleConfig>
   <styleConfig name="HY_P_Ford">
     <remoteStyle featureTypeName="hy-p_4.0:Ford" url="feature-styles/HY_P_Ford.se"/>
   </styleConfig>
+  <styleConfig name="HY_P_Ford_v5">
+    <remoteStyle featureTypeName="hy-p_5.0:Ford" url="feature-styles/HY_P_Ford_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="HY_P_Lock">
     <remoteStyle featureTypeName="hy-p_4.0:Lock" url="feature-styles/HY_P_Lock.se"/>
+  </styleConfig>
+  <styleConfig name="HY_P_Lock_v5">
+    <remoteStyle featureTypeName="hy-p_5.0:Lock" url="feature-styles/HY_P_Lock_v5_0.se"/>
   </styleConfig>
   <styleConfig name="HY_P_Shore">
     <remoteStyle featureTypeName="hy-p_4.0:Shore" url="feature-styles/HY_P_Shore.se"/>
   </styleConfig>
+  <styleConfig name="HY_P_Shore_v5">
+    <remoteStyle featureTypeName="hy-p_5.0:Shore" url="feature-styles/HY_P_Shore_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="HY_P_Watercourse">
     <remoteStyle featureTypeName="hy-p_4.0:Watercourse" url="feature-styles/HY_P_Watercourse.se"/>
+  </styleConfig>
+  <styleConfig name="HY_P_Watercourse_v5">
+    <remoteStyle featureTypeName="hy-p_5.0:Watercourse" url="feature-styles/HY_P_Watercourse_v5_0.se"/>
   </styleConfig>
   <styleConfig name="HY_P_StandingWater">
     <remoteStyle featureTypeName="hy-p_4.0:StandingWater" url="feature-styles/HY_P_StandingWater.se"/>
   </styleConfig>
+  <styleConfig name="HY_P_StandingWater_v5">
+    <remoteStyle featureTypeName="hy-p_5.0:StandingWater" url="feature-styles/HY_P_StandingWater_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="HY_P_Watercourse_ManMade">
     <remoteStyle featureTypeName="hy-p_4.0:Watercourse" url="feature-styles/HY_P_Watercourse_ManMade.se"/>
+  </styleConfig>
+  <styleConfig name="HY_P_Watercourse_ManMade_v5">
+    <remoteStyle featureTypeName="hy-p_5.0:Watercourse" url="feature-styles/HY_P_Watercourse_ManMade_v5_0.se"/>
   </styleConfig>
   <styleConfig name="HY_P_StandingWater_ManMade">
     <remoteStyle featureTypeName="hy-p_4.0:StandingWater" url="feature-styles/HY_P_StandingWater_ManMade.se"/>
   </styleConfig>
+  <styleConfig name="HY_P_StandingWater_ManMade_v5">
+    <remoteStyle featureTypeName="hy-p_5.0:StandingWater" url="feature-styles/HY_P_StandingWater_ManMade_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="HY_P_WatercoursePersistence">
     <remoteStyle featureTypeName="hy-p_4.0:Watercourse" url="feature-styles/HY_P_WatercoursePersistence.se"/>
+  </styleConfig>
+  <styleConfig name="HY_P_WatercoursePersistence_v5">
+    <remoteStyle featureTypeName="hy-p_5.0:Watercourse" url="feature-styles/HY_P_WatercoursePersistence_v5_0.se"/>
   </styleConfig>
   <styleConfig name="HY_P_WaterbodiesPersistence">
     <remoteStyle featureTypeName="hy-p_4.0:StandingWater" url="feature-styles/HY_P_WaterbodiesPersistence.se"/>
   </styleConfig>
+  <styleConfig name="HY_P_WaterbodiesPersistence_v5">
+    <remoteStyle featureTypeName="hy-p_5.0:StandingWater" url="feature-styles/HY_P_WaterbodiesPersistence_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="HY_P_Wetland">
     <remoteStyle featureTypeName="hy-p_4.0:Wetland" url="feature-styles/HY_P_Wetland.se"/>
   </styleConfig>
+  <styleConfig name="HY_P_Wetland_v5">
+    <remoteStyle featureTypeName="hy-p_5.0:Wetland" url="feature-styles/HY_P_Wetland_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="PS_ProtectedSite">
     <remoteStyle featureTypeName="ps_4.0:ProtectedSite" url="feature-styles/PS_ProtectedSites.se"/>
+  </styleConfig>
+  <styleConfig name="PS_ProtectedSite_v5">
+    <remoteStyle featureTypeName="ps_5.0:ProtectedSite" url="feature-styles/PS_ProtectedSites_v5_0.se"/>
   </styleConfig>
   <styleConfig name="PS_ProtectedSite_v5">
     <remoteStyle featureTypeName="ps_5.0:ProtectedSite" url="feature-styles/PS_ProtectedSites_v5.se"/>
@@ -952,74 +1326,146 @@
   <styleConfig name="TN_A_AerodromeArea">
     <remoteStyle featureTypeName="tn-a_4.0:AerodromeArea" url="feature-styles/TN_A_AerodromeArea.se"/>
   </styleConfig>
+  <styleConfig name="TN_A_AerodromeArea_v5">
+    <remoteStyle featureTypeName="tn-a_5.0:AerodromeArea" url="feature-styles/TN_A_AerodromeArea_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="TN_A_ProcedureLink">
     <remoteStyle featureTypeName="tn-a_4.0:ProcedureLink" url="feature-styles/TN_A_ProcedureLink.se"/>
+  </styleConfig>
+  <styleConfig name="TN_A_ProcedureLink_v5">
+    <remoteStyle featureTypeName="tn-a_5.0:ProcedureLink" url="feature-styles/TN_A_ProcedureLink_v5_0.se"/>
   </styleConfig>
   <styleConfig name="TN_A_AirRouteLink">
     <remoteStyle featureTypeName="tn-a_4.0:AirRouteLink" url="feature-styles/TN_A_AirRouteLink.se"/>
   </styleConfig>
+  <styleConfig name="TN_A_AirRouteLink_v5">
+    <remoteStyle featureTypeName="tn-a_5.0:AirRouteLink" url="feature-styles/TN_A_AirRouteLink_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="TN_A_AirspaceArea">
     <remoteStyle featureTypeName="tn-a_4.0:AirspaceArea" url="feature-styles/TN_A_AirspaceArea.se"/>
+  </styleConfig>
+  <styleConfig name="TN_A_AirspaceArea_v5">
+    <remoteStyle featureTypeName="tn-a_5.0:AirspaceArea" url="feature-styles/TN_A_AirspaceArea_v5_0.se"/>
   </styleConfig>
   <styleConfig name="TN_A_ApronArea">
     <remoteStyle featureTypeName="tn-a_4.0:ApronArea" url="feature-styles/TN_A_ApronArea.se"/>
   </styleConfig>
+  <styleConfig name="TN_A_ApronArea_v5">
+    <remoteStyle featureTypeName="tn-a_5.0:ApronArea" url="feature-styles/TN_A_ApronArea_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="TN_A_RunwayArea">
     <remoteStyle featureTypeName="tn-a_4.0:RunwayArea" url="feature-styles/TN_A_RunwayArea.se"/>
+  </styleConfig>
+  <styleConfig name="TN_A_RunwayArea_v5">
+    <remoteStyle featureTypeName="tn-a_5.0:RunwayArea" url="feature-styles/TN_A_RunwayArea_v5_0.se"/>
   </styleConfig>
   <styleConfig name="TN_A_TaxiwayArea">
     <remoteStyle featureTypeName="tn-a_4.0:TaxiwayArea" url="feature-styles/TN_A_TaxiwayArea.se"/>
   </styleConfig>
+  <styleConfig name="TN_A_TaxiwayArea_v5">
+    <remoteStyle featureTypeName="tn-a_5.0:TaxiwayArea" url="feature-styles/TN_A_TaxiwayArea_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="TN_C_CablewayLink">
     <remoteStyle featureTypeName="tn-c_4.0:CablewayLink" url="feature-styles/TN_C_CablewayLink.se"/>
+  </styleConfig>
+  <styleConfig name="TN_C_CablewayLink_v5">
+    <remoteStyle featureTypeName="tn-c_5.0:CablewayLink" url="feature-styles/TN_C_CablewayLink_v5_0.se"/>
   </styleConfig>
   <styleConfig name="TN_TransportArea">
     <remoteStyle featureTypeName="tn_4.0:TransportArea" url="feature-styles/TN_TransportArea.se"/>
   </styleConfig>
+  <styleConfig name="TN_TransportArea_v5">
+    <remoteStyle featureTypeName="tn_5.0:TransportArea" url="feature-styles/TN_TransportArea_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="TN_TransportLink">
     <remoteStyle featureTypeName="tn_4.0:TransportLink" url="feature-styles/TN_TransportLink.se"/>
+  </styleConfig>
+  <styleConfig name="TN_TransportLink_v5">
+    <remoteStyle featureTypeName="tn_5.0:TransportLink" url="feature-styles/TN_TransportLink_v5_0.se"/>
   </styleConfig>
   <styleConfig name="TN_TransportNode">
     <remoteStyle featureTypeName="tn_4.0:TransportNode" url="feature-styles/TN_TransportNode.se"/>
   </styleConfig>
+  <styleConfig name="TN_TransportNode_v5">
+    <remoteStyle featureTypeName="tn_5.0:TransportNode" url="feature-styles/TN_TransportNode_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="TN_RA_RailwayArea">
     <remoteStyle featureTypeName="tn-ra_4.0:RailwayArea" url="feature-styles/TN_RA_RailwayArea.se"/>
+  </styleConfig>
+  <styleConfig name="TN_RA_RailwayArea_v5">
+    <remoteStyle featureTypeName="tn-ra_5.0:RailwayArea" url="feature-styles/TN_RA_RailwayArea_v5_0.se"/>
   </styleConfig>
   <styleConfig name="TN_RA_RailwayLink">
     <remoteStyle featureTypeName="tn-ra_4.0:RailwayLink" url="feature-styles/TN_RA_RailwayLink.se"/>
   </styleConfig>
+  <styleConfig name="TN_RA_RailwayLink_v5">
+    <remoteStyle featureTypeName="tn-ra_5.0:RailwayLink" url="feature-styles/TN_RA_RailwayLink_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="TN_RA_RailwayStationArea">
     <remoteStyle featureTypeName="tn-ra_4.0:RailwayStationArea" url="feature-styles/TN_RA_RailwayStationArea.se"/>
+  </styleConfig>
+  <styleConfig name="TN_RA_RailwayStationArea_v5">
+    <remoteStyle featureTypeName="tn-ra_5.0:RailwayStationArea" url="feature-styles/TN_RA_RailwayStationArea_v5_0.se"/>
   </styleConfig>
   <styleConfig name="TN_RA_RailwayYardArea">
     <remoteStyle featureTypeName="tn-ra_4.0:RailwayYardArea" url="feature-styles/TN_RA_RailwayYardArea.se"/>
   </styleConfig>
+  <styleConfig name="TN_RA_RailwayYardArea_v5">
+    <remoteStyle featureTypeName="tn-ra_5.0:RailwayYardArea" url="feature-styles/TN_RA_RailwayYardArea_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="TN_RO_RoadArea">
     <remoteStyle featureTypeName="tn-ro_4.0:RoadArea" url="feature-styles/TN_RO_RoadArea.se"/>
+  </styleConfig>
+  <styleConfig name="TN_RO_RoadArea_v5">
+    <remoteStyle featureTypeName="tn-ro_5.0:RoadArea" url="feature-styles/TN_RO_RoadArea_v5_0.se"/>
   </styleConfig>
   <styleConfig name="TN_RO_RoadLink">
     <remoteStyle featureTypeName="tn-ro_4.0:RoadLink" url="feature-styles/TN_RO_RoadLink.se"/>
   </styleConfig>
+  <styleConfig name="TN_RO_RoadLink_v5">
+    <remoteStyle featureTypeName="tn-ro_5.0:RoadLink" url="feature-styles/TN_RO_RoadLink_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="TN_RO_RoadServiceArea">
     <remoteStyle featureTypeName="tn-ro_4.0:RoadServiceArea" url="feature-styles/TN_RO_RoadServiceArea.se"/>
+  </styleConfig>
+  <styleConfig name="TN_RO_RoadServiceArea_v5">
+    <remoteStyle featureTypeName="tn-ro_5.0:RoadServiceArea" url="feature-styles/TN_RO_RoadServiceArea_v5_0.se"/>
   </styleConfig>
   <styleConfig name="TN_RO_VehicleTrafficArea">
     <remoteStyle featureTypeName="tn-ro_4.0:VehicleTrafficArea" url="feature-styles/TN_RO_VehicleTrafficArea.se"/>
   </styleConfig>
+  <styleConfig name="TN_RO_VehicleTrafficArea_v5">
+    <remoteStyle featureTypeName="tn-ro_5.0:VehicleTrafficArea" url="feature-styles/TN_RO_VehicleTrafficArea_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="TN_W_FairwayArea">
     <remoteStyle featureTypeName="tn-w_4.0:FairwayArea" url="feature-styles/TN_W_FairwayArea.se"/>
+  </styleConfig>
+  <styleConfig name="TN_W_FairwayArea_v5">
+    <remoteStyle featureTypeName="tn-w_5.0:FairwayArea" url="feature-styles/TN_W_FairwayArea_v5_0.se"/>
   </styleConfig>
   <styleConfig name="TN_W_PortArea">
     <remoteStyle featureTypeName="tn-w_4.0:PortArea" url="feature-styles/TN_W_PortArea.se"/>
   </styleConfig>
+  <styleConfig name="TN_W_PortArea_v5">
+    <remoteStyle featureTypeName="tn-w_5.0:PortArea" url="feature-styles/TN_W_PortArea_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="TN_W_WaterwayLink">
     <remoteStyle featureTypeName="tn-w_4.0:WaterwayLink" url="feature-styles/TN_W_WaterwayLink.se"/>
+  </styleConfig>
+  <styleConfig name="TN_W_WaterwayLink_v5">
+    <remoteStyle featureTypeName="tn-w_5.0:WaterwayLink" url="feature-styles/TN_W_WaterwayLink_v5_0.se"/>
   </styleConfig>
   <styleConfig name="LC_LandCoverSurfaces">
     <remoteStyle featureTypeName="lcv_4.0:LandCoverUnit" url="feature-styles/LC_LandCoverSurfaces.se"/>
   </styleConfig>
+  <styleConfig name="LC_LandCoverSurfaces_v5">
+    <remoteStyle featureTypeName="lcv_5.0:LandCoverUnit" url="feature-styles/LC_LandCoverSurfaces_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="LC_LandCoverPoints">
     <remoteStyle featureTypeName="lcv_4.0:LandCoverUnit" url="feature-styles/LC_LandCoverPoints.se"/>
+  </styleConfig>
+  <styleConfig name="LC_LandCoverPoints_v5">
+    <remoteStyle featureTypeName="lcv_5.0:LandCoverUnit" url="feature-styles/LC_LandCoverPoints_v5_0.se"/>
   </styleConfig>
   <styleConfig name="BU_Building">
     <remoteStyle featureTypeName="bu-core2d_4.0:Building" url="feature-styles/BU_Building.se"/>

--- a/config.xml
+++ b/config.xml
@@ -1,123 +1,150 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<styleconfig:StyleModel xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:ad_4.0="http://inspire.ec.europa.eu/schemas/ad/4.0" xmlns:am_4.0="http://inspire.ec.europa.eu/schemas/am/4.0" xmlns:au_4.0="http://inspire.ec.europa.eu/schemas/au/4.0" xmlns:br_4.0="http://inspire.ec.europa.eu/schemas/br/4.0" xmlns:bu-core2d_4.0="http://inspire.ec.europa.eu/schemas/bu-core2d/4.0" xmlns:cp_4.0="http://inspire.ec.europa.eu/schemas/cp/4.0" xmlns:ef_4.0="http://inspire.ec.europa.eu/schemas/ef/4.0" xmlns:el-tin_4.0="http://inspire.ec.europa.eu/schemas/el-tin/4.0" xmlns:el-vec_4.0="http://inspire.ec.europa.eu/schemas/el-vec/4.0" xmlns:elu_4.0="http://inspire.ec.europa.eu/schemas/elu/4.0" xmlns:er-v_4.0="http://inspire.ec.europa.eu/schemas/er-v/4.0" xmlns:ge-core_4.0="http://inspire.ec.europa.eu/schemas/ge-core/4.0" xmlns:gn_4.0="http://inspire.ec.europa.eu/schemas/gn/4.0" xmlns:hh_4.0="http://inspire.ec.europa.eu/schemas/hh/4.0" xmlns:hy-n_4.0="http://inspire.ec.europa.eu/schemas/hy-n/4.0" xmlns:hy-p_4.0="http://inspire.ec.europa.eu/schemas/hy-p/4.0" xmlns:lcv_4.0="http://inspire.ec.europa.eu/schemas/lcv/4.0" xmlns:mu_3.0="http://inspire.ec.europa.eu/schemas/mu/3.0" xmlns:nz-core_4.0="http://inspire.ec.europa.eu/schemas/nz-core/4.0" xmlns:pf_4.0="http://inspire.ec.europa.eu/schemas/pf/4.0" xmlns:plu_4.0="http://inspire.ec.europa.eu/schemas/plu/4.0" xmlns:ps_4.0="http://inspire.ec.europa.eu/schemas/ps/4.0" xmlns:ps_5.0="http://inspire.ec.europa.eu/schemas/ps/5.0" xmlns:samplingSpatial_2.0="http://www.opengis.net/samplingSpatial/2.0" xmlns:sd_4.0="http://inspire.ec.europa.eu/schemas/sd/4.0" xmlns:styleconfig="http://to.wetf.styling.models/model/styles" xmlns:su-grid_4.0="https://inspire.ec.europa.eu/schemas/su-grid/4.0" xmlns:su-vector_4.0="http://inspire.ec.europa.eu/schemas/su-vector/4.0" xmlns:tn-a_4.0="http://inspire.ec.europa.eu/schemas/tn-a/4.0" xmlns:tn-c_4.0="http://inspire.ec.europa.eu/schemas/tn-c/4.0" xmlns:tn-ra_4.0="http://inspire.ec.europa.eu/schemas/tn-ra/4.0" xmlns:tn-ro_4.0="http://inspire.ec.europa.eu/schemas/tn-ro/4.0" xmlns:tn-w_4.0="http://inspire.ec.europa.eu/schemas/tn-w/4.0" xmlns:tn_4.0="http://inspire.ec.europa.eu/schemas/tn/4.0" xmlns:us-emf_4.0="http://inspire.ec.europa.eu/schemas/us-emf/4.0" xmlns:us-govserv_4.0="http://inspire.ec.europa.eu/schemas/us-govserv/4.0" xmlns:us-net-common_4.0="http://inspire.ec.europa.eu/schemas/us-net-common/4.0">
+<styleconfig:StyleModel xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:ad_4.0="http://inspire.ec.europa.eu/schemas/ad/4.0" xmlns:am_4.0="http://inspire.ec.europa.eu/schemas/am/4.0" xmlns:au_4.0="http://inspire.ec.europa.eu/schemas/au/4.0" xmlns:br_4.0="http://inspire.ec.europa.eu/schemas/br/4.0" xmlns:bu-core2d_4.0="http://inspire.ec.europa.eu/schemas/bu-core2d/4.0" xmlns:cp_4.0="http://inspire.ec.europa.eu/schemas/cp/4.0" xmlns:ef_4.0="http://inspire.ec.europa.eu/schemas/ef/4.0" xmlns:el-tin_4.0="http://inspire.ec.europa.eu/schemas/el-tin/4.0" xmlns:el-vec_4.0="http://inspire.ec.europa.eu/schemas/el-vec/4.0" xmlns:elu_4.0="http://inspire.ec.europa.eu/schemas/elu/4.0" xmlns:er-v_4.0="http://inspire.ec.europa.eu/schemas/er-v/4.0" xmlns:ge-core_4.0="http://inspire.ec.europa.eu/schemas/ge-core/4.0" xmlns:gn_4.0="http://inspire.ec.europa.eu/schemas/gn/4.0" xmlns:hh_4.0="http://inspire.ec.europa.eu/schemas/hh/4.0" xmlns:hh_5.0="http://inspire.ec.europa.eu/schemas/hh/5.0" xmlns:hy-n_4.0="http://inspire.ec.europa.eu/schemas/hy-n/4.0" xmlns:hy-n_5.0="http://inspire.ec.europa.eu/schemas/hy-n/5.0" xmlns:hy-p_4.0="http://inspire.ec.europa.eu/schemas/hy-p/4.0" xmlns:hy-p_5.0="http://inspire.ec.europa.eu/schemas/hy-p/5.0" xmlns:lcv_4.0="http://inspire.ec.europa.eu/schemas/lcv/4.0" xmlns:lcv_5.0="http://inspire.ec.europa.eu/schemas/lcv/5.0" xmlns:mu_3.0="http://inspire.ec.europa.eu/schemas/mu/3.0" xmlns:nz-core_4.0="http://inspire.ec.europa.eu/schemas/nz-core/4.0" xmlns:pf_4.0="http://inspire.ec.europa.eu/schemas/pf/4.0" xmlns:plu_4.0="http://inspire.ec.europa.eu/schemas/plu/4.0" xmlns:ps_4.0="http://inspire.ec.europa.eu/schemas/ps/4.0" xmlns:ps_5.0="http://inspire.ec.europa.eu/schemas/ps/5.0" xmlns:samplingSpatial_2.0="http://www.opengis.net/samplingSpatial/2.0" xmlns:sd_4.0="http://inspire.ec.europa.eu/schemas/sd/4.0" xmlns:styleconfig="http://to.wetf.styling.models/model/styles" xmlns:su-grid_4.0="https://inspire.ec.europa.eu/schemas/su-grid/4.0" xmlns:su-vector_4.0="http://inspire.ec.europa.eu/schemas/su-vector/4.0" xmlns:tn-a_4.0="http://inspire.ec.europa.eu/schemas/tn-a/4.0" xmlns:tn-a_5.0="http://inspire.ec.europa.eu/schemas/tn-a/5.0" xmlns:tn-c_4.0="http://inspire.ec.europa.eu/schemas/tn-c/4.0" xmlns:tn-c_5.0="http://inspire.ec.europa.eu/schemas/tn-c/5.0" xmlns:tn-ra_4.0="http://inspire.ec.europa.eu/schemas/tn-ra/4.0" xmlns:tn-ra_5.0="http://inspire.ec.europa.eu/schemas/tn-ra/5.0" xmlns:tn-ro_4.0="http://inspire.ec.europa.eu/schemas/tn-ro/4.0" xmlns:tn-ro_5.0="http://inspire.ec.europa.eu/schemas/tn-ro/5.0" xmlns:tn-w_4.0="http://inspire.ec.europa.eu/schemas/tn-w/4.0" xmlns:tn-w_5.0="http://inspire.ec.europa.eu/schemas/tn-w/5.0" xmlns:tn_4.0="http://inspire.ec.europa.eu/schemas/tn/4.0" xmlns:tn_5.0="http://inspire.ec.europa.eu/schemas/tn/5.0" xmlns:us-emf_4.0="http://inspire.ec.europa.eu/schemas/us-emf/4.0" xmlns:us-emf_5.0="http://inspire.ec.europa.eu/schemas/us-emf/5.0" xmlns:us-govserv_4.0="http://inspire.ec.europa.eu/schemas/us-govserv/4.0" xmlns:us-govserv_5.0="http://inspire.ec.europa.eu/schemas/us-govserv/5.0" xmlns:us-net-common_4.0="http://inspire.ec.europa.eu/schemas/us-net-common/4.0" xmlns:us-net-common_5.0="http://inspire.ec.europa.eu/schemas/us-net-common/5.0">
   <tags name="inspire"/>
   <tags name="inspire_wetransform"/>
   <tags name="production"/>
-  <layerConfig name="AD_Address" registryId="http://inspire.ec.europa.eu/layer/AD.Address" tags="//@tags.0 //@tags.2" layerName="AD.Address" styleConfig="//@styleConfig.67">
+  <layerConfig name="AD_Address" registryId="http://inspire.ec.europa.eu/layer/AD.Address" tags="//@tags.0 //@tags.2" layerName="AD.Address" styleConfig="//@styleConfig.83">
     <title lang="en" text="Addresses"/>
     <title text="Addressen"/>
     <objectType>ad_4.0:Address</objectType>
   </layerConfig>
-  <layerConfig name="AU_AdministrativeBoundary" registryId="http://inspire.ec.europa.eu/layer/AU.AdministrativeBoundary" tags="//@tags.2 //@tags.0" layerName="AU.AdministrativeBoundary" styleConfig="//@styleConfig.68">
+  <layerConfig name="AU_AdministrativeBoundary" registryId="http://inspire.ec.europa.eu/layer/AU.AdministrativeBoundary" tags="//@tags.2 //@tags.0" layerName="AU.AdministrativeBoundary" styleConfig="//@styleConfig.84">
     <title lang="en" text="Administrative boundary"/>
     <title text="Verwaltungsgrenze"/>
     <objectType>au_4.0:AdministrativeBoundary</objectType>
   </layerConfig>
-  <layerConfig name="AU_AdministrativeUnit" registryId="http://inspire.ec.europa.eu/layer/AU.AdministrativeUnit" tags="//@tags.2 //@tags.0" layerName="AU.AdministrativeUnit" styleConfig="//@styleConfig.69">
+  <layerConfig name="AU_AdministrativeUnit" registryId="http://inspire.ec.europa.eu/layer/AU.AdministrativeUnit" tags="//@tags.2 //@tags.0" layerName="AU.AdministrativeUnit" styleConfig="//@styleConfig.85">
     <title lang="en" text="Administrative unit"/>
     <title text="Verwaltungseinheit"/>
     <objectType>au_4.0:AdministrativeUnit</objectType>
   </layerConfig>
-  <layerConfig name="AU_Baseline" registryId="http://inspire.ec.europa.eu/layer/AU.Baseline" layerName="AU.Baseline" styleConfig="//@styleConfig.70">
+  <layerConfig name="AU_Baseline" registryId="http://inspire.ec.europa.eu/layer/AU.Baseline" layerName="AU.Baseline" styleConfig="//@styleConfig.86">
     <title lang="en" text="Baseline"/>
     <title text="Basislinie"/>
     <objectType>mu_3.0:Baseline</objectType>
   </layerConfig>
-  <layerConfig name="AU_Condominium" registryId="http://inspire.ec.europa.eu/layer/AU.Condominium" layerName="AU.Condominium" styleConfig="//@styleConfig.71">
+  <layerConfig name="AU_Condominium" registryId="http://inspire.ec.europa.eu/layer/AU.Condominium" layerName="AU.Condominium" styleConfig="//@styleConfig.87">
     <title lang="en" text="Condominium"/>
     <title text="Kondominium"/>
     <objectType>au_4.0:Condominium</objectType>
   </layerConfig>
-  <layerConfig name="AU_ContiguousZone" registryId="http://inspire.ec.europa.eu/layer/AU.ContiguousZone" layerName="AU.ContiguousZone" styleConfig="//@styleConfig.72">
+  <layerConfig name="AU_ContiguousZone" registryId="http://inspire.ec.europa.eu/layer/AU.ContiguousZone" layerName="AU.ContiguousZone" styleConfig="//@styleConfig.88">
     <title lang="en" text="Contiguous zone"/>
     <title text="Anschlusszone"/>
     <objectType>mu_3.0:ContiguousZone</objectType>
   </layerConfig>
-  <layerConfig name="AU_ContinentalShelf" registryId="http://inspire.ec.europa.eu/layer/AU.ContinentalShelf" layerName="AU.ContinentalShelf" styleConfig="//@styleConfig.73">
+  <layerConfig name="AU_ContinentalShelf" registryId="http://inspire.ec.europa.eu/layer/AU.ContinentalShelf" layerName="AU.ContinentalShelf" styleConfig="//@styleConfig.89">
     <title lang="en" text="Continental shelf"/>
     <title text="Festlandsockel"/>
     <objectType>mu_3.0:ContinentalShelf</objectType>
   </layerConfig>
-  <layerConfig name="AU_ExclusiveEconomicZone" registryId="http://inspire.ec.europa.eu/layer/AU.ExclusiveEconomicZone" layerName="AU.ExclusiveEconomicZone" styleConfig="//@styleConfig.74">
+  <layerConfig name="AU_ExclusiveEconomicZone" registryId="http://inspire.ec.europa.eu/layer/AU.ExclusiveEconomicZone" layerName="AU.ExclusiveEconomicZone" styleConfig="//@styleConfig.90">
     <title lang="en" text="Exclusive economic zone"/>
     <title text="Ausschließliche Wirtschaftszone"/>
     <objectType>mu_3.0:ExclusiveEconomicZone</objectType>
   </layerConfig>
-  <layerConfig name="AU_InternalWaters" registryId="http://inspire.ec.europa.eu/layer/AU.InternalWaters" layerName="AU.InternalWaters" styleConfig="//@styleConfig.75">
+  <layerConfig name="AU_InternalWaters" registryId="http://inspire.ec.europa.eu/layer/AU.InternalWaters" layerName="AU.InternalWaters" styleConfig="//@styleConfig.91">
     <title lang="en" text="Internal waters"/>
     <title text="Innere Gewässer"/>
     <objectType>mu_3.0:InternalWaters</objectType>
   </layerConfig>
-  <layerConfig name="AU_MaritimeBoundary" registryId="http://inspire.ec.europa.eu/layer/AU.MaritimeBoundary" layerName="AU.MaritimeBoundary" styleConfig="//@styleConfig.76">
+  <layerConfig name="AU_MaritimeBoundary" registryId="http://inspire.ec.europa.eu/layer/AU.MaritimeBoundary" layerName="AU.MaritimeBoundary" styleConfig="//@styleConfig.92">
     <title lang="en" text="Maritime boundary"/>
     <title text="Seegrenze"/>
     <objectType>mu_3.0:MaritimeBoundary</objectType>
   </layerConfig>
-  <layerConfig name="AU_TerritorialSea" registryId="http://inspire.ec.europa.eu/layer/AU.TerritorialSea" layerName="AU.TerritorialSea" styleConfig="//@styleConfig.77">
+  <layerConfig name="AU_TerritorialSea" registryId="http://inspire.ec.europa.eu/layer/AU.TerritorialSea" layerName="AU.TerritorialSea" styleConfig="//@styleConfig.93">
     <title lang="en" text="Territorial sea"/>
     <title text="Küstenmeer"/>
     <objectType>mu_3.0:TerritorialSea</objectType>
   </layerConfig>
-  <layerConfig name="CP_CadastralBoundary" registryId="http://inspire.ec.europa.eu/layer/CP.CadastralBoundary" tags="//@tags.2 //@tags.0" layerName="CP.CadastralBoundary" styleConfig="//@styleConfig.78">
+  <layerConfig name="CP_CadastralBoundary" registryId="http://inspire.ec.europa.eu/layer/CP.CadastralBoundary" tags="//@tags.2 //@tags.0" layerName="CP.CadastralBoundary" styleConfig="//@styleConfig.94">
     <title lang="en" text="Cadastral Boundary"/>
     <title text="Flurstücksgrenze"/>
     <objectType>cp_4.0:CadastralBoundary</objectType>
   </layerConfig>
-  <layerConfig name="CP_Cadastr" registryId="http://inspire.ec.europa.eu/layer/CP.CadastralParcel" tags="//@tags.2 //@tags.0" layerName="CP.CadastralParcel.BoundariesOnly" styleConfig="//@styleConfig.79">
+  <layerConfig name="CP_Cadastr" registryId="http://inspire.ec.europa.eu/layer/CP.CadastralParcel" tags="//@tags.2 //@tags.0" layerName="CP.CadastralParcel.BoundariesOnly" styleConfig="//@styleConfig.95">
     <title lang="en" text="Cadastral Parcel (Boundary only)"/>
     <objectType>cp_4.0:CadastralParcel</objectType>
   </layerConfig>
-  <layerConfig name="CP_CadastralParcel" registryId="http://inspire.ec.europa.eu/layer/CP.CadastralParcel" tags="//@tags.2 //@tags.0" layerName="CP.CadastralParcel" styleConfig="//@styleConfig.80">
+  <layerConfig name="CP_CadastralParcel" registryId="http://inspire.ec.europa.eu/layer/CP.CadastralParcel" tags="//@tags.2 //@tags.0" layerName="CP.CadastralParcel" styleConfig="//@styleConfig.96">
     <title lang="en" text="Cadastral Parcel"/>
     <title text="Flurstück"/>
     <objectType>cp_4.0:CadastralParcel</objectType>
   </layerConfig>
-  <layerConfig name="CP_Cadastr_1" registryId="http://inspire.ec.europa.eu/layer/CP.CadastralParcel" tags="//@tags.2 //@tags.0" layerName="CP.CadastralParcel.LabelOnReferencePoint" styleConfig="//@styleConfig.81">
+  <layerConfig name="CP_Cadastr_1" registryId="http://inspire.ec.europa.eu/layer/CP.CadastralParcel" tags="//@tags.2 //@tags.0" layerName="CP.CadastralParcel.LabelOnReferencePoint" styleConfig="//@styleConfig.97">
     <title lang="en" text="Cadastral Parcel (LabelOnReferencePoint)"/>
     <objectType>cp_4.0:CadastralParcel</objectType>
   </layerConfig>
-  <layerConfig name="CP_Cadastr_2" registryId="http://inspire.ec.europa.eu/layer/CP.CadastralParcel" tags="//@tags.2 //@tags.0" layerName="CP.CadastralParcel.ReferencePointOnly" styleConfig="//@styleConfig.82">
+  <layerConfig name="CP_Cadastr_2" registryId="http://inspire.ec.europa.eu/layer/CP.CadastralParcel" tags="//@tags.2 //@tags.0" layerName="CP.CadastralParcel.ReferencePointOnly" styleConfig="//@styleConfig.98">
     <title lang="en" text="Cadastral Parcel (ReferencePointOnly)"/>
     <objectType>cp_4.0:CadastralParcel</objectType>
   </layerConfig>
-  <layerConfig name="CP_CadastralZoning" registryId="http://inspire.ec.europa.eu/layer/CP.CadastralZoning" tags="//@tags.2 //@tags.0" layerName="CP.CadastralZoning" styleConfig="//@styleConfig.83">
+  <layerConfig name="CP_CadastralZoning" registryId="http://inspire.ec.europa.eu/layer/CP.CadastralZoning" tags="//@tags.2 //@tags.0" layerName="CP.CadastralZoning" styleConfig="//@styleConfig.99">
     <title lang="en" text="Cadastral Zoning"/>
     <title text="Katasterbezirk"/>
     <objectType>cp_4.0:CadastralZoning</objectType>
   </layerConfig>
-  <layerConfig name="GN_GeographicalNames" registryId="http://inspire.ec.europa.eu/layer/GN.GeographicalNames" tags="//@tags.0 //@tags.2" layerName="GN.GeographicalNames" styleConfig="//@styleConfig.84">
+  <layerConfig name="GN_GeographicalNames" registryId="http://inspire.ec.europa.eu/layer/GN.GeographicalNames" tags="//@tags.0 //@tags.2" layerName="GN.GeographicalNames" styleConfig="//@styleConfig.100">
     <title lang="en" text="Geographical Names"/>
     <title text="Geografische Bezeichnungen"/>
     <objectType>gn_4.0:NamedPlace</objectType>
   </layerConfig>
-  <layerConfig name="HY_Network_WatercourseLink" registryId="" tags="//@tags.0 //@tags.2" layerName="HY.Network.WatercourseLink" styleConfig="//@styleConfig.85">
+  <layerConfig name="HY_Network_WatercourseLink" registryId="" tags="//@tags.0 //@tags.2" layerName="HY.Network.WatercourseLink" styleConfig="//@styleConfig.101">
     <title lang="en" text="Hydrographic network - WatercourseLink"/>
     <title text="Hydrografisches Netzwerk- WatercourseLink"/>
     <objectType>hy-n_4.0:WatercourseLink</objectType>
   </layerConfig>
-  <layerConfig name="HY_Network_HydroNode" registryId="" tags="//@tags.0 //@tags.2" layerName="HY.Network.HydroNode" styleConfig="//@styleConfig.86">
+  <layerConfig name="HY_Network_WatercourseLink_v5" registryId="" tags="//@tags.0 //@tags.2" layerName="HY.Network.WatercourseLink" styleConfig="//@styleConfig.102">
+    <title lang="en" text="Hydrographic network - WatercourseLink"/>
+    <title text="Hydrografisches Netzwerk- WatercourseLink"/>
+    <objectType>hy-n_5.0:WatercourseLink</objectType>
+  </layerConfig>
+  <layerConfig name="HY_Network_HydroNode" registryId="" tags="//@tags.0 //@tags.2" layerName="HY.Network.HydroNode" styleConfig="//@styleConfig.103">
     <title lang="en" text="Hydrographic network - HydroNode"/>
     <title text="Hydrografisches Netzwerk- HydroNode"/>
     <objectType>hy-n_4.0:HydroNode</objectType>
   </layerConfig>
-  <layerConfig name="HY_Physica" registryId="http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.Catchments" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.Catchments" styleConfig="//@styleConfig.87 //@styleConfig.88">
+  <layerConfig name="HY_Network_HydroNode_v5" registryId="" tags="//@tags.0 //@tags.2" layerName="HY.Network.HydroNode" styleConfig="//@styleConfig.104">
+    <title lang="en" text="Hydrographic network - HydroNode"/>
+    <title text="Hydrografisches Netzwerk- HydroNode"/>
+    <objectType>hy-n_5.0:HydroNode</objectType>
+  </layerConfig>
+  <layerConfig name="HY_Physica" registryId="http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.Catchments" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.Catchments" styleConfig="//@styleConfig.105 //@styleConfig.107">
     <title lang="en" text="Catchment"/>
     <title text="Einzugsgebiete"/>
     <objectType>hy-p_4.0:DrainageBasin</objectType>
     <objectType>hy-p_4.0:RiverBasin</objectType>
   </layerConfig>
-  <layerConfig name="HY_Physica_1" registryId="http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.HydroPointOfInterest" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.HydroPointOfInterest" styleConfig="//@styleConfig.89 //@styleConfig.90">
+  <layerConfig name="HY_Physica_v5" registryId="http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.Catchments" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.Catchments" styleConfig="//@styleConfig.106 //@styleConfig.108">
+    <title lang="en" text="Catchment"/>
+    <title text="Einzugsgebiete"/>
+    <objectType>hy-p_5.0:DrainageBasin</objectType>
+    <objectType>hy-p_5.0:RiverBasin</objectType>
+  </layerConfig>
+  <layerConfig name="HY_Physica_1" registryId="http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.HydroPointOfInterest" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.HydroPointOfInterest" styleConfig="//@styleConfig.109 //@styleConfig.111">
     <title lang="en" text="Hydro Point of Interest"/>
     <title text="Interessante hydrologische Punkte"/>
     <objectType>hy-p_4.0:Rapids</objectType>
     <objectType>hy-p_4.0:Falls</objectType>
   </layerConfig>
-  <layerConfig name="HY_Physica_2" registryId="http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.LandWaterBoundary" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.LandWaterBoundary" styleConfig="//@styleConfig.91">
+  <layerConfig name="HY_Physica_1_v5" registryId="http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.HydroPointOfInterest" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.HydroPointOfInterest" styleConfig="//@styleConfig.110 //@styleConfig.112">
+    <title lang="en" text="Hydro Point of Interest"/>
+    <title text="Interessante hydrologische Punkte"/>
+    <objectType>hy-p_5.0:Rapids</objectType>
+    <objectType>hy-p_5.0:Falls</objectType>
+  </layerConfig>
+  <layerConfig name="HY_Physica_2" registryId="http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.LandWaterBoundary" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.LandWaterBoundary" styleConfig="//@styleConfig.113">
     <title lang="en" text="Land water boundary"/>
     <title text="Uferlinien"/>
     <objectType>hy-p_4.0:LandWaterBoundary</objectType>
   </layerConfig>
-  <layerConfig name="HY_Physica_4" registryId="http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.ManMadeObject" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.ManMadeObject" styleConfig="//@styleConfig.92 //@styleConfig.93 //@styleConfig.94 //@styleConfig.95 //@styleConfig.96">
+  <layerConfig name="HY_Physica_2_v5" registryId="http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.LandWaterBoundary" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.LandWaterBoundary" styleConfig="//@styleConfig.114">
+    <title lang="en" text="Land water boundary"/>
+    <title text="Uferlinien"/>
+    <objectType>hy-p_5.0:LandWaterBoundary</objectType>
+  </layerConfig>
+  <layerConfig name="HY_Physica_4" registryId="http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.ManMadeObject" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.ManMadeObject" styleConfig="//@styleConfig.115 //@styleConfig.117 //@styleConfig.119 //@styleConfig.121 //@styleConfig.123">
     <title lang="en" text="Man-made Object"/>
     <title text="Bauwerke an Gewässern"/>
     <objectType>hy-p_4.0:Crossing</objectType>
@@ -126,502 +153,738 @@
     <objectType>hy-p_4.0:Ford</objectType>
     <objectType>hy-p_4.0:Lock</objectType>
   </layerConfig>
-  <layerConfig name="HY_PhysicalWaters_Shore" registryId="http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.Shore" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.Shore" styleConfig="//@styleConfig.97">
+  <layerConfig name="HY_Physica_4_v5" registryId="http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.ManMadeObject" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.ManMadeObject" styleConfig="//@styleConfig.116 //@styleConfig.118 //@styleConfig.120 //@styleConfig.122 //@styleConfig.124">
+    <title lang="en" text="Man-made Object"/>
+    <title text="Bauwerke an Gewässern"/>
+    <objectType>hy-p_4.0:Crossing</objectType>
+    <objectType>hy-p_5.0:DamOrWeir</objectType>
+    <objectType>hy-p_5.0:ShorelineConstruction</objectType>
+    <objectType>hy-p_5.0:Ford</objectType>
+    <objectType>hy-p_5.0:Lock</objectType>
+  </layerConfig>
+  <layerConfig name="HY_PhysicalWaters_Shore" registryId="http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.Shore" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.Shore" styleConfig="//@styleConfig.125">
     <title lang="en" text="Shores"/>
     <title text="Küsten"/>
     <objectType>hy-p_4.0:Shore</objectType>
   </layerConfig>
-  <layerConfig name="HY_Physica_5" registryId="http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.Waterbodies" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.Waterbodies" styleConfig="//@styleConfig.98 //@styleConfig.99">
+  <layerConfig name="HY_PhysicalWaters_Shore_v5" registryId="http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.Shore" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.Shore" styleConfig="//@styleConfig.126">
+    <title lang="en" text="Shores"/>
+    <title text="Küsten"/>
+    <objectType>hy-p_5.0:Shore</objectType>
+  </layerConfig>
+  <layerConfig name="HY_Physica_5" registryId="http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.Waterbodies" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.Waterbodies" styleConfig="//@styleConfig.127 //@styleConfig.129">
     <title lang="en" text="Waterbody"/>
     <title text="Wasserkörper"/>
     <objectType>hy-p_4.0:Watercourse</objectType>
     <objectType>hy-p_4.0:StandingWater</objectType>
   </layerConfig>
-  <layerConfig name="HY_Physica_6" registryId="" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.Waterbodies.Man.Made" styleConfig="//@styleConfig.100 //@styleConfig.101">
+  <layerConfig name="HY_Physica_5_v5" registryId="http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.Waterbodies" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.Waterbodies" styleConfig="//@styleConfig.128 //@styleConfig.130">
+    <title lang="en" text="Waterbody"/>
+    <title text="Wasserkörper"/>
+    <objectType>hy-p_5.0:Watercourse</objectType>
+    <objectType>hy-p_5.0:StandingWater</objectType>
+  </layerConfig>
+  <layerConfig name="HY_Physica_6" registryId="" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.Waterbodies.Man.Made" styleConfig="//@styleConfig.131 //@styleConfig.133">
     <title lang="en" text="Man-made Object (Natural)"/>
     <objectType>hy-p_4.0:Watercourse</objectType>
     <objectType>hy-p_4.0:StandingWater</objectType>
   </layerConfig>
-  <layerConfig name="HY_Physica_7" registryId="" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.Waterbodies.Persistence" styleConfig="//@styleConfig.102 //@styleConfig.103">
+  <layerConfig name="HY_Physica_6_v5" registryId="" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.Waterbodies.Man.Made" styleConfig="//@styleConfig.132 //@styleConfig.134">
+    <title lang="en" text="Man-made Object (Natural)"/>
+    <objectType>hy-p_5.0:Watercourse</objectType>
+    <objectType>hy-p_5.0:StandingWater</objectType>
+  </layerConfig>
+  <layerConfig name="HY_Physica_7" registryId="" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.Waterbodies.Persistence" styleConfig="//@styleConfig.135 //@styleConfig.137">
     <title lang="en" text="Waterbody (Persistence)"/>
     <objectType>hy-p_4.0:Watercourse</objectType>
     <objectType>hy-p_4.0:StandingWater</objectType>
   </layerConfig>
-  <layerConfig name="HY_PhysicalWaters_Wetland" registryId="http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.Wetland" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.Wetland" styleConfig="//@styleConfig.104">
+  <layerConfig name="HY_Physica_7_v5" registryId="" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.Waterbodies.Persistence" styleConfig="//@styleConfig.136 //@styleConfig.138">
+    <title lang="en" text="Waterbody (Persistence)"/>
+    <objectType>hy-p_5.0:Watercourse</objectType>
+    <objectType>hy-p_5.0:StandingWater</objectType>
+  </layerConfig>
+  <layerConfig name="HY_PhysicalWaters_Wetland" registryId="http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.Wetland" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.Wetland" styleConfig="//@styleConfig.139">
     <title lang="en" text="Wetlands"/>
     <title text="Feuchtgebiete"/>
     <objectType>hy-p_4.0:Wetland</objectType>
   </layerConfig>
-  <layerConfig name="PS_ProtectedSite" registryId="http://inspire.ec.europa.eu/layer/PS.ProtectedSite" tags="//@tags.0 //@tags.2" layerName="PS.ProtectedSite" styleConfig="//@styleConfig.105">
+  <layerConfig name="HY_PhysicalWaters_Wetland_v5" registryId="http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.Wetland" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.Wetland" styleConfig="//@styleConfig.140">
+    <title lang="en" text="Wetlands"/>
+    <title text="Feuchtgebiete"/>
+    <objectType>hy-p_5.0:Wetland</objectType>
+  </layerConfig>
+  <layerConfig name="PS_ProtectedSite" registryId="http://inspire.ec.europa.eu/layer/PS.ProtectedSite" tags="//@tags.0 //@tags.2" layerName="PS.ProtectedSite" styleConfig="//@styleConfig.141">
     <title lang="en" text="Protected Sites"/>
     <title text="Schutzgebiete"/>
     <objectType>ps_4.0:ProtectedSite</objectType>
   </layerConfig>
-  <layerConfig name="PS_ProtectedSite_v5" registryId="http://inspire.ec.europa.eu/layer/PS.ProtectedSite" tags="//@tags.0 //@tags.2" layerName="PS.ProtectedSite_v5" styleConfig="//@styleConfig.106">
+  <layerConfig name="PS_ProtectedSite_v5" registryId="http://inspire.ec.europa.eu/layer/PS.ProtectedSite" tags="//@tags.0 //@tags.2" layerName="PS.ProtectedSite" styleConfig="//@styleConfig.142">
     <title lang="en" text="Protected Sites"/>
     <title text="Schutzgebiete"/>
     <objectType>ps_5.0:ProtectedSite</objectType>
   </layerConfig>
-  <layerConfig name="TN_AirTran" registryId="http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.AerodromeArea" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.AerodromeArea" styleConfig="//@styleConfig.107">
+  <layerConfig name="PS_ProtectedSite_v5" registryId="http://inspire.ec.europa.eu/layer/PS.ProtectedSite" tags="//@tags.0 //@tags.2" layerName="PS.ProtectedSite_v5" styleConfig="//@styleConfig.142">
+    <title lang="en" text="Protected Sites"/>
+    <title text="Schutzgebiete"/>
+    <objectType>ps_5.0:ProtectedSite</objectType>
+  </layerConfig>
+  <layerConfig name="TN_AirTran" registryId="http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.AerodromeArea" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.AerodromeArea" styleConfig="//@styleConfig.144">
     <title lang="en" text="Aerodrome Area Default Style"/>
     <title text="Flugplatzgelände"/>
     <objectType>tn-a_4.0:AerodromeArea</objectType>
   </layerConfig>
-  <layerConfig name="TN_AirTran_1" registryId="http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.AirLink" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.AirLink" styleConfig="//@styleConfig.108 //@styleConfig.109">
+  <layerConfig name="TN_AirTran_v5" registryId="http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.AerodromeArea" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.AerodromeArea" styleConfig="//@styleConfig.145">
+    <title lang="en" text="Aerodrome Area Default Style"/>
+    <title text="Flugplatzgelände"/>
+    <objectType>tn-a_5.0:AerodromeArea</objectType>
+  </layerConfig>
+  <layerConfig name="TN_AirTran_1" registryId="http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.AirLink" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.AirLink" styleConfig="//@styleConfig.146 //@styleConfig.148">
     <title lang="en" text="Air Link Default Style"/>
     <title text="Luftverbindung"/>
     <objectType>tn-a_4.0:ProcedureLink</objectType>
     <objectType>tn-a_4.0:AirRouteLink</objectType>
   </layerConfig>
-  <layerConfig name="TN_AirTran_2" registryId="http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.AirspaceArea" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.AirSpaceArea" styleConfig="//@styleConfig.110">
+  <layerConfig name="TN_AirTran_1_v5" registryId="http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.AirLink" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.AirLink" styleConfig="//@styleConfig.147 //@styleConfig.149">
+    <title lang="en" text="Air Link Default Style"/>
+    <title text="Luftverbindung"/>
+    <objectType>tn-a_5.0:ProcedureLink</objectType>
+    <objectType>tn-a_5.0:AirRouteLink</objectType>
+  </layerConfig>
+  <layerConfig name="TN_AirTran_2" registryId="http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.AirspaceArea" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.AirSpaceArea" styleConfig="//@styleConfig.150">
     <title lang="en" text="Air Space Area Default Style"/>
     <title text="Luftraumbereich"/>
     <objectType>tn-a_4.0:AirspaceArea</objectType>
   </layerConfig>
-  <layerConfig name="TN_AirTran_3" registryId="http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.ApronArea" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.ApronArea" styleConfig="//@styleConfig.111">
+  <layerConfig name="TN_AirTran_2_v5" registryId="http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.AirspaceArea" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.AirSpaceArea" styleConfig="//@styleConfig.151">
+    <title lang="en" text="Air Space Area Default Style"/>
+    <title text="Luftraumbereich"/>
+    <objectType>tn-a_5.0:AirspaceArea</objectType>
+  </layerConfig>
+  <layerConfig name="TN_AirTran_3" registryId="http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.ApronArea" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.ApronArea" styleConfig="//@styleConfig.152">
     <title lang="en" text="Apron Area Default Style"/>
     <title text="Vorfeldgelände"/>
     <objectType>tn-a_4.0:ApronArea</objectType>
   </layerConfig>
-  <layerConfig name="TN_AirTran_4" registryId="http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.RunwayArea" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.RunwayArea" styleConfig="//@styleConfig.112">
+  <layerConfig name="TN_AirTran_3_v5" registryId="http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.ApronArea" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.ApronArea" styleConfig="//@styleConfig.153">
+    <title lang="en" text="Apron Area Default Style"/>
+    <title text="Vorfeldgelände"/>
+    <objectType>tn-a_5.0:ApronArea</objectType>
+  </layerConfig>
+  <layerConfig name="TN_AirTran_4" registryId="http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.RunwayArea" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.RunwayArea" styleConfig="//@styleConfig.154">
     <title lang="en" text="Runway Area Default Style"/>
     <title text="Landebahngelände"/>
     <objectType>tn-a_4.0:RunwayArea</objectType>
   </layerConfig>
-  <layerConfig name="TN_AirTran_5" registryId="http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.TaxiwayArea" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.TaxiwayArea" styleConfig="//@styleConfig.113">
+  <layerConfig name="TN_AirTran_4_v5" registryId="http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.RunwayArea" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.RunwayArea" styleConfig="//@styleConfig.155">
+    <title lang="en" text="Runway Area Default Style"/>
+    <title text="Landebahngelände"/>
+    <objectType>tn-a_5.0:RunwayArea</objectType>
+  </layerConfig>
+  <layerConfig name="TN_AirTran_5" registryId="http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.TaxiwayArea" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.TaxiwayArea" styleConfig="//@styleConfig.156">
     <title lang="en" text="Taxiway Area Default Style"/>
     <title text="Rollfeld"/>
     <objectType>tn-a_4.0:TaxiwayArea</objectType>
   </layerConfig>
-  <layerConfig name="TN_AirTran_6" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.DesignatedPoint" styleConfig="//@styleConfig.4">
+  <layerConfig name="TN_AirTran_5_v5" registryId="http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.TaxiwayArea" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.TaxiwayArea" styleConfig="//@styleConfig.157">
+    <title lang="en" text="Taxiway Area Default Style"/>
+    <title text="Rollfeld"/>
+    <objectType>tn-a_5.0:TaxiwayArea</objectType>
+  </layerConfig>
+  <layerConfig name="TN_AirTran_6" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.DesignatedPoint" styleConfig="//@styleConfig.7">
     <title lang="en" text="Designated Point Default Style"/>
     <title text="Designierter Punkt"/>
     <objectType>tn-a_4.0:DesignatedPoint</objectType>
   </layerConfig>
-  <layerConfig name="TN_AirTran_7" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.AerodromeNode" styleConfig="//@styleConfig.7">
+  <layerConfig name="TN_AirTran_6_v5" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.DesignatedPoint" styleConfig="//@styleConfig.8">
+    <title lang="en" text="Designated Point Default Style"/>
+    <title text="Designierter Punkt"/>
+    <objectType>tn-a_5.0:DesignatedPoint</objectType>
+  </layerConfig>
+  <layerConfig name="TN_AirTran_7" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.AerodromeNode" styleConfig="//@styleConfig.13">
     <title lang="en" text="Aerodrome Node Default Style"/>
     <title text="Flugplatzknotenpunkt"/>
     <objectType>tn-a_4.0:AerodromeNode</objectType>
   </layerConfig>
-  <layerConfig name="TN_AirTran_8" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.TouchDownLiftOff" styleConfig="//@styleConfig.8">
+  <layerConfig name="TN_AirTran_7_v5" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.AerodromeNode" styleConfig="//@styleConfig.14">
+    <title lang="en" text="Aerodrome Node Default Style"/>
+    <title text="Flugplatzknotenpunkt"/>
+    <objectType>tn-a_5.0:AerodromeNode</objectType>
+  </layerConfig>
+  <layerConfig name="TN_AirTran_8" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.TouchDownLiftOff" styleConfig="//@styleConfig.15">
     <title lang="en" text="Touch Down Lift Off Area Default Style"/>
     <title text="Start- und Landebereich für Hubschrauber"/>
     <objectType>tn-a_4.0:TouchDownLiftOff</objectType>
   </layerConfig>
-  <layerConfig name="TN_AirTran_9" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.Navaid" styleConfig="//@styleConfig.5">
+  <layerConfig name="TN_AirTran_8_v5" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.TouchDownLiftOff" styleConfig="//@styleConfig.16">
+    <title lang="en" text="Touch Down Lift Off Area Default Style"/>
+    <title text="Start- und Landebereich für Hubschrauber"/>
+    <objectType>tn-a_5.0:TouchDownLiftOff</objectType>
+  </layerConfig>
+  <layerConfig name="TN_AirTran_9" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.Navaid" styleConfig="//@styleConfig.9">
     <title lang="en" text="Navaid Default Style"/>
     <title text="Navigationshilfe"/>
     <objectType>tn-a_4.0:Navaid</objectType>
   </layerConfig>
-  <layerConfig name="TN_AirTran_10" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.RunwayCentrelinePoint" styleConfig="//@styleConfig.6">
+  <layerConfig name="TN_AirTran_9_v5" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.Navaid" styleConfig="//@styleConfig.10">
+    <title lang="en" text="Navaid Default Style"/>
+    <title text="Navigationshilfe"/>
+    <objectType>tn-a_5.0:Navaid</objectType>
+  </layerConfig>
+  <layerConfig name="TN_AirTran_10" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.RunwayCentrelinePoint" styleConfig="//@styleConfig.11">
     <title lang="en" text="Runway Centreline Point Default Style"/>
     <title text="Mittellinienpunkt der Landebahn"/>
     <objectType>tn-a_4.0:RunwayCentrelinePoint</objectType>
   </layerConfig>
-  <layerConfig name="TN_CableTr" registryId="http://inspire.ec.europa.eu/layer/TN.CableTransportNetwork.CablewayLink" tags="//@tags.0 //@tags.2" layerName="TN.CableTransportNetwork.CablewayLink" styleConfig="//@styleConfig.114">
+  <layerConfig name="TN_AirTran_10_v5" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.RunwayCentrelinePoint" styleConfig="//@styleConfig.12">
+    <title lang="en" text="Runway Centreline Point Default Style"/>
+    <title text="Mittellinienpunkt der Landebahn"/>
+    <objectType>tn-a_5.0:RunwayCentrelinePoint</objectType>
+  </layerConfig>
+  <layerConfig name="TN_CableTr" registryId="http://inspire.ec.europa.eu/layer/TN.CableTransportNetwork.CablewayLink" tags="//@tags.0 //@tags.2" layerName="TN.CableTransportNetwork.CablewayLink" styleConfig="//@styleConfig.158">
     <title lang="en" text="Cableway Link Default Style"/>
     <title text="Seilbahnverbindung"/>
     <objectType>tn-c_4.0:CablewayLink</objectType>
   </layerConfig>
-  <layerConfig name="TN_CommonT" registryId="http://inspire.ec.europa.eu/layer/TN.CommonTransportElements.TransportArea" tags="//@tags.0 //@tags.2" layerName="TN.CommonTransportElements.TransportArea" styleConfig="//@styleConfig.115">
+  <layerConfig name="TN_CableTr_v5" registryId="http://inspire.ec.europa.eu/layer/TN.CableTransportNetwork.CablewayLink" tags="//@tags.0 //@tags.2" layerName="TN.CableTransportNetwork.CablewayLink" styleConfig="//@styleConfig.159">
+    <title lang="en" text="Cableway Link Default Style"/>
+    <title text="Seilbahnverbindung"/>
+    <objectType>tn-c_5.0:CablewayLink</objectType>
+  </layerConfig>
+  <layerConfig name="TN_CommonT" registryId="http://inspire.ec.europa.eu/layer/TN.CommonTransportElements.TransportArea" tags="//@tags.0 //@tags.2" layerName="TN.CommonTransportElements.TransportArea" styleConfig="//@styleConfig.160">
     <title lang="en" text="Generic Transport Area Default Style"/>
     <title text="Generischer Verkehrsbereich"/>
     <objectType>tn_4.0:TransportArea</objectType>
   </layerConfig>
-  <layerConfig name="TN_CommonT_1" registryId="http://inspire.ec.europa.eu/layer/TN.CommonTransportElements.TransportLink" tags="//@tags.0 //@tags.2" layerName="TN.CommonTransportElements.TransportLink" styleConfig="//@styleConfig.116">
+  <layerConfig name="TN_CommonT_v5" registryId="http://inspire.ec.europa.eu/layer/TN.CommonTransportElements.TransportArea" tags="//@tags.0 //@tags.2" layerName="TN.CommonTransportElements.TransportArea" styleConfig="//@styleConfig.161">
+    <title lang="en" text="Generic Transport Area Default Style"/>
+    <title text="Generischer Verkehrsbereich"/>
+    <objectType>tn_5.0:TransportArea</objectType>
+  </layerConfig>
+  <layerConfig name="TN_CommonT_1" registryId="http://inspire.ec.europa.eu/layer/TN.CommonTransportElements.TransportLink" tags="//@tags.0 //@tags.2" layerName="TN.CommonTransportElements.TransportLink" styleConfig="//@styleConfig.162">
     <title lang="en" text="Generic Transport Link Default Style"/>
     <title text="Generisches Verkehrssegment"/>
     <objectType>tn_4.0:TransportLink</objectType>
   </layerConfig>
-  <layerConfig name="TN_CommonT_2" registryId="http://inspire.ec.europa.eu/layer/TN.CommonTransportElements.TransportNode" tags="//@tags.0 //@tags.2" layerName="TN.CommonTransportElements.TransportNode" styleConfig="//@styleConfig.117">
+  <layerConfig name="TN_CommonT_1_v5" registryId="http://inspire.ec.europa.eu/layer/TN.CommonTransportElements.TransportLink" tags="//@tags.0 //@tags.2" layerName="TN.CommonTransportElements.TransportLink" styleConfig="//@styleConfig.163">
+    <title lang="en" text="Generic Transport Link Default Style"/>
+    <title text="Generisches Verkehrssegment"/>
+    <objectType>tn_5.0:TransportLink</objectType>
+  </layerConfig>
+  <layerConfig name="TN_CommonT_2" registryId="http://inspire.ec.europa.eu/layer/TN.CommonTransportElements.TransportNode" tags="//@tags.0 //@tags.2" layerName="TN.CommonTransportElements.TransportNode" styleConfig="//@styleConfig.164">
     <title lang="en" text="Generic Transport Node Default Style"/>
     <title text="Generischer Verkehrsknotenpunkt"/>
     <objectType>tn_4.0:TransportNode</objectType>
   </layerConfig>
-  <layerConfig name="TN_RailTra" registryId="http://inspire.ec.europa.eu/layer/TN.RailTransportNetwork.RailwayArea" tags="//@tags.0 //@tags.2" layerName="TN.RailTransportNetwork.RailwayArea" styleConfig="//@styleConfig.118">
+  <layerConfig name="TN_CommonT_2_v5" registryId="http://inspire.ec.europa.eu/layer/TN.CommonTransportElements.TransportNode" tags="//@tags.0 //@tags.2" layerName="TN.CommonTransportElements.TransportNode" styleConfig="//@styleConfig.165">
+    <title lang="en" text="Generic Transport Node Default Style"/>
+    <title text="Generischer Verkehrsknotenpunkt"/>
+    <objectType>tn_5.0:TransportNode</objectType>
+  </layerConfig>
+  <layerConfig name="TN_RailTra" registryId="http://inspire.ec.europa.eu/layer/TN.RailTransportNetwork.RailwayArea" tags="//@tags.0 //@tags.2" layerName="TN.RailTransportNetwork.RailwayArea" styleConfig="//@styleConfig.166">
     <title lang="en" text="Railway Area Default Style"/>
     <title text="Bahngelände"/>
     <objectType>tn-ra_4.0:RailwayArea</objectType>
   </layerConfig>
-  <layerConfig name="TN_RailTra_1" registryId="http://inspire.ec.europa.eu/layer/TN.RailTransportNetwork.RailwayLink" tags="//@tags.0 //@tags.2" layerName="TN.RailTransportNetwork.RailwayLink" styleConfig="//@styleConfig.119">
+  <layerConfig name="TN_RailTra_v5" registryId="http://inspire.ec.europa.eu/layer/TN.RailTransportNetwork.RailwayArea" tags="//@tags.0 //@tags.2" layerName="TN.RailTransportNetwork.RailwayArea" styleConfig="//@styleConfig.167">
+    <title lang="en" text="Railway Area Default Style"/>
+    <title text="Bahngelände"/>
+    <objectType>tn-ra_5.0:RailwayArea</objectType>
+  </layerConfig>
+  <layerConfig name="TN_RailTra_1" registryId="http://inspire.ec.europa.eu/layer/TN.RailTransportNetwork.RailwayLink" tags="//@tags.0 //@tags.2" layerName="TN.RailTransportNetwork.RailwayLink" styleConfig="//@styleConfig.168">
     <title lang="en" text="Railway Link Default Style"/>
     <title text="Eisenbahnverbindung"/>
     <objectType>tn-ra_4.0:RailwayLink</objectType>
   </layerConfig>
-  <layerConfig name="TN_RailTra_2" registryId="http://inspire.ec.europa.eu/layer/TN.RailTransportNetwork.RailwayStationArea" tags="//@tags.0 //@tags.2" layerName="TN.RailTransportNetwork.RailwayStationArea" styleConfig="//@styleConfig.120">
+  <layerConfig name="TN_RailTra_1_v5" registryId="http://inspire.ec.europa.eu/layer/TN.RailTransportNetwork.RailwayLink" tags="//@tags.0 //@tags.2" layerName="TN.RailTransportNetwork.RailwayLink" styleConfig="//@styleConfig.169">
+    <title lang="en" text="Railway Link Default Style"/>
+    <title text="Eisenbahnverbindung"/>
+    <objectType>tn-ra_5.0:RailwayLink</objectType>
+  </layerConfig>
+  <layerConfig name="TN_RailTra_2" registryId="http://inspire.ec.europa.eu/layer/TN.RailTransportNetwork.RailwayStationArea" tags="//@tags.0 //@tags.2" layerName="TN.RailTransportNetwork.RailwayStationArea" styleConfig="//@styleConfig.170">
     <title lang="en" text="Railway Station Area Default Style"/>
     <title text="Bahnhofsgelände"/>
     <objectType>tn-ra_4.0:RailwayStationArea</objectType>
   </layerConfig>
-  <layerConfig name="TN_RailTra_3" registryId="http://inspire.ec.europa.eu/layer/TN.RailTransportNetwork.RailwayYardArea" tags="//@tags.0 //@tags.2" layerName="TN.RailTransportNetwork.RailwayYardArea" styleConfig="//@styleConfig.121">
+  <layerConfig name="TN_RailTra_2_v5" registryId="http://inspire.ec.europa.eu/layer/TN.RailTransportNetwork.RailwayStationArea" tags="//@tags.0 //@tags.2" layerName="TN.RailTransportNetwork.RailwayStationArea" styleConfig="//@styleConfig.171">
+    <title lang="en" text="Railway Station Area Default Style"/>
+    <title text="Bahnhofsgelände"/>
+    <objectType>tn-ra_5.0:RailwayStationArea</objectType>
+  </layerConfig>
+  <layerConfig name="TN_RailTra_3" registryId="http://inspire.ec.europa.eu/layer/TN.RailTransportNetwork.RailwayYardArea" tags="//@tags.0 //@tags.2" layerName="TN.RailTransportNetwork.RailwayYardArea" styleConfig="//@styleConfig.172">
     <title lang="en" text="Railway Yard Area Default Style"/>
     <title text="Rangierbahnhofsgelände"/>
     <objectType>tn-ra_4.0:RailwayYardArea</objectType>
   </layerConfig>
-  <layerConfig name="TN_RoadTra" registryId="http://inspire.ec.europa.eu/layer/TN.RoadTransportNetwork.RoadArea" tags="//@tags.0 //@tags.2" layerName="TN.RoadTransportNetwork.RoadArea" styleConfig="//@styleConfig.122">
+  <layerConfig name="TN_RailTra_3_v5" registryId="http://inspire.ec.europa.eu/layer/TN.RailTransportNetwork.RailwayYardArea" tags="//@tags.0 //@tags.2" layerName="TN.RailTransportNetwork.RailwayYardArea" styleConfig="//@styleConfig.173">
+    <title lang="en" text="Railway Yard Area Default Style"/>
+    <title text="Rangierbahnhofsgelände"/>
+    <objectType>tn-ra_5.0:RailwayYardArea</objectType>
+  </layerConfig>
+  <layerConfig name="TN_RoadTra" registryId="http://inspire.ec.europa.eu/layer/TN.RoadTransportNetwork.RoadArea" tags="//@tags.0 //@tags.2" layerName="TN.RoadTransportNetwork.RoadArea" styleConfig="//@styleConfig.174">
     <title lang="en" text="Road Area Default Style"/>
     <title text="Straßenfläche"/>
     <objectType>tn-ro_4.0:RoadArea</objectType>
   </layerConfig>
-  <layerConfig name="TN_RoadTra_1" registryId="http://inspire.ec.europa.eu/layer/TN.RoadTransportNetwork.RoadLink" tags="//@tags.0 //@tags.2" layerName="TN.RoadTransportNetwork.RoadLink" styleConfig="//@styleConfig.123">
+  <layerConfig name="TN_RoadTra_v5" registryId="http://inspire.ec.europa.eu/layer/TN.RoadTransportNetwork.RoadArea" tags="//@tags.0 //@tags.2" layerName="TN.RoadTransportNetwork.RoadArea" styleConfig="//@styleConfig.175">
+    <title lang="en" text="Road Area Default Style"/>
+    <title text="Straßenfläche"/>
+    <objectType>tn-ro_5.0:RoadArea</objectType>
+  </layerConfig>
+  <layerConfig name="TN_RoadTra_1" registryId="http://inspire.ec.europa.eu/layer/TN.RoadTransportNetwork.RoadLink" tags="//@tags.0 //@tags.2" layerName="TN.RoadTransportNetwork.RoadLink" styleConfig="//@styleConfig.176">
     <title lang="en" text="Road Link Default Style"/>
     <title text="Straßensegment"/>
     <objectType>tn-ro_4.0:RoadLink</objectType>
   </layerConfig>
-  <layerConfig name="TN_RoadTra_2" registryId="http://inspire.ec.europa.eu/layer/TN.RoadTransportNetwork.RoadServiceArea" tags="//@tags.0 //@tags.2" layerName="TN.RoadTransportNetwork.RoadServiceArea" styleConfig="//@styleConfig.124">
+  <layerConfig name="TN_RoadTra_1_v5" registryId="http://inspire.ec.europa.eu/layer/TN.RoadTransportNetwork.RoadLink" tags="//@tags.0 //@tags.2" layerName="TN.RoadTransportNetwork.RoadLink" styleConfig="//@styleConfig.177">
+    <title lang="en" text="Road Link Default Style"/>
+    <title text="Straßensegment"/>
+    <objectType>tn-ro_5.0:RoadLink</objectType>
+  </layerConfig>
+  <layerConfig name="TN_RoadTra_2" registryId="http://inspire.ec.europa.eu/layer/TN.RoadTransportNetwork.RoadServiceArea" tags="//@tags.0 //@tags.2" layerName="TN.RoadTransportNetwork.RoadServiceArea" styleConfig="//@styleConfig.178">
     <title lang="en" text="Road Service Area Default Style"/>
     <title text="Servicebereich"/>
     <objectType>tn-ro_4.0:RoadServiceArea</objectType>
   </layerConfig>
-  <layerConfig name="TN_RoadTra_3" registryId="http://inspire.ec.europa.eu/layer/TN.RoadTransportNetwork.VehicleTrafficArea" tags="//@tags.0 //@tags.2" layerName="TN.RoadTransportNetwork.VehicleTrafficArea" styleConfig="//@styleConfig.125">
+  <layerConfig name="TN_RoadTra_2_v5" registryId="http://inspire.ec.europa.eu/layer/TN.RoadTransportNetwork.RoadServiceArea" tags="//@tags.0 //@tags.2" layerName="TN.RoadTransportNetwork.RoadServiceArea" styleConfig="//@styleConfig.179">
+    <title lang="en" text="Road Service Area Default Style"/>
+    <title text="Servicebereich"/>
+    <objectType>tn-ro_5.0:RoadServiceArea</objectType>
+  </layerConfig>
+  <layerConfig name="TN_RoadTra_3" registryId="http://inspire.ec.europa.eu/layer/TN.RoadTransportNetwork.VehicleTrafficArea" tags="//@tags.0 //@tags.2" layerName="TN.RoadTransportNetwork.VehicleTrafficArea" styleConfig="//@styleConfig.180">
     <title lang="en" text="Vehicle traffic Area Default Style"/>
     <title text="Verkehrsfläche"/>
     <objectType>tn-ro_4.0:VehicleTrafficArea</objectType>
   </layerConfig>
-  <layerConfig name="TN_WaterTr" registryId="http://inspire.ec.europa.eu/layer/TN.WaterTransportNetwork.FairwayArea" tags="//@tags.0 //@tags.2" layerName="TN.WaterTransportNetwork.FairwayArea" styleConfig="//@styleConfig.126">
+  <layerConfig name="TN_RoadTra_3_v5" registryId="http://inspire.ec.europa.eu/layer/TN.RoadTransportNetwork.VehicleTrafficArea" tags="//@tags.0 //@tags.2" layerName="TN.RoadTransportNetwork.VehicleTrafficArea" styleConfig="//@styleConfig.181">
+    <title lang="en" text="Vehicle traffic Area Default Style"/>
+    <title text="Verkehrsfläche"/>
+    <objectType>tn-ro_5.0:VehicleTrafficArea</objectType>
+  </layerConfig>
+  <layerConfig name="TN_WaterTr" registryId="http://inspire.ec.europa.eu/layer/TN.WaterTransportNetwork.FairwayArea" tags="//@tags.0 //@tags.2" layerName="TN.WaterTransportNetwork.FairwayArea" styleConfig="//@styleConfig.182">
     <title lang="en" text="Fairway Area Default Style"/>
     <title text="Fahrrinnenbereich"/>
     <objectType>tn-w_4.0:FairwayArea</objectType>
   </layerConfig>
-  <layerConfig name="TN_WaterTr_1" registryId="http://inspire.ec.europa.eu/layer/TN.WaterTransportNetwork.PortArea" tags="//@tags.0 //@tags.2" layerName="TN.WaterTransportNetwork.PortArea" styleConfig="//@styleConfig.127">
+  <layerConfig name="TN_WaterTr_v5" registryId="http://inspire.ec.europa.eu/layer/TN.WaterTransportNetwork.FairwayArea" tags="//@tags.0 //@tags.2" layerName="TN.WaterTransportNetwork.FairwayArea" styleConfig="//@styleConfig.183">
+    <title lang="en" text="Fairway Area Default Style"/>
+    <title text="Fahrrinnenbereich"/>
+    <objectType>tn-w_5.0:FairwayArea</objectType>
+  </layerConfig>
+  <layerConfig name="TN_WaterTr_1" registryId="http://inspire.ec.europa.eu/layer/TN.WaterTransportNetwork.PortArea" tags="//@tags.0 //@tags.2" layerName="TN.WaterTransportNetwork.PortArea" styleConfig="//@styleConfig.184">
     <title lang="en" text="Port Area Default Style"/>
     <title text="Hafengelände"/>
     <objectType>tn-w_4.0:PortArea</objectType>
   </layerConfig>
-  <layerConfig name="TN_WaterTr_2" registryId="http://inspire.ec.europa.eu/layer/TN.WaterTransportNetwork.WaterwayLink" tags="//@tags.0 //@tags.2" layerName="TN.WaterTransportNetwork.WaterwayLink" styleConfig="//@styleConfig.128">
+  <layerConfig name="TN_WaterTr_1_v5" registryId="http://inspire.ec.europa.eu/layer/TN.WaterTransportNetwork.PortArea" tags="//@tags.0 //@tags.2" layerName="TN.WaterTransportNetwork.PortArea" styleConfig="//@styleConfig.185">
+    <title lang="en" text="Port Area Default Style"/>
+    <title text="Hafengelände"/>
+    <objectType>tn-w_5.0:PortArea</objectType>
+  </layerConfig>
+  <layerConfig name="TN_WaterTr_2" registryId="http://inspire.ec.europa.eu/layer/TN.WaterTransportNetwork.WaterwayLink" tags="//@tags.0 //@tags.2" layerName="TN.WaterTransportNetwork.WaterwayLink" styleConfig="//@styleConfig.186">
     <title lang="en" text="Waterway Link Default Style"/>
     <title text="Wasserstraßenverbindung"/>
     <objectType>tn-w_4.0:WaterwayLink</objectType>
   </layerConfig>
-  <layerConfig name="LC_LandCoverSurfaces" registryId="http://inspire.ec.europa.eu/layer/LC.LandCoverSurfaces" tags="//@tags.2 //@tags.0" layerName="LC.LandCoverSurfaces" styleConfig="//@styleConfig.129">
+  <layerConfig name="TN_WaterTr_2_v5" registryId="http://inspire.ec.europa.eu/layer/TN.WaterTransportNetwork.WaterwayLink" tags="//@tags.0 //@tags.2" layerName="TN.WaterTransportNetwork.WaterwayLink" styleConfig="//@styleConfig.187">
+    <title lang="en" text="Waterway Link Default Style"/>
+    <title text="Wasserstraßenverbindung"/>
+    <objectType>tn-w_5.0:WaterwayLink</objectType>
+  </layerConfig>
+  <layerConfig name="LC_LandCoverSurfaces" registryId="http://inspire.ec.europa.eu/layer/LC.LandCoverSurfaces" tags="//@tags.2 //@tags.0" layerName="LC.LandCoverSurfaces" styleConfig="//@styleConfig.188">
     <title lang="en" text="Land Cover Surfaces"/>
     <title text="Bodenbedeckungsflächen"/>
     <objectType>lcv_4.0:LandCoverUnit</objectType>
   </layerConfig>
-  <layerConfig name="LC_LandCoverPoints" registryId="http://inspire.ec.europa.eu/layer/LC.LandCoverPoints" tags="//@tags.2 //@tags.0" layerName="LC.LandCoverPoints" styleConfig="//@styleConfig.130">
+  <layerConfig name="LC_LandCoverSurfaces_v5" registryId="http://inspire.ec.europa.eu/layer/LC.LandCoverSurfaces" tags="//@tags.2 //@tags.0" layerName="LC.LandCoverSurfaces" styleConfig="//@styleConfig.189">
+    <title lang="en" text="Land Cover Surfaces"/>
+    <title text="Bodenbedeckungsflächen"/>
+    <objectType>lcv_5.0:LandCoverUnit</objectType>
+  </layerConfig>
+  <layerConfig name="LC_LandCoverPoints" registryId="http://inspire.ec.europa.eu/layer/LC.LandCoverPoints" tags="//@tags.2 //@tags.0" layerName="LC.LandCoverPoints" styleConfig="//@styleConfig.190">
     <title lang="en" text="Land Cover Points"/>
     <title text="Bodenbedeckungspunkte"/>
     <objectType>lcv_4.0:LandCoverUnit</objectType>
   </layerConfig>
-  <layerConfig name="BU_Building" registryId="http://inspire.ec.europa.eu/layer/BU.Building" tags="//@tags.0 //@tags.2" layerName="BU.Building" styleConfig="//@styleConfig.131">
+  <layerConfig name="LC_LandCoverPoints_v5" registryId="http://inspire.ec.europa.eu/layer/LC.LandCoverPoints" tags="//@tags.2 //@tags.0" layerName="LC.LandCoverPoints" styleConfig="//@styleConfig.191">
+    <title lang="en" text="Land Cover Points"/>
+    <title text="Bodenbedeckungspunkte"/>
+    <objectType>lcv_5.0:LandCoverUnit</objectType>
+  </layerConfig>
+  <layerConfig name="BU_Building" registryId="http://inspire.ec.europa.eu/layer/BU.Building" tags="//@tags.0 //@tags.2" layerName="BU.Building" styleConfig="//@styleConfig.192">
     <title lang="en" text="Building"/>
     <title text="Gebäude"/>
     <objectType>bu-core2d_4.0:Building</objectType>
   </layerConfig>
-  <layerConfig name="BU_BuildingPart" registryId="http://inspire.ec.europa.eu/layer/BU.BuildingPart" tags="//@tags.0 //@tags.2" layerName="BU.BuildingPart" styleConfig="//@styleConfig.132">
+  <layerConfig name="BU_BuildingPart" registryId="http://inspire.ec.europa.eu/layer/BU.BuildingPart" tags="//@tags.0 //@tags.2" layerName="BU.BuildingPart" styleConfig="//@styleConfig.193">
     <title lang="en" text="BuildingPart"/>
     <title text="Gebäudeteile"/>
     <objectType>bu-core2d_4.0:BuildingPart</objectType>
   </layerConfig>
-  <layerConfig name="LU_ExistingLandUse" registryId="http://inspire.ec.europa.eu/layer/LU.ExistingLandUse" tags="//@tags.2 //@tags.0" layerName="LU.ExistingLandUse" styleConfig="//@styleConfig.66">
+  <layerConfig name="LU_ExistingLandUse" registryId="http://inspire.ec.europa.eu/layer/LU.ExistingLandUse" tags="//@tags.2 //@tags.0" layerName="LU.ExistingLandUse" styleConfig="//@styleConfig.82">
     <title lang="en" text="Existing Land Use"/>
     <title text="Existierende Bodennutzung"/>
     <objectType>elu_4.0:ExistingLandUseObject</objectType>
   </layerConfig>
-  <layerConfig name="LU_SpatialPlan" registryId="http://inspire.ec.europa.eu/layer/LU.SpatialPlan" tags="//@tags.2 //@tags.0" layerName="LU.SpatialPlan" styleConfig="//@styleConfig.65">
+  <layerConfig name="LU_SpatialPlan" registryId="http://inspire.ec.europa.eu/layer/LU.SpatialPlan" tags="//@tags.2 //@tags.0" layerName="LU.SpatialPlan" styleConfig="//@styleConfig.81">
     <title lang="en" text="Spatial Plan"/>
     <title text="Räumlicher Plan"/>
     <objectType>plu_4.0:SpatialPlan</objectType>
   </layerConfig>
-  <layerConfig name="LU_ZoningElement" registryId="http://inspire.ec.europa.eu/layer/LU.ZoningElement" tags="//@tags.2 //@tags.0" layerName="LU.ZoningElement" styleConfig="//@styleConfig.64">
+  <layerConfig name="LU_ZoningElement" registryId="http://inspire.ec.europa.eu/layer/LU.ZoningElement" tags="//@tags.2 //@tags.0" layerName="LU.ZoningElement" styleConfig="//@styleConfig.80">
     <title lang="en" text="Zoning Element"/>
     <title text="Zonierungselement"/>
     <objectType>plu_4.0:ZoningElement</objectType>
   </layerConfig>
-  <layerConfig name="LU_SupplementaryRegulation" registryId="http://inspire.ec.europa.eu/layer/LU.SupplementaryRegulation" tags="//@tags.2 //@tags.0" layerName="LU.SupplementaryRegulation" styleConfig="//@styleConfig.63">
+  <layerConfig name="LU_SupplementaryRegulation" registryId="http://inspire.ec.europa.eu/layer/LU.SupplementaryRegulation" tags="//@tags.2 //@tags.0" layerName="LU.SupplementaryRegulation" styleConfig="//@styleConfig.79">
     <title lang="en" text="Supplementary Regulation"/>
     <title text="Ergänzende Vorschrift"/>
     <objectType>plu_4.0:SupplementaryRegulation</objectType>
   </layerConfig>
-  <layerConfig name="US_GovernmentalService" registryId="" tags="//@tags.0" layerName="US.GovernmentalService" styleConfig="//@styleConfig.62">
+  <layerConfig name="US_GovernmentalService" registryId="" tags="//@tags.0" layerName="US.GovernmentalService" styleConfig="//@styleConfig.77">
     <title lang="en" text="Governmental Service"/>
     <title text="Staatlicher Dienst"/>
     <objectType>us-govserv_4.0:GovernmentalService</objectType>
   </layerConfig>
-  <layerConfig name="AM_AirQualityManagementZone" registryId="http://inspire.ec.europa.eu/layer/AM.AirQualityManagementZone" tags="//@tags.0 //@tags.2" layerName="AM.AirQualityManagementZone" styleConfig="//@styleConfig.60">
+  <layerConfig name="US_GovernmentalService_v5" registryId="" tags="//@tags.0" layerName="US.GovernmentalService" styleConfig="//@styleConfig.78">
+    <title lang="en" text="Governmental Service"/>
+    <title text="Staatlicher Dienst"/>
+    <objectType>us-govserv_5.0:GovernmentalService</objectType>
+  </layerConfig>
+  <layerConfig name="AM_AirQualityManagementZone" registryId="http://inspire.ec.europa.eu/layer/AM.AirQualityManagementZone" tags="//@tags.0 //@tags.2" layerName="AM.AirQualityManagementZone" styleConfig="//@styleConfig.75">
     <title lang="en" text="Air Quality Management Zone"/>
     <title text="Luftqualitäts-Kontrollgebiet"/>
     <objectType>am_4.0:ManagementRestrictionOrRegulationZone</objectType>
   </layerConfig>
-  <layerConfig name="AM_AnimalHealthRestrictionZone" registryId="http://inspire.ec.europa.eu/layer/AM.AnimalHealthRestrictionZone" tags="//@tags.0 //@tags.2" layerName="AM.AnimalHealthRestrictionZone" styleConfig="//@styleConfig.61">
+  <layerConfig name="AM_AnimalHealthRestrictionZone" registryId="http://inspire.ec.europa.eu/layer/AM.AnimalHealthRestrictionZone" tags="//@tags.0 //@tags.2" layerName="AM.AnimalHealthRestrictionZone" styleConfig="//@styleConfig.76">
     <title lang="en" text="Animal Health Restriction Zone"/>
     <title text="Tiergesundheits-Schutzgebiet"/>
     <objectType>am_4.0:ManagementRestrictionOrRegulationZone</objectType>
   </layerConfig>
-  <layerConfig name="AM_AreaForDisposalOfWaste" registryId="http://inspire.ec.europa.eu/layer/AM.AreaForDisposalOfWaste" tags="//@tags.0 //@tags.2" layerName="AM.AreaForDisposalOfWaste" styleConfig="//@styleConfig.59">
+  <layerConfig name="AM_AreaForDisposalOfWaste" registryId="http://inspire.ec.europa.eu/layer/AM.AreaForDisposalOfWaste" tags="//@tags.0 //@tags.2" layerName="AM.AreaForDisposalOfWaste" styleConfig="//@styleConfig.74">
     <title lang="en" text="Area For Disposal Of Waste"/>
     <title text="Abfallentsorgungsgebiet"/>
     <objectType>am_4.0:ManagementRestrictionOrRegulationZone</objectType>
   </layerConfig>
-  <layerConfig name="AM_BathingWaters" registryId="http://inspire.ec.europa.eu/layer/AM.BathingWaters" tags="//@tags.0 //@tags.2" layerName="AM.BathingWaters" styleConfig="//@styleConfig.58">
+  <layerConfig name="AM_BathingWaters" registryId="http://inspire.ec.europa.eu/layer/AM.BathingWaters" tags="//@tags.0 //@tags.2" layerName="AM.BathingWaters" styleConfig="//@styleConfig.73">
     <title lang="en" text="Bathing Waters"/>
     <title text="Badegewässer"/>
     <objectType>am_4.0:ManagementRestrictionOrRegulationZone</objectType>
   </layerConfig>
-  <layerConfig name="AM_CoastalZoneManagementArea" registryId="http://inspire.ec.europa.eu/layer/AM.CoastalZoneManagementArea" tags="//@tags.0 //@tags.2" layerName="AM.CoastalZoneManagementArea" styleConfig="//@styleConfig.57">
+  <layerConfig name="AM_CoastalZoneManagementArea" registryId="http://inspire.ec.europa.eu/layer/AM.CoastalZoneManagementArea" tags="//@tags.0 //@tags.2" layerName="AM.CoastalZoneManagementArea" styleConfig="//@styleConfig.72">
     <title lang="en" text="Coastal Zone Management Area"/>
     <title text="Gebiete des Küstenzonenmanagements"/>
     <objectType>am_4.0:ManagementRestrictionOrRegulationZone</objectType>
   </layerConfig>
-  <layerConfig name="AM_DesignatedWaters" registryId="http://inspire.ec.europa.eu/layer/AM.DesignatedWaters" tags="//@tags.0 //@tags.2" layerName="AM.DesignatedWaters" styleConfig="//@styleConfig.56">
+  <layerConfig name="AM_DesignatedWaters" registryId="http://inspire.ec.europa.eu/layer/AM.DesignatedWaters" tags="//@tags.0 //@tags.2" layerName="AM.DesignatedWaters" styleConfig="//@styleConfig.71">
     <title lang="en" text="Designated Waters"/>
     <title text="Bezeichnetes Gewässer"/>
     <objectType>am_4.0:ManagementRestrictionOrRegulationZone</objectType>
   </layerConfig>
-  <layerConfig name="AM_DrinkingWaterProtectionArea" registryId="http://inspire.ec.europa.eu/layer/AM.DrinkingWaterProtectionArea" tags="//@tags.0 //@tags.2" layerName="AM.DrinkingWaterProtectionArea" styleConfig="//@styleConfig.55">
+  <layerConfig name="AM_DrinkingWaterProtectionArea" registryId="http://inspire.ec.europa.eu/layer/AM.DrinkingWaterProtectionArea" tags="//@tags.0 //@tags.2" layerName="AM.DrinkingWaterProtectionArea" styleConfig="//@styleConfig.70">
     <title lang="en" text="Drinking Water Protection Area"/>
     <title text="Trinkwasserschutzgebiet"/>
     <objectType>am_4.0:ManagementRestrictionOrRegulationZone</objectType>
   </layerConfig>
-  <layerConfig name="AM_FloodUnitOfManagement" registryId="http://inspire.ec.europa.eu/layer/AM.FloodUnitOfManagement" tags="//@tags.0 //@tags.2" layerName="AM.FloodUnitOfManagement" styleConfig="//@styleConfig.54">
+  <layerConfig name="AM_FloodUnitOfManagement" registryId="http://inspire.ec.europa.eu/layer/AM.FloodUnitOfManagement" tags="//@tags.0 //@tags.2" layerName="AM.FloodUnitOfManagement" styleConfig="//@styleConfig.69">
     <title lang="en" text="Flood Unit Of Management"/>
     <title text="Bewirtschaftungseinheit für Hochwasserrisiken"/>
     <objectType>am_4.0:ManagementRestrictionOrRegulationZone</objectType>
   </layerConfig>
-  <layerConfig name="AM_ForestManagementArea" registryId="http://inspire.ec.europa.eu/layer/AM.ForestManagementArea" tags="//@tags.0 //@tags.2" layerName="AM.ForestManagementArea" styleConfig="//@styleConfig.53">
+  <layerConfig name="AM_ForestManagementArea" registryId="http://inspire.ec.europa.eu/layer/AM.ForestManagementArea" tags="//@tags.0 //@tags.2" layerName="AM.ForestManagementArea" styleConfig="//@styleConfig.68">
     <title lang="en" text="Forest Management Area"/>
     <title text="Waldbewirtschaftungsgebiet"/>
     <objectType>am_4.0:ManagementRestrictionOrRegulationZone</objectType>
   </layerConfig>
-  <layerConfig name="AM_MarineRegion" registryId="http://inspire.ec.europa.eu/layer/AM.MarineRegion" tags="//@tags.0 //@tags.2" layerName="AM.MarineRegion" styleConfig="//@styleConfig.52">
+  <layerConfig name="AM_MarineRegion" registryId="http://inspire.ec.europa.eu/layer/AM.MarineRegion" tags="//@tags.0 //@tags.2" layerName="AM.MarineRegion" styleConfig="//@styleConfig.67">
     <title lang="en" text="Marine Region"/>
     <title text="Meeresregion"/>
     <objectType>am_4.0:ManagementRestrictionOrRegulationZone</objectType>
   </layerConfig>
-  <layerConfig name="AM_NitrateVulnerableZone" registryId="http://inspire.ec.europa.eu/layer/AM.NitrateVulnerableZone" tags="//@tags.0 //@tags.2" layerName="AM.NitrateVulnerableZone" styleConfig="//@styleConfig.51">
+  <layerConfig name="AM_NitrateVulnerableZone" registryId="http://inspire.ec.europa.eu/layer/AM.NitrateVulnerableZone" tags="//@tags.0 //@tags.2" layerName="AM.NitrateVulnerableZone" styleConfig="//@styleConfig.66">
     <title lang="en" text="Nitrate Vulnerable Zone"/>
     <title text="Nitratgefährdetes Gebiet"/>
     <objectType>am_4.0:ManagementRestrictionOrRegulationZone</objectType>
   </layerConfig>
-  <layerConfig name="AM_NoiseRestrictionZone" registryId="http://inspire.ec.europa.eu/layer/AM.NoiseRestrictionZone" tags="//@tags.0 //@tags.2" layerName="AM.NoiseRestrictionZone" styleConfig="//@styleConfig.50">
+  <layerConfig name="AM_NoiseRestrictionZone" registryId="http://inspire.ec.europa.eu/layer/AM.NoiseRestrictionZone" tags="//@tags.0 //@tags.2" layerName="AM.NoiseRestrictionZone" styleConfig="//@styleConfig.65">
     <title lang="en" text="Noise Restriction Zone"/>
     <title text="Lärmschutzgebiet"/>
     <objectType>am_4.0:ManagementRestrictionOrRegulationZone</objectType>
   </layerConfig>
-  <layerConfig name="AM_PlantHealthProtectionZone" registryId="http://inspire.ec.europa.eu/layer/AM.PlantHealthProtectionZone" tags="//@tags.0 //@tags.2" layerName="AM.PlantHealthProtectionZone" styleConfig="//@styleConfig.49">
+  <layerConfig name="AM_PlantHealthProtectionZone" registryId="http://inspire.ec.europa.eu/layer/AM.PlantHealthProtectionZone" tags="//@tags.0 //@tags.2" layerName="AM.PlantHealthProtectionZone" styleConfig="//@styleConfig.64">
     <title lang="en" text="Plant Health Protection Zone"/>
     <title text="Pflanzengesundheitliches Schutzgebiet"/>
     <objectType>am_4.0:ManagementRestrictionOrRegulationZone</objectType>
   </layerConfig>
-  <layerConfig name="AM_ProspectingAndMiningPermitArea" registryId="http://inspire.ec.europa.eu/layer/AM.ProspectingAndMiningPermitArea" tags="//@tags.0 //@tags.2" layerName="AM.ProspectingAndMiningPermitArea" styleConfig="//@styleConfig.48">
+  <layerConfig name="AM_ProspectingAndMiningPermitArea" registryId="http://inspire.ec.europa.eu/layer/AM.ProspectingAndMiningPermitArea" tags="//@tags.0 //@tags.2" layerName="AM.ProspectingAndMiningPermitArea" styleConfig="//@styleConfig.63">
     <title lang="en" text="Prospecting And Mining Permit Area"/>
     <title text="Für Prospektion und Bergbau ausgewiesenes Gebiet"/>
     <objectType>am_4.0:ManagementRestrictionOrRegulationZone</objectType>
   </layerConfig>
-  <layerConfig name="AM_RegulatedFairwayAtSeaOrLargeInlandWater" registryId="http://inspire.ec.europa.eu/layer/AM.RegulatedFairwayAtSeaOrLargeInlandWater" tags="//@tags.0 //@tags.2" layerName="AM.RegulatedFairwayAtSeaOrLargeInlandWater" styleConfig="//@styleConfig.47">
+  <layerConfig name="AM_RegulatedFairwayAtSeaOrLargeInlandWater" registryId="http://inspire.ec.europa.eu/layer/AM.RegulatedFairwayAtSeaOrLargeInlandWater" tags="//@tags.0 //@tags.2" layerName="AM.RegulatedFairwayAtSeaOrLargeInlandWater" styleConfig="//@styleConfig.62">
     <title lang="en" text="Regulated Fairway At Sea Or Large Inland Water"/>
     <title text="Geregeltes Fahrwasser auf See oder auf großen Binnengewässern"/>
     <objectType>am_4.0:ManagementRestrictionOrRegulationZone</objectType>
   </layerConfig>
-  <layerConfig name="AM_RestrictedZonesAroundContaminatedSites" registryId="http://inspire.ec.europa.eu/layer/AM.RestrictedZonesAroundContaminatedSites" tags="//@tags.0 //@tags.2" layerName="AM.RestrictedZonesAroundContaminatedSites" styleConfig="//@styleConfig.46">
+  <layerConfig name="AM_RestrictedZonesAroundContaminatedSites" registryId="http://inspire.ec.europa.eu/layer/AM.RestrictedZonesAroundContaminatedSites" tags="//@tags.0 //@tags.2" layerName="AM.RestrictedZonesAroundContaminatedSites" styleConfig="//@styleConfig.61">
     <title lang="en" text="Restricted Zones Around Contaminated Sites"/>
     <title text="Schutzgebiete um kontaminierte Standorte (Altlasten)"/>
     <objectType>am_4.0:ManagementRestrictionOrRegulationZone</objectType>
   </layerConfig>
-  <layerConfig name="AM_RiverBasinDistrict" registryId="http://inspire.ec.europa.eu/layer/AM.RiverBasinDistrict" tags="//@tags.0 //@tags.2" layerName="AM.RiverBasinDistrict" styleConfig="//@styleConfig.45">
+  <layerConfig name="AM_RiverBasinDistrict" registryId="http://inspire.ec.europa.eu/layer/AM.RiverBasinDistrict" tags="//@tags.0 //@tags.2" layerName="AM.RiverBasinDistrict" styleConfig="//@styleConfig.60">
     <title lang="en" text="River Basin District"/>
     <title text="Flussgebietseinheit"/>
     <objectType>am_4.0:ManagementRestrictionOrRegulationZone</objectType>
   </layerConfig>
-  <layerConfig name="AM_SensitiveArea" registryId="http://inspire.ec.europa.eu/layer/AM.SensitiveArea" tags="//@tags.0 //@tags.2" layerName="AM.SensitiveArea" styleConfig="//@styleConfig.44">
+  <layerConfig name="AM_SensitiveArea" registryId="http://inspire.ec.europa.eu/layer/AM.SensitiveArea" tags="//@tags.0 //@tags.2" layerName="AM.SensitiveArea" styleConfig="//@styleConfig.59">
     <title lang="en" text="Sensitive Area"/>
     <title text="Empfindliches Gebiet"/>
     <objectType>am_4.0:ManagementRestrictionOrRegulationZone</objectType>
   </layerConfig>
-  <layerConfig name="AM_WaterBodyForWFD" registryId="http://inspire.ec.europa.eu/layer/AM.WaterBodyForWFD" tags="//@tags.0 //@tags.2" layerName="AM.WaterBodyForWFD" styleConfig="//@styleConfig.43">
+  <layerConfig name="AM_WaterBodyForWFD" registryId="http://inspire.ec.europa.eu/layer/AM.WaterBodyForWFD" tags="//@tags.0 //@tags.2" layerName="AM.WaterBodyForWFD" styleConfig="//@styleConfig.58">
     <title lang="en" text="WaterBodyForWFD"/>
     <title text="Wasserkörper gemäß der Wasserrahmenrichtlinie (2000/60/EG)"/>
     <objectType>am_4.0:ManagementRestrictionOrRegulationZone</objectType>
   </layerConfig>
-  <layerConfig name="US_EnvironmentalManagementFacility" registryId="https://inspire.ec.europa.eu/layer/US.EnvironmentalManagementFacility" tags="//@tags.0 //@tags.2" layerName="US.EnvironmentalManagementFacility" styleConfig="//@styleConfig.3">
+  <layerConfig name="US_EnvironmentalManagementFacility" registryId="https://inspire.ec.europa.eu/layer/US.EnvironmentalManagementFacility" tags="//@tags.0 //@tags.2" layerName="US.EnvironmentalManagementFacility" styleConfig="//@styleConfig.5">
     <title lang="en" text="Environmental Management Facility"/>
     <title text="Umweltmanagementeinrichtungen"/>
     <objectType>us-emf_4.0:EnvironmentalManagementFacility</objectType>
+  </layerConfig>
+  <layerConfig name="US_EnvironmentalManagementFacility_v5" registryId="https://inspire.ec.europa.eu/layer/US.EnvironmentalManagementFacility" tags="//@tags.0 //@tags.2" layerName="US.EnvironmentalManagementFacility" styleConfig="//@styleConfig.6">
+    <title lang="en" text="Environmental Management Facility"/>
+    <title text="Umweltmanagementeinrichtungen"/>
+    <objectType>us-emf_5.0:EnvironmentalManagementFacility</objectType>
   </layerConfig>
   <layerConfig name="US_UtilityNetworkAppurtenance" registryId="" tags="//@tags.0 //@tags.2" layerName="US.UtilityNetworkAppurtenance" styleConfig="//@styleConfig.1">
     <title lang="en" text="Appurtenance"/>
     <title text="Zubehörteil"/>
     <objectType>us-net-common_4.0:Appurtenance</objectType>
   </layerConfig>
-  <layerConfig name="US_UtilityNetworkLink" registryId="" tags="//@tags.0 //@tags.2" layerName="US.UtilityNetworkLink" styleConfig="//@styleConfig.2">
+  <layerConfig name="US_UtilityNetworkAppurtenance_v5" registryId="" tags="//@tags.0 //@tags.2" layerName="US.UtilityNetworkAppurtenance" styleConfig="//@styleConfig.2">
+    <title lang="en" text="Appurtenance"/>
+    <title text="Zubehörteil"/>
+    <objectType>us-net-common_5.0:Appurtenance</objectType>
+  </layerConfig>
+  <layerConfig name="US_UtilityNetworkLink" registryId="" tags="//@tags.0 //@tags.2" layerName="US.UtilityNetworkLink" styleConfig="//@styleConfig.3">
     <title lang="en" text="Utility Link"/>
     <title text="Versorgungsverbindung"/>
     <objectType>us-net-common_4.0:UtilityLink</objectType>
   </layerConfig>
-  <layerConfig name="EF_EnvironmentalMonitoringFacilities" registryId="http://inspire.ec.europa.eu/layer/EF.EnvironmentalMonitoringFacilities" tags="//@tags.0 //@tags.2" layerName="EF.EnvironmentalMonitoringFacilities" styleConfig="//@styleConfig.42">
+  <layerConfig name="US_UtilityNetworkLink_v5" registryId="" tags="//@tags.0 //@tags.2" layerName="US.UtilityNetworkLink" styleConfig="//@styleConfig.4">
+    <title lang="en" text="Utility Link"/>
+    <title text="Versorgungsverbindung"/>
+    <objectType>us-net-common_5.0:UtilityLink</objectType>
+  </layerConfig>
+  <layerConfig name="EF_EnvironmentalMonitoringFacilities" registryId="http://inspire.ec.europa.eu/layer/EF.EnvironmentalMonitoringFacilities" tags="//@tags.0 //@tags.2" layerName="EF.EnvironmentalMonitoringFacilities" styleConfig="//@styleConfig.57">
     <title lang="en" text="Environmental Monitoring Facilities"/>
     <title text="Umweltüberwachungseinrichtungen"/>
     <objectType>ef_4.0:EnvironmentalMonitoringFacility</objectType>
   </layerConfig>
-  <layerConfig name="EF_EnvironmentalMonitoringNetworks" registryId="http://inspire.ec.europa.eu/layer/EF.EnvironmentalMonitoringNetworks" tags="//@tags.0 //@tags.2" layerName="EF.EnvironmentalMonitoringNetworks" styleConfig="//@styleConfig.41">
+  <layerConfig name="EF_EnvironmentalMonitoringNetworks" registryId="http://inspire.ec.europa.eu/layer/EF.EnvironmentalMonitoringNetworks" tags="//@tags.0 //@tags.2" layerName="EF.EnvironmentalMonitoringNetworks" styleConfig="//@styleConfig.56">
     <title lang="en" text="Environmental Monitoring Networks"/>
     <title text="Umweltüberwachungsnetzwerke"/>
     <objectType>ef_4.0:EnvironmentalMonitoringNetwork</objectType>
   </layerConfig>
-  <layerConfig name="EF_EnvironmentalMonitoringProgrammes" registryId="http://inspire.ec.europa.eu/layer/EF.EnvironmentalMonitoringProgrammes" tags="//@tags.0 //@tags.2" layerName="EF.EnvironmentalMonitoringProgrammes" styleConfig="//@styleConfig.40">
+  <layerConfig name="EF_EnvironmentalMonitoringProgrammes" registryId="http://inspire.ec.europa.eu/layer/EF.EnvironmentalMonitoringProgrammes" tags="//@tags.0 //@tags.2" layerName="EF.EnvironmentalMonitoringProgrammes" styleConfig="//@styleConfig.55">
     <title lang="en" text="Environmental Monitoring Programmes"/>
     <title text="Umweltüberwachungsprogramme"/>
     <objectType>ef_4.0:EnvironmentalMonitoringProgramme</objectType>
   </layerConfig>
-  <layerConfig name="NZ_RiskZone" registryId="" tags="//@tags.0 //@tags.2" layerName="NZ.RiskZone" styleConfig="//@styleConfig.39">
+  <layerConfig name="NZ_RiskZone" registryId="" tags="//@tags.0 //@tags.2" layerName="NZ.RiskZone" styleConfig="//@styleConfig.54">
     <title lang="en" text="Risk Zones"/>
     <title text="Risikogebiet"/>
     <objectType>nz-core_4.0:RiskZone</objectType>
   </layerConfig>
-  <layerConfig name="NZ_HazardArea" registryId="" tags="//@tags.0 //@tags.2" layerName="NZ.HazardArea" styleConfig="//@styleConfig.38">
+  <layerConfig name="NZ_HazardArea" registryId="" tags="//@tags.0 //@tags.2" layerName="NZ.HazardArea" styleConfig="//@styleConfig.53">
     <title lang="en" text="Hazard Area"/>
     <title text="Gefahrengebiet"/>
     <objectType>nz-core_4.0:HazardArea</objectType>
   </layerConfig>
-  <layerConfig name="NZ_ExposedElement" registryId="http://inspire.ec.europa.eu/layer/NZ.ExposedElement" tags="//@tags.0 //@tags.2" layerName="NZ.ExposedElement" styleConfig="//@styleConfig.37">
+  <layerConfig name="NZ_ExposedElement" registryId="http://inspire.ec.europa.eu/layer/NZ.ExposedElement" tags="//@tags.0 //@tags.2" layerName="NZ.ExposedElement" styleConfig="//@styleConfig.52">
     <title lang="en" text="Exposed Elements"/>
     <title text="Gefährdetes Element"/>
     <objectType>nz-core_4.0:ExposedElement</objectType>
   </layerConfig>
-  <layerConfig name="NZ_ObservedEvent" registryId="" tags="//@tags.0" layerName="NZ.ObservedEvent" styleConfig="//@styleConfig.36">
+  <layerConfig name="NZ_ObservedEvent" registryId="" tags="//@tags.0" layerName="NZ.ObservedEvent" styleConfig="//@styleConfig.51">
     <title lang="en" text="Observed Event"/>
     <title text="Beobachtetes Ereignis"/>
     <objectType>nz-core_4.0:ObservedEvent</objectType>
   </layerConfig>
-  <layerConfig name="TN_MarkerPost" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.CommonTransportElements.MarkerPost" styleConfig="//@styleConfig.35">
+  <layerConfig name="TN_MarkerPost" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.CommonTransportElements.MarkerPost" styleConfig="//@styleConfig.49">
     <title lang="en" text="Marker Post"/>
     <title text="Stationszeichen"/>
     <objectType>tn_4.0:MarkerPost</objectType>
   </layerConfig>
-  <layerConfig name="TN_W_Beacon" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.WaterTransportNetwork.Beacon" styleConfig="//@styleConfig.34">
+  <layerConfig name="TN_MarkerPost_v5" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.CommonTransportElements.MarkerPost" styleConfig="//@styleConfig.50">
+    <title lang="en" text="Marker Post"/>
+    <title text="Stationszeichen"/>
+    <objectType>tn_5.0:MarkerPost</objectType>
+  </layerConfig>
+  <layerConfig name="TN_W_Beacon" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.WaterTransportNetwork.Beacon" styleConfig="//@styleConfig.47">
     <title lang="en" text="Beacon"/>
     <title text="Leuchtfeuer"/>
     <objectType>tn-w_4.0:Beacon</objectType>
   </layerConfig>
-  <layerConfig name="TN_W_Buoy" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.WaterTransportNetwork.Buoy" styleConfig="//@styleConfig.33">
+  <layerConfig name="TN_W_Beacon_v5" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.WaterTransportNetwork.Beacon" styleConfig="//@styleConfig.48">
+    <title lang="en" text="Beacon"/>
+    <title text="Leuchtfeuer"/>
+    <objectType>tn-w_5.0:Beacon</objectType>
+  </layerConfig>
+  <layerConfig name="TN_W_Buoy" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.WaterTransportNetwork.Buoy" styleConfig="//@styleConfig.45">
     <title lang="en" text="Buoy"/>
     <title text="Tonne"/>
     <objectType>tn-w_4.0:Buoy</objectType>
   </layerConfig>
-  <layerConfig name="TN_W_TrafficSeparationSchemeCrossing" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.WaterTransportNetwork.TrafficSeparationSchemeCrossing" styleConfig="//@styleConfig.32">
+  <layerConfig name="TN_W_Buoy_v5" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.WaterTransportNetwork.Buoy" styleConfig="//@styleConfig.46">
+    <title lang="en" text="Buoy"/>
+    <title text="Tonne"/>
+    <objectType>tn-w_5.0:Buoy</objectType>
+  </layerConfig>
+  <layerConfig name="TN_W_TrafficSeparationSchemeCrossing" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.WaterTransportNetwork.TrafficSeparationSchemeCrossing" styleConfig="//@styleConfig.43">
     <title lang="en" text="Traffic Separation Scheme Crossing"/>
     <title text="Kreuzung eines Verkehrstrennungsgebiets"/>
     <objectType>tn-w_4.0:TrafficSeparationSchemeCrossing</objectType>
   </layerConfig>
-  <layerConfig name="TN_W_TrafficSeparationSchemeSeparator" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.WaterTransportNetwork.TrafficSeparationSchemeSeparator" styleConfig="//@styleConfig.31">
+  <layerConfig name="TN_W_TrafficSeparationSchemeCrossing_v5" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.WaterTransportNetwork.TrafficSeparationSchemeCrossing" styleConfig="//@styleConfig.44">
+    <title lang="en" text="Traffic Separation Scheme Crossing"/>
+    <title text="Kreuzung eines Verkehrstrennungsgebiets"/>
+    <objectType>tn-w_5.0:TrafficSeparationSchemeCrossing</objectType>
+  </layerConfig>
+  <layerConfig name="TN_W_TrafficSeparationSchemeSeparator" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.WaterTransportNetwork.TrafficSeparationSchemeSeparator" styleConfig="//@styleConfig.41">
     <title lang="en" text="Traffic Separation Scheme Separator"/>
     <title text="Übergangszone eines Verkehrstrennungsgebiets"/>
     <objectType>tn-w_4.0:TrafficSeparationSchemeSeparator</objectType>
   </layerConfig>
-  <layerConfig name="PF_ProductionFacility" registryId="" tags="//@tags.0" layerName="PF.ProductionFacility" styleConfig="//@styleConfig.30">
+  <layerConfig name="TN_W_TrafficSeparationSchemeSeparator_v5" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.WaterTransportNetwork.TrafficSeparationSchemeSeparator" styleConfig="//@styleConfig.42">
+    <title lang="en" text="Traffic Separation Scheme Separator"/>
+    <title text="Übergangszone eines Verkehrstrennungsgebiets"/>
+    <objectType>tn-w_5.0:TrafficSeparationSchemeSeparator</objectType>
+  </layerConfig>
+  <layerConfig name="PF_ProductionFacility" registryId="" tags="//@tags.0" layerName="PF.ProductionFacility" styleConfig="//@styleConfig.40">
     <title lang="en" text="Production Facility"/>
     <title text="Produktionsstätte"/>
     <objectType>pf_4.0:ProductionFacility</objectType>
   </layerConfig>
-  <layerConfig name="PF_ProductionBuilding" registryId="http://inspire.ec.europa.eu/layer/PF.ProductionBuilding" tags="//@tags.0 //@tags.2" layerName="PF.ProductionBuilding" styleConfig="//@styleConfig.29">
+  <layerConfig name="PF_ProductionBuilding" registryId="http://inspire.ec.europa.eu/layer/PF.ProductionBuilding" tags="//@tags.0 //@tags.2" layerName="PF.ProductionBuilding" styleConfig="//@styleConfig.39">
     <title lang="en" text="Production And Industrial Building"/>
     <title text="Produktions- und Industriegebäude"/>
     <objectType>pf_4.0:ProductionBuilding</objectType>
   </layerConfig>
-  <layerConfig name="PF_ProductionInstallation" registryId="http://inspire.ec.europa.eu/layer/PF.ProductionInstallation" tags="//@tags.0 //@tags.2" layerName="PF.ProductionInstallation" styleConfig="//@styleConfig.28">
+  <layerConfig name="PF_ProductionInstallation" registryId="http://inspire.ec.europa.eu/layer/PF.ProductionInstallation" tags="//@tags.0 //@tags.2" layerName="PF.ProductionInstallation" styleConfig="//@styleConfig.38">
     <title lang="en" text="Production And Industrial Installation"/>
     <title text="Produktions- und Industrieanlage"/>
     <objectType>pf_4.0:ProductionInstallation</objectType>
   </layerConfig>
-  <layerConfig name="PF_ProductionInstallationPart" registryId="http://inspire.ec.europa.eu/layer/PF.ProductionInstallationPart" tags="//@tags.0 //@tags.2" layerName="PF.ProductionInstallationPart" styleConfig="//@styleConfig.27">
+  <layerConfig name="PF_ProductionInstallationPart" registryId="http://inspire.ec.europa.eu/layer/PF.ProductionInstallationPart" tags="//@tags.0 //@tags.2" layerName="PF.ProductionInstallationPart" styleConfig="//@styleConfig.37">
     <title lang="en" text="Production And Industrial Installation Part"/>
     <title text="Produktions- und Industrieanlagenteil"/>
     <objectType>pf_4.0:ProductionInstallationPart</objectType>
   </layerConfig>
-  <layerConfig name="PF_ProductionPlot" registryId="http://inspire.ec.europa.eu/layer/PF.ProductionPlot" tags="//@tags.0 //@tags.2" layerName="PF.ProductionPlot" styleConfig="//@styleConfig.26">
+  <layerConfig name="PF_ProductionPlot" registryId="http://inspire.ec.europa.eu/layer/PF.ProductionPlot" tags="//@tags.0 //@tags.2" layerName="PF.ProductionPlot" styleConfig="//@styleConfig.36">
     <title lang="en" text="Production And Industrial Plot"/>
     <title text="Produktions- und Industriegelände"/>
     <objectType>pf_4.0:ProductionPlot</objectType>
   </layerConfig>
-  <layerConfig name="PF_ProductionSite" registryId="http://inspire.ec.europa.eu/layer/PF.ProductionSite" tags="//@tags.0 //@tags.2" layerName="PF.ProductionSite" styleConfig="//@styleConfig.25">
+  <layerConfig name="PF_ProductionSite" registryId="http://inspire.ec.europa.eu/layer/PF.ProductionSite" tags="//@tags.0 //@tags.2" layerName="PF.ProductionSite" styleConfig="//@styleConfig.35">
     <title lang="en" text="Production And Industrial Site"/>
     <title text="Produktions- und Industriestandort"/>
     <objectType>pf_4.0:ProductionSite</objectType>
   </layerConfig>
-  <layerConfig name="ER_RenewableAndWasteResource" registryId="http://inspire.ec.europa.eu/layer/ER.RenewableAndWasteResource" tags="//@tags.0" layerName="ER.RenewableAndWasteResource" styleConfig="//@styleConfig.24">
+  <layerConfig name="ER_RenewableAndWasteResource" registryId="http://inspire.ec.europa.eu/layer/ER.RenewableAndWasteResource" tags="//@tags.0" layerName="ER.RenewableAndWasteResource" styleConfig="//@styleConfig.34">
     <title lang="en" text="Renewable And Waste Resource"/>
     <title text="Ressourcen erneuerbarer Energien und Abfallressourcen"/>
     <objectType>er-v_4.0:RenewableAndWasteResource</objectType>
   </layerConfig>
-  <layerConfig name="GE_GeologicUnit_AgeOfRocks" registryId="http://inspire.ec.europa.eu/layer/GE.GeologicUnit" tags="//@tags.0 //@tags.2" layerName="GE.GeologicUnit.AgeOfRocks" styleConfig="//@styleConfig.23">
+  <layerConfig name="GE_GeologicUnit_AgeOfRocks" registryId="http://inspire.ec.europa.eu/layer/GE.GeologicUnit" tags="//@tags.0 //@tags.2" layerName="GE.GeologicUnit.AgeOfRocks" styleConfig="//@styleConfig.33">
     <title lang="en" text="Geologic Units"/>
     <title text="Geologische Einheiten"/>
     <objectType>ge-core_4.0:MappedFeature</objectType>
   </layerConfig>
-  <layerConfig name="GE_Borehole" registryId="http://inspire.ec.europa.eu/layer/GE.Borehole" tags="//@tags.0 //@tags.2" layerName="GE.Borehole" styleConfig="//@styleConfig.133">
+  <layerConfig name="GE_Borehole" registryId="http://inspire.ec.europa.eu/layer/GE.Borehole" tags="//@tags.0 //@tags.2" layerName="GE.Borehole" styleConfig="//@styleConfig.194">
     <title lang="en" text="Boreholes"/>
     <title text="Bohrlöcher"/>
     <objectType>ge-core_4.0:Borehole</objectType>
   </layerConfig>
-  <layerConfig name="BR_BiogeographicalRegion" registryId="http://inspire.ec.europa.eu/layer/BR.Bio-geographicalRegion" tags="//@tags.0 //@tags.2" layerName="BR.Bio-geographicalRegion" styleConfig="//@styleConfig.22">
+  <layerConfig name="BR_BiogeographicalRegion" registryId="http://inspire.ec.europa.eu/layer/BR.Bio-geographicalRegion" tags="//@tags.0 //@tags.2" layerName="BR.Bio-geographicalRegion" styleConfig="//@styleConfig.32">
     <title lang="en" text="Bio-geographical regions"/>
     <title text="Biogeografische Regionen"/>
     <objectType>br_4.0:Bio-geographicalRegion</objectType>
   </layerConfig>
-  <layerConfig name="BR_Natura2000andEmeraldBiogeographicalRegion" registryId="" tags="//@tags.0 //@tags.2" layerName="BR.Natura2000andEmeraldBio-geographicalRegion" styleConfig="//@styleConfig.21">
+  <layerConfig name="BR_Natura2000andEmeraldBiogeographicalRegion" registryId="" tags="//@tags.0 //@tags.2" layerName="BR.Natura2000andEmeraldBio-geographicalRegion" styleConfig="//@styleConfig.31">
     <title lang="en" text="Bio-geographical regions"/>
     <title text="Biogeografische Regionen"/>
     <objectType>br_4.0:Bio-geographicalRegion</objectType>
   </layerConfig>
-  <layerConfig name="SU_VectorStatisticalUnit" registryId="http://inspire.ec.europa.eu/layer/SU.VectorStatisticalUnit" tags="//@tags.0 //@tags.2" layerName="SU.VectorStatisticalUnit" styleConfig="//@styleConfig.19">
+  <layerConfig name="SU_VectorStatisticalUnit" registryId="http://inspire.ec.europa.eu/layer/SU.VectorStatisticalUnit" tags="//@tags.0 //@tags.2" layerName="SU.VectorStatisticalUnit" styleConfig="//@styleConfig.29">
     <title lang="en" text="Vector statistical units"/>
     <title text="Statistische Vektoreinheiten"/>
     <objectType>su-vector_4.0:VectorStatisticalUnit</objectType>
   </layerConfig>
-  <layerConfig name="SU_StatisticalGridCell" registryId="http://inspire.ec.europa.eu/layer/SU.StatisticalGridCell" tags="//@tags.0" layerName="SU.StatisticalGridCell" styleConfig="//@styleConfig.20">
+  <layerConfig name="SU_StatisticalGridCell" registryId="http://inspire.ec.europa.eu/layer/SU.StatisticalGridCell" tags="//@tags.0" layerName="SU.StatisticalGridCell" styleConfig="//@styleConfig.30">
     <title lang="en" text="Statistical grid cells"/>
     <title text="Statistische Vektoreinheiten"/>
     <objectType>su-grid_4.0:StatisticalGridCell</objectType>
   </layerConfig>
-  <layerConfig name="HH_HealthDeterminantMeasure" registryId="http://inspire.ec.europa.eu/layer/HH.HealthDeterminantMeasure" tags="//@tags.0 //@tags.2" layerName="HH.HealthDeterminantMeasure" styleConfig="//@styleConfig.18">
+  <layerConfig name="HH_HealthDeterminantMeasure" registryId="http://inspire.ec.europa.eu/layer/HH.HealthDeterminantMeasure" tags="//@tags.0 //@tags.2" layerName="HH.HealthDeterminantMeasure" styleConfig="//@styleConfig.27">
     <title lang="en" text="Health determinant measure"/>
     <title text="Messwerte für Gesundheitsfaktoren"/>
     <objectType>hh_4.0:EnvHealthDeterminantMeasure</objectType>
   </layerConfig>
-  <layerConfig name="EL_BreakLine" registryId="http://inspire.ec.europa.eu/layer/EL.BreakLine" tags="//@tags.0 //@tags.2" layerName="EL.BreakLine" styleConfig="//@styleConfig.17">
+  <layerConfig name="HH_HealthDeterminantMeasure_v5" registryId="http://inspire.ec.europa.eu/layer/HH.HealthDeterminantMeasure" tags="//@tags.0 //@tags.2" layerName="HH.HealthDeterminantMeasure" styleConfig="//@styleConfig.28">
+    <title lang="en" text="Health determinant measure"/>
+    <title text="Messwerte für Gesundheitsfaktoren"/>
+    <objectType>hh_5.0:EnvHealthDeterminantMeasure</objectType>
+  </layerConfig>
+  <layerConfig name="EL_BreakLine" registryId="http://inspire.ec.europa.eu/layer/EL.BreakLine" tags="//@tags.0 //@tags.2" layerName="EL.BreakLine" styleConfig="//@styleConfig.26">
     <title lang="en" text="Break Line"/>
     <title text="Bruchkante"/>
     <objectType>el-vec_4.0:BreakLine</objectType>
   </layerConfig>
-  <layerConfig name="EL_ContourLine" registryId="http://inspire.ec.europa.eu/layer/EL.ContourLine" tags="//@tags.0 //@tags.2" layerName="EL.ContourLine" styleConfig="//@styleConfig.16">
+  <layerConfig name="EL_ContourLine" registryId="http://inspire.ec.europa.eu/layer/EL.ContourLine" tags="//@tags.0 //@tags.2" layerName="EL.ContourLine" styleConfig="//@styleConfig.25">
     <title lang="en" text="Contour Line"/>
     <title text="Höhenlinie"/>
     <objectType>el-vec_4.0:ContourLine</objectType>
   </layerConfig>
-  <layerConfig name="EL_IsolatedArea" registryId="http://inspire.ec.europa.eu/layer/EL.IsolatedArea" tags="//@tags.0 //@tags.2" layerName="EL.IsolatedArea" styleConfig="//@styleConfig.15">
+  <layerConfig name="EL_IsolatedArea" registryId="http://inspire.ec.europa.eu/layer/EL.IsolatedArea" tags="//@tags.0 //@tags.2" layerName="EL.IsolatedArea" styleConfig="//@styleConfig.24">
     <title lang="en" text="Isolated Area"/>
     <title text="Abgesondertes Gebiet"/>
     <objectType>el-vec_4.0:IsolatedArea</objectType>
   </layerConfig>
-  <layerConfig name="EL_SpotElevation" registryId="http://inspire.ec.europa.eu/layer/EL.SpotElevation" tags="//@tags.0 //@tags.2" layerName="EL.SpotElevation" styleConfig="//@styleConfig.14">
+  <layerConfig name="EL_SpotElevation" registryId="http://inspire.ec.europa.eu/layer/EL.SpotElevation" tags="//@tags.0 //@tags.2" layerName="EL.SpotElevation" styleConfig="//@styleConfig.23">
     <title lang="en" text="Spot Elevation"/>
     <title text="Höhenlagenpunkt"/>
     <objectType>el-vec_4.0:SpotElevation</objectType>
   </layerConfig>
-  <layerConfig name="EL_VoidArea" registryId="http://inspire.ec.europa.eu/layer/EL.VoidArea" tags="//@tags.0 //@tags.2" layerName="EL.VoidArea" styleConfig="//@styleConfig.13">
+  <layerConfig name="EL_VoidArea" registryId="http://inspire.ec.europa.eu/layer/EL.VoidArea" tags="//@tags.0 //@tags.2" layerName="EL.VoidArea" styleConfig="//@styleConfig.22">
     <title lang="en" text="Void Area"/>
     <title text="Leeres Gebiet"/>
     <objectType>el-vec_4.0:VoidArea</objectType>
   </layerConfig>
-  <layerConfig name="EL_ContourLineType" registryId="" tags="//@tags.0 //@tags.2" layerName="EL.ContourLineType" styleConfig="//@styleConfig.12">
+  <layerConfig name="EL_ContourLineType" registryId="" tags="//@tags.0 //@tags.2" layerName="EL.ContourLineType" styleConfig="//@styleConfig.21">
     <title lang="en" text="Contour Line Type"/>
     <title text="Höhenlinie"/>
     <objectType>el-vec_4.0:ContourLine</objectType>
   </layerConfig>
-  <layerConfig name="EL_TIN" registryId="http://inspire.ec.europa.eu/layer/EL.ElevationTIN" tags="//@tags.0" layerName="EL.ElevationTIN" styleConfig="//@styleConfig.11">
+  <layerConfig name="EL_TIN" registryId="http://inspire.ec.europa.eu/layer/EL.ElevationTIN" tags="//@tags.0" layerName="EL.ElevationTIN" styleConfig="//@styleConfig.20">
     <title lang="en" text="Elevation TIN"/>
     <title text="Höhenlagenstruktur-TIN"/>
     <objectType>el-tin_4.0:ElevationTIN</objectType>
   </layerConfig>
-  <layerConfig name="SD_SpeciesDistribution" registryId="" tags="//@tags.0 //@tags.2" layerName="SD.SpeciesDistribution" styleConfig="//@styleConfig.10">
+  <layerConfig name="SD_SpeciesDistribution" registryId="" tags="//@tags.0 //@tags.2" layerName="SD.SpeciesDistribution" styleConfig="//@styleConfig.19">
     <title lang="en" text="Species Distribution"/>
     <title text="Verteilung der Arten"/>
     <objectType>sd_4.0:SpeciesDistributionUnit</objectType>
   </layerConfig>
-  <layerConfig name="TN_RO_RoadNode" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.RoadNode" styleConfig="//@styleConfig.9">
+  <layerConfig name="TN_RO_RoadNode" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.RoadNode" styleConfig="//@styleConfig.17">
     <title lang="en" text="Road Node"/>
     <title text="Strassenknotenpunkt"/>
     <objectType>tn-ro_4.0:RoadNode</objectType>
+  </layerConfig>
+  <layerConfig name="TN_RO_RoadNode_v5" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.RoadNode" styleConfig="//@styleConfig.18">
+    <title lang="en" text="Road Node"/>
+    <title text="Strassenknotenpunkt"/>
+    <objectType>tn-ro_5.0:RoadNode</objectType>
   </layerConfig>
   <layerConfig name="SF_SpatialSamplingFeature" registryId="" tags="//@tags.0 //@tags.2" layerName="SF.SpatialSamplingFeature" styleConfig="//@styleConfig.0">
     <title lang="en" text="Spatial Sampling Feature"/>
@@ -634,29 +897,56 @@
   <styleConfig name="US_UtilityNetworkAppurtenance">
     <remoteStyle featureTypeName="us-net-common_4.0:Appurtenance" url="feature-styles/US_UtilityNetworkAppurtenance.se"/>
   </styleConfig>
+  <styleConfig name="US_UtilityNetworkAppurtenance_v5">
+    <remoteStyle featureTypeName="us-net-common_5.0:Appurtenance" url="feature-styles/US_UtilityNetworkAppurtenance_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="US_UtilityNetworkLink">
     <remoteStyle featureTypeName="us-net-common_4.0:UtilityLink" url="feature-styles/US_UtilityNetworkLink.se"/>
+  </styleConfig>
+  <styleConfig name="US_UtilityNetworkLink_v5">
+    <remoteStyle featureTypeName="us-net-common_5.0:UtilityLink" url="feature-styles/US_UtilityNetworkLink_v5_0.se"/>
   </styleConfig>
   <styleConfig name="US_EnvironmentalManagementFacility">
     <remoteStyle featureTypeName="us-emf_4.0:EnvironmentalManagementFacility" url="feature-styles/US_EnvironmentalManagementFacility.se"/>
   </styleConfig>
+  <styleConfig name="US_EnvironmentalManagementFacility_v5">
+    <remoteStyle featureTypeName="us-emf_5.0:EnvironmentalManagementFacility" url="feature-styles/US_EnvironmentalManagementFacility_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="TN_A_DesignatedPoint">
     <remoteStyle featureTypeName="tn-a_4.0:DesignatedPoint" url="feature-styles/TN_A_DesignatedPoint.se"/>
+  </styleConfig>
+  <styleConfig name="TN_A_DesignatedPoint_v5">
+    <remoteStyle featureTypeName="tn-a_5.0:DesignatedPoint" url="feature-styles/TN_A_DesignatedPoint_v5_0.se"/>
   </styleConfig>
   <styleConfig name="TN_A_Navaid">
     <remoteStyle featureTypeName="tn-a_4.0:Navaid" url="feature-styles/TN_A_Navaid.se"/>
   </styleConfig>
+  <styleConfig name="TN_A_Navaid_v5">
+    <remoteStyle featureTypeName="tn-a_5.0:Navaid" url="feature-styles/TN_A_Navaid_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="TN_A_RunwayCentrelinePoint">
     <remoteStyle featureTypeName="tn-a_4.0:RunwayCentrelinePoint" url="feature-styles/TN_A_RunwayCentrelinePoint.se"/>
+  </styleConfig>
+  <styleConfig name="TN_A_RunwayCentrelinePoint_v5">
+    <remoteStyle featureTypeName="tn-a_5.0:RunwayCentrelinePoint" url="feature-styles/TN_A_RunwayCentrelinePoint_v5_0.se"/>
   </styleConfig>
   <styleConfig name="TN_A_AerodromeNode">
     <remoteStyle featureTypeName="tn-a_4.0:AerodromeNode" url="feature-styles/TN_A_AerodromeNode.se"/>
   </styleConfig>
+  <styleConfig name="TN_A_AerodromeNode_v5">
+    <remoteStyle featureTypeName="tn-a_5.0:AerodromeNode" url="feature-styles/TN_A_AerodromeNode_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="TN_A_TouchDownLiftOff">
     <remoteStyle featureTypeName="tn-a_4.0:TouchDownLiftOff" url="feature-styles/TN_A_TouchDownLiftOff.se"/>
   </styleConfig>
+  <styleConfig name="TN_A_TouchDownLiftOff_v5">
+    <remoteStyle featureTypeName="tn-a_5.0:TouchDownLiftOff" url="feature-styles/TN_A_TouchDownLiftOff_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="TN_RO_RoadNode">
     <remoteStyle featureTypeName="tn-ro_4.0:RoadNode" url="feature-styles/TN_RO_RoadNode.se"/>
+  </styleConfig>
+  <styleConfig name="TN_RO_RoadNode_v5">
+    <remoteStyle featureTypeName="tn-ro_5.0:RoadNode" url="feature-styles/TN_RO_RoadNode_v5_0.se"/>
   </styleConfig>
   <styleConfig name="SD_SpeciesDistribution">
     <remoteStyle featureTypeName="sd_4.0:SpeciesDistributionUnit" url="feature-styles/SD_SpeciesDistribution.se"/>
@@ -684,6 +974,9 @@
   </styleConfig>
   <styleConfig name="HH_HealthDeterminantMeasure">
     <remoteStyle featureTypeName="hh_4.0:EnvHealthDeterminantMeasure" url="feature-styles/HH_HealthDeterminantMeasure.se"/>
+  </styleConfig>
+  <styleConfig name="HH_HealthDeterminantMeasure_v5">
+    <remoteStyle featureTypeName="hh_5.0:EnvHealthDeterminantMeasure" url="feature-styles/HH_HealthDeterminantMeasure_v5_0.se"/>
   </styleConfig>
   <styleConfig name="SU_VectorStatisticalUnit">
     <remoteStyle featureTypeName="su-vector_4.0:VectorStatisticalUnit" url="feature-styles/SU_VectorStatisticalUnit.se"/>
@@ -724,17 +1017,32 @@
   <styleConfig name="TN_W_TrafficSeparationSchemeSeparator">
     <remoteStyle featureTypeName="tn-w_4.0:TrafficSeparationSchemeSeparator" url="feature-styles/TN_W_TrafficSeparationSchemeSeparator.se"/>
   </styleConfig>
+  <styleConfig name="TN_W_TrafficSeparationSchemeSeparator_v5">
+    <remoteStyle featureTypeName="tn-w_5.0:TrafficSeparationSchemeSeparator" url="feature-styles/TN_W_TrafficSeparationSchemeSeparator_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="TN_W_TrafficSeparationSchemeCrossing">
     <remoteStyle featureTypeName="tn-w_4.0:TrafficSeparationSchemeCrossing" url="feature-styles/TN_W_TrafficSeparationSchemeCrossing.se"/>
+  </styleConfig>
+  <styleConfig name="TN_W_TrafficSeparationSchemeCrossing_v5">
+    <remoteStyle featureTypeName="tn-w_5.0:TrafficSeparationSchemeCrossing" url="feature-styles/TN_W_TrafficSeparationSchemeCrossing_v5_0.se"/>
   </styleConfig>
   <styleConfig name="TN_W_Buoy">
     <remoteStyle featureTypeName="tn-w_4.0:Buoy" url="feature-styles/TN_W_Buoy.se"/>
   </styleConfig>
+  <styleConfig name="TN_W_Buoy_v5">
+    <remoteStyle featureTypeName="tn-w_5.0:Buoy" url="feature-styles/TN_W_Buoy_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="TN_W_Beacon">
     <remoteStyle featureTypeName="tn-w_4.0:Beacon" url="feature-styles/TN_W_Beacon.se"/>
   </styleConfig>
+  <styleConfig name="TN_W_Beacon_v5">
+    <remoteStyle featureTypeName="tn-w_5.0:Beacon" url="feature-styles/TN_W_Beacon_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="TN_MarkerPost">
     <remoteStyle featureTypeName="tn_4.0:MarkerPost" url="feature-styles/TN_MarkerPost.se"/>
+  </styleConfig>
+  <styleConfig name="TN_MarkerPost_v5">
+    <remoteStyle featureTypeName="tn_5.0:MarkerPost" url="feature-styles/TN_MarkerPost_v5_0.se"/>
   </styleConfig>
   <styleConfig name="NZ_ObservedEvent">
     <remoteStyle featureTypeName="nz-core_4.0:ObservedEvent" url="feature-styles/NZ_ObservedEvent.se"/>
@@ -817,6 +1125,9 @@
   <styleConfig name="US_GovernmentalService">
     <remoteStyle featureTypeName="us-govserv_4.0:GovernmentalService" url="feature-styles/US_GovernmentalService.se"/>
   </styleConfig>
+  <styleConfig name="US_GovernmentalService_v5">
+    <remoteStyle featureTypeName="us-govserv_5.0:GovernmentalService" url="feature-styles/US_GovernmentalService_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="LU_SupplementaryRegulation">
     <remoteStyle featureTypeName="plu_4.0:SupplementaryRegulation" url="feature-styles/LU_SupplementaryRegulation.se"/>
   </styleConfig>
@@ -886,65 +1197,128 @@
   <styleConfig name="HY_N_WatercourseLink">
     <remoteStyle featureTypeName="hy-n_4.0:WatercourseLink" url="feature-styles/HY_N_WatercourseLink.se"/>
   </styleConfig>
+  <styleConfig name="HY_N_WatercourseLink_v5">
+    <remoteStyle featureTypeName="hy-n_5.0:WatercourseLink" url="feature-styles/HY_N_WatercourseLink_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="HY_N_HydroNode">
     <remoteStyle featureTypeName="hy-n_4.0:HydroNode" url="feature-styles/HY_N_HydroNode.se"/>
+  </styleConfig>
+  <styleConfig name="HY_N_HydroNode_v5">
+    <remoteStyle featureTypeName="hy-n_5.0:HydroNode" url="feature-styles/HY_N_HydroNode_v5_0.se"/>
   </styleConfig>
   <styleConfig name="HY_P_DrainageBasin">
     <remoteStyle featureTypeName="hy-p_4.0:DrainageBasin" url="feature-styles/HY_P_DrainageBasin.se"/>
   </styleConfig>
+  <styleConfig name="HY_P_DrainageBasin_v5">
+    <remoteStyle featureTypeName="hy-p_5.0:DrainageBasin" url="feature-styles/HY_P_DrainageBasin_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="HY_P_RiverBasin">
     <remoteStyle featureTypeName="hy-p_4.0:RiverBasin" url="feature-styles/HY_P_RiverBasin.se"/>
+  </styleConfig>
+  <styleConfig name="HY_P_RiverBasin_v5">
+    <remoteStyle featureTypeName="hy-p_5.0:RiverBasin" url="feature-styles/HY_P_RiverBasin_v5_0.se"/>
   </styleConfig>
   <styleConfig name="HY_P_Rapids">
     <remoteStyle featureTypeName="hy-p_4.0:Rapids" url="feature-styles/HY_P_Rapids.se"/>
   </styleConfig>
+  <styleConfig name="HY_P_Rapids_v5">
+    <remoteStyle featureTypeName="hy-p_5.0:Rapids" url="feature-styles/HY_P_Rapids_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="HY_P_Falls">
     <remoteStyle featureTypeName="hy-p_4.0:Falls" url="feature-styles/HY_P_Falls.se"/>
+  </styleConfig>
+  <styleConfig name="HY_P_Falls_v5">
+    <remoteStyle featureTypeName="hy-p_5.0:Falls" url="feature-styles/HY_P_Falls_v5_0.se"/>
   </styleConfig>
   <styleConfig name="HY_P_LandWaterBoundary">
     <remoteStyle featureTypeName="hy-p_4.0:LandWaterBoundary" url="feature-styles/HY_P_LandWaterBoundary.se"/>
   </styleConfig>
+  <styleConfig name="HY_P_LandWaterBoundary_v5">
+    <remoteStyle featureTypeName="hy-p_5.0:LandWaterBoundary" url="feature-styles/HY_P_LandWaterBoundary_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="HY_P_Crossing">
     <remoteStyle featureTypeName="hy-p_4.0:Crossing" url="feature-styles/HY_P_Crossing.se"/>
+  </styleConfig>
+  <styleConfig name="HY_P_Crossing_v5">
+    <remoteStyle featureTypeName="hy-p_5.0:Crossing" url="feature-styles/HY_P_Crossing_v5_0.se"/>
   </styleConfig>
   <styleConfig name="HY_P_DamOrWeir">
     <remoteStyle featureTypeName="hy-p_4.0:DamOrWeir" url="feature-styles/HY_P_DamOrWeir.se"/>
   </styleConfig>
+  <styleConfig name="HY_P_DamOrWeir_v5">
+    <remoteStyle featureTypeName="hy-p_5.0:DamOrWeir" url="feature-styles/HY_P_DamOrWeir_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="HY_P_ShoreLineConstruction">
     <remoteStyle featureTypeName="hy-p_4.0:ShorelineConstruction" url="feature-styles/HY_P_ShoreLineConstruction.se"/>
+  </styleConfig>
+  <styleConfig name="HY_P_ShoreLineConstruction_v5">
+    <remoteStyle featureTypeName="hy-p_5.0:ShorelineConstruction" url="feature-styles/HY_P_ShoreLineConstruction_v5_0.se"/>
   </styleConfig>
   <styleConfig name="HY_P_Ford">
     <remoteStyle featureTypeName="hy-p_4.0:Ford" url="feature-styles/HY_P_Ford.se"/>
   </styleConfig>
+  <styleConfig name="HY_P_Ford_v5">
+    <remoteStyle featureTypeName="hy-p_5.0:Ford" url="feature-styles/HY_P_Ford_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="HY_P_Lock">
     <remoteStyle featureTypeName="hy-p_4.0:Lock" url="feature-styles/HY_P_Lock.se"/>
+  </styleConfig>
+  <styleConfig name="HY_P_Lock_v5">
+    <remoteStyle featureTypeName="hy-p_5.0:Lock" url="feature-styles/HY_P_Lock_v5_0.se"/>
   </styleConfig>
   <styleConfig name="HY_P_Shore">
     <remoteStyle featureTypeName="hy-p_4.0:Shore" url="feature-styles/HY_P_Shore.se"/>
   </styleConfig>
+  <styleConfig name="HY_P_Shore_v5">
+    <remoteStyle featureTypeName="hy-p_5.0:Shore" url="feature-styles/HY_P_Shore_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="HY_P_Watercourse">
     <remoteStyle featureTypeName="hy-p_4.0:Watercourse" url="feature-styles/HY_P_Watercourse.se"/>
+  </styleConfig>
+  <styleConfig name="HY_P_Watercourse_v5">
+    <remoteStyle featureTypeName="hy-p_5.0:Watercourse" url="feature-styles/HY_P_Watercourse_v5_0.se"/>
   </styleConfig>
   <styleConfig name="HY_P_StandingWater">
     <remoteStyle featureTypeName="hy-p_4.0:StandingWater" url="feature-styles/HY_P_StandingWater.se"/>
   </styleConfig>
+  <styleConfig name="HY_P_StandingWater_v5">
+    <remoteStyle featureTypeName="hy-p_5.0:StandingWater" url="feature-styles/HY_P_StandingWater_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="HY_P_Watercourse_ManMade">
     <remoteStyle featureTypeName="hy-p_4.0:Watercourse" url="feature-styles/HY_P_Watercourse_ManMade.se"/>
+  </styleConfig>
+  <styleConfig name="HY_P_Watercourse_ManMade_v5">
+    <remoteStyle featureTypeName="hy-p_5.0:Watercourse" url="feature-styles/HY_P_Watercourse_ManMade_v5_0.se"/>
   </styleConfig>
   <styleConfig name="HY_P_StandingWater_ManMade">
     <remoteStyle featureTypeName="hy-p_4.0:StandingWater" url="feature-styles/HY_P_StandingWater_ManMade.se"/>
   </styleConfig>
+  <styleConfig name="HY_P_StandingWater_ManMade_v5">
+    <remoteStyle featureTypeName="hy-p_5.0:StandingWater" url="feature-styles/HY_P_StandingWater_ManMade_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="HY_P_WatercoursePersistence">
     <remoteStyle featureTypeName="hy-p_4.0:Watercourse" url="feature-styles/HY_P_WatercoursePersistence.se"/>
+  </styleConfig>
+  <styleConfig name="HY_P_WatercoursePersistence_v5">
+    <remoteStyle featureTypeName="hy-p_5.0:Watercourse" url="feature-styles/HY_P_WatercoursePersistence_v5_0.se"/>
   </styleConfig>
   <styleConfig name="HY_P_WaterbodiesPersistence">
     <remoteStyle featureTypeName="hy-p_4.0:StandingWater" url="feature-styles/HY_P_WaterbodiesPersistence.se"/>
   </styleConfig>
+  <styleConfig name="HY_P_WaterbodiesPersistence_v5">
+    <remoteStyle featureTypeName="hy-p_5.0:StandingWater" url="feature-styles/HY_P_WaterbodiesPersistence_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="HY_P_Wetland">
     <remoteStyle featureTypeName="hy-p_4.0:Wetland" url="feature-styles/HY_P_Wetland.se"/>
   </styleConfig>
+  <styleConfig name="HY_P_Wetland_v5">
+    <remoteStyle featureTypeName="hy-p_5.0:Wetland" url="feature-styles/HY_P_Wetland_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="PS_ProtectedSite">
     <remoteStyle featureTypeName="ps_4.0:ProtectedSite" url="feature-styles/PS_ProtectedSites.se"/>
+  </styleConfig>
+  <styleConfig name="PS_ProtectedSite_v5">
+    <remoteStyle featureTypeName="ps_5.0:ProtectedSite" url="feature-styles/PS_ProtectedSites_v5_0.se"/>
   </styleConfig>
   <styleConfig name="PS_ProtectedSite_v5">
     <remoteStyle featureTypeName="ps_5.0:ProtectedSite" url="feature-styles/PS_ProtectedSites_v5.se"/>
@@ -952,74 +1326,146 @@
   <styleConfig name="TN_A_AerodromeArea">
     <remoteStyle featureTypeName="tn-a_4.0:AerodromeArea" url="feature-styles/TN_A_AerodromeArea.se"/>
   </styleConfig>
+  <styleConfig name="TN_A_AerodromeArea_v5">
+    <remoteStyle featureTypeName="tn-a_5.0:AerodromeArea" url="feature-styles/TN_A_AerodromeArea_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="TN_A_ProcedureLink">
     <remoteStyle featureTypeName="tn-a_4.0:ProcedureLink" url="feature-styles/TN_A_ProcedureLink.se"/>
+  </styleConfig>
+  <styleConfig name="TN_A_ProcedureLink_v5">
+    <remoteStyle featureTypeName="tn-a_5.0:ProcedureLink" url="feature-styles/TN_A_ProcedureLink_v5_0.se"/>
   </styleConfig>
   <styleConfig name="TN_A_AirRouteLink">
     <remoteStyle featureTypeName="tn-a_4.0:AirRouteLink" url="feature-styles/TN_A_AirRouteLink.se"/>
   </styleConfig>
+  <styleConfig name="TN_A_AirRouteLink_v5">
+    <remoteStyle featureTypeName="tn-a_5.0:AirRouteLink" url="feature-styles/TN_A_AirRouteLink_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="TN_A_AirspaceArea">
     <remoteStyle featureTypeName="tn-a_4.0:AirspaceArea" url="feature-styles/TN_A_AirspaceArea.se"/>
+  </styleConfig>
+  <styleConfig name="TN_A_AirspaceArea_v5">
+    <remoteStyle featureTypeName="tn-a_5.0:AirspaceArea" url="feature-styles/TN_A_AirspaceArea_v5_0.se"/>
   </styleConfig>
   <styleConfig name="TN_A_ApronArea">
     <remoteStyle featureTypeName="tn-a_4.0:ApronArea" url="feature-styles/TN_A_ApronArea.se"/>
   </styleConfig>
+  <styleConfig name="TN_A_ApronArea_v5">
+    <remoteStyle featureTypeName="tn-a_5.0:ApronArea" url="feature-styles/TN_A_ApronArea_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="TN_A_RunwayArea">
     <remoteStyle featureTypeName="tn-a_4.0:RunwayArea" url="feature-styles/TN_A_RunwayArea.se"/>
+  </styleConfig>
+  <styleConfig name="TN_A_RunwayArea_v5">
+    <remoteStyle featureTypeName="tn-a_5.0:RunwayArea" url="feature-styles/TN_A_RunwayArea_v5_0.se"/>
   </styleConfig>
   <styleConfig name="TN_A_TaxiwayArea">
     <remoteStyle featureTypeName="tn-a_4.0:TaxiwayArea" url="feature-styles/TN_A_TaxiwayArea.se"/>
   </styleConfig>
+  <styleConfig name="TN_A_TaxiwayArea_v5">
+    <remoteStyle featureTypeName="tn-a_5.0:TaxiwayArea" url="feature-styles/TN_A_TaxiwayArea_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="TN_C_CablewayLink">
     <remoteStyle featureTypeName="tn-c_4.0:CablewayLink" url="feature-styles/TN_C_CablewayLink.se"/>
+  </styleConfig>
+  <styleConfig name="TN_C_CablewayLink_v5">
+    <remoteStyle featureTypeName="tn-c_5.0:CablewayLink" url="feature-styles/TN_C_CablewayLink_v5_0.se"/>
   </styleConfig>
   <styleConfig name="TN_TransportArea">
     <remoteStyle featureTypeName="tn_4.0:TransportArea" url="feature-styles/TN_TransportArea.se"/>
   </styleConfig>
+  <styleConfig name="TN_TransportArea_v5">
+    <remoteStyle featureTypeName="tn_5.0:TransportArea" url="feature-styles/TN_TransportArea_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="TN_TransportLink">
     <remoteStyle featureTypeName="tn_4.0:TransportLink" url="feature-styles/TN_TransportLink.se"/>
+  </styleConfig>
+  <styleConfig name="TN_TransportLink_v5">
+    <remoteStyle featureTypeName="tn_5.0:TransportLink" url="feature-styles/TN_TransportLink_v5_0.se"/>
   </styleConfig>
   <styleConfig name="TN_TransportNode">
     <remoteStyle featureTypeName="tn_4.0:TransportNode" url="feature-styles/TN_TransportNode.se"/>
   </styleConfig>
+  <styleConfig name="TN_TransportNode_v5">
+    <remoteStyle featureTypeName="tn_5.0:TransportNode" url="feature-styles/TN_TransportNode_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="TN_RA_RailwayArea">
     <remoteStyle featureTypeName="tn-ra_4.0:RailwayArea" url="feature-styles/TN_RA_RailwayArea.se"/>
+  </styleConfig>
+  <styleConfig name="TN_RA_RailwayArea_v5">
+    <remoteStyle featureTypeName="tn-ra_5.0:RailwayArea" url="feature-styles/TN_RA_RailwayArea_v5_0.se"/>
   </styleConfig>
   <styleConfig name="TN_RA_RailwayLink">
     <remoteStyle featureTypeName="tn-ra_4.0:RailwayLink" url="feature-styles/TN_RA_RailwayLink.se"/>
   </styleConfig>
+  <styleConfig name="TN_RA_RailwayLink_v5">
+    <remoteStyle featureTypeName="tn-ra_5.0:RailwayLink" url="feature-styles/TN_RA_RailwayLink_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="TN_RA_RailwayStationArea">
     <remoteStyle featureTypeName="tn-ra_4.0:RailwayStationArea" url="feature-styles/TN_RA_RailwayStationArea.se"/>
+  </styleConfig>
+  <styleConfig name="TN_RA_RailwayStationArea_v5">
+    <remoteStyle featureTypeName="tn-ra_5.0:RailwayStationArea" url="feature-styles/TN_RA_RailwayStationArea_v5_0.se"/>
   </styleConfig>
   <styleConfig name="TN_RA_RailwayYardArea">
     <remoteStyle featureTypeName="tn-ra_4.0:RailwayYardArea" url="feature-styles/TN_RA_RailwayYardArea.se"/>
   </styleConfig>
+  <styleConfig name="TN_RA_RailwayYardArea_v5">
+    <remoteStyle featureTypeName="tn-ra_5.0:RailwayYardArea" url="feature-styles/TN_RA_RailwayYardArea_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="TN_RO_RoadArea">
     <remoteStyle featureTypeName="tn-ro_4.0:RoadArea" url="feature-styles/TN_RO_RoadArea.se"/>
+  </styleConfig>
+  <styleConfig name="TN_RO_RoadArea_v5">
+    <remoteStyle featureTypeName="tn-ro_5.0:RoadArea" url="feature-styles/TN_RO_RoadArea_v5_0.se"/>
   </styleConfig>
   <styleConfig name="TN_RO_RoadLink">
     <remoteStyle featureTypeName="tn-ro_4.0:RoadLink" url="feature-styles/TN_RO_RoadLink.se"/>
   </styleConfig>
+  <styleConfig name="TN_RO_RoadLink_v5">
+    <remoteStyle featureTypeName="tn-ro_5.0:RoadLink" url="feature-styles/TN_RO_RoadLink_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="TN_RO_RoadServiceArea">
     <remoteStyle featureTypeName="tn-ro_4.0:RoadServiceArea" url="feature-styles/TN_RO_RoadServiceArea.se"/>
+  </styleConfig>
+  <styleConfig name="TN_RO_RoadServiceArea_v5">
+    <remoteStyle featureTypeName="tn-ro_5.0:RoadServiceArea" url="feature-styles/TN_RO_RoadServiceArea_v5_0.se"/>
   </styleConfig>
   <styleConfig name="TN_RO_VehicleTrafficArea">
     <remoteStyle featureTypeName="tn-ro_4.0:VehicleTrafficArea" url="feature-styles/TN_RO_VehicleTrafficArea.se"/>
   </styleConfig>
+  <styleConfig name="TN_RO_VehicleTrafficArea_v5">
+    <remoteStyle featureTypeName="tn-ro_5.0:VehicleTrafficArea" url="feature-styles/TN_RO_VehicleTrafficArea_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="TN_W_FairwayArea">
     <remoteStyle featureTypeName="tn-w_4.0:FairwayArea" url="feature-styles/TN_W_FairwayArea.se"/>
+  </styleConfig>
+  <styleConfig name="TN_W_FairwayArea_v5">
+    <remoteStyle featureTypeName="tn-w_5.0:FairwayArea" url="feature-styles/TN_W_FairwayArea_v5_0.se"/>
   </styleConfig>
   <styleConfig name="TN_W_PortArea">
     <remoteStyle featureTypeName="tn-w_4.0:PortArea" url="feature-styles/TN_W_PortArea.se"/>
   </styleConfig>
+  <styleConfig name="TN_W_PortArea_v5">
+    <remoteStyle featureTypeName="tn-w_5.0:PortArea" url="feature-styles/TN_W_PortArea_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="TN_W_WaterwayLink">
     <remoteStyle featureTypeName="tn-w_4.0:WaterwayLink" url="feature-styles/TN_W_WaterwayLink.se"/>
+  </styleConfig>
+  <styleConfig name="TN_W_WaterwayLink_v5">
+    <remoteStyle featureTypeName="tn-w_5.0:WaterwayLink" url="feature-styles/TN_W_WaterwayLink_v5_0.se"/>
   </styleConfig>
   <styleConfig name="LC_LandCoverSurfaces">
     <remoteStyle featureTypeName="lcv_4.0:LandCoverUnit" url="feature-styles/LC_LandCoverSurfaces.se"/>
   </styleConfig>
+  <styleConfig name="LC_LandCoverSurfaces_v5">
+    <remoteStyle featureTypeName="lcv_5.0:LandCoverUnit" url="feature-styles/LC_LandCoverSurfaces_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="LC_LandCoverPoints">
     <remoteStyle featureTypeName="lcv_4.0:LandCoverUnit" url="feature-styles/LC_LandCoverPoints.se"/>
+  </styleConfig>
+  <styleConfig name="LC_LandCoverPoints_v5">
+    <remoteStyle featureTypeName="lcv_5.0:LandCoverUnit" url="feature-styles/LC_LandCoverPoints_v5_0.se"/>
   </styleConfig>
   <styleConfig name="BU_Building">
     <remoteStyle featureTypeName="bu-core2d_4.0:Building" url="feature-styles/BU_Building.se"/>

--- a/feature-styles/HH_HealthDeterminantMeasure_v5_0.se
+++ b/feature-styles/HH_HealthDeterminantMeasure_v5_0.se
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<se:FeatureTypeStyle xmlns:hh="http://inspire.ec.europa.eu/schemas/hh/4.0" 
+<se:FeatureTypeStyle xmlns:hh="http://inspire.ec.europa.eu/schemas/hh/5.0" 
 xmlns:ogc="http://www.opengis.net/ogc" 
 xmlns:se="http://www.opengis.net/se" 
 xmlns:sld="http://www.opengis.net/sld" 

--- a/feature-styles/HH_HealthDeterminantMeasure_v5_0.se
+++ b/feature-styles/HH_HealthDeterminantMeasure_v5_0.se
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:hh="http://inspire.ec.europa.eu/schemas/hh/4.0" 
+xmlns:ogc="http://www.opengis.net/ogc" 
+xmlns:se="http://www.opengis.net/se" 
+xmlns:sld="http://www.opengis.net/sld" 
+xmlns:xlink="http://www.w3.org/1999/xlink" 
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+version="1.1.0" xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd">
+  <se:Name>HH.HealthDeterminantMeasure.Default</se:Name>
+  <se:Description>
+    <se:Title>Health Determinant Measure Default Style</se:Title>
+    <se:Abstract>Geometries are rendered in solid blue (#0000FF) outline with a stroke width of 1 pixel.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>hh:EnvHealthDeterminantMeasure</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Human health: polygons</se:Title>
+    </se:Description>
+    <ogc:Filter>
+    	<ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsSurface">
+        		<ogc:PropertyName>hh:location</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+   	</ogc:Filter>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hh:location</ogc:PropertyName>
+      </se:Geometry>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#0000FF</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">3</se:SvgParameter>
+      </se:Stroke>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Human health: lines</se:Title>
+    </se:Description>
+    <ogc:Filter>
+    	<ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsCurve">
+        		<ogc:PropertyName>hh:location</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+   	</ogc:Filter>
+    <se:LineSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hh:location</ogc:PropertyName>
+      </se:Geometry>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#0000FF</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">3</se:SvgParameter>
+      </se:Stroke>
+    </se:LineSymbolizer>
+  </se:Rule>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Human health: points</se:Title>
+    </se:Description>
+    <ogc:Filter>
+    	<ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsPoint">
+        		<ogc:PropertyName>hh:location</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+   	</ogc:Filter>
+    <se:PointSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hh:location</ogc:PropertyName>
+      </se:Geometry>
+      <se:Graphic>
+        <se:Mark>
+          <se:WellKnownName>circle</se:WellKnownName>
+          <se:Fill>
+            <se:SvgParameter name="fill">#0000FF</se:SvgParameter>
+          </se:Fill>
+          <se:Stroke>
+            <se:SvgParameter name="stroke">#0000FF</se:SvgParameter>
+            <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+          </se:Stroke>
+        </se:Mark>
+        <se:Size>3</se:Size>
+      </se:Graphic>
+    </se:PointSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/feature-styles/HY_N_HydroNode_v5_0.se
+++ b/feature-styles/HY_N_HydroNode_v5_0.se
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<se:FeatureTypeStyle xmlns:hy-n="http://inspire.ec.europa.eu/schemas/hy-n/4.0" 
-xmlns:net="http://inspire.ec.europa.eu/schemas/net/4.0" xmlns:ogc="http://www.opengis.net/ogc" 
+<se:FeatureTypeStyle xmlns:hy-n="http://inspire.ec.europa.eu/schemas/hy-n/5.0" 
+xmlns:net="http://inspire.ec.europa.eu/schemas/net/5.0" xmlns:ogc="http://www.opengis.net/ogc" 
 xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:xlink="http://www.w3.org/1999/xlink" 
 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd"

--- a/feature-styles/HY_N_HydroNode_v5_0.se
+++ b/feature-styles/HY_N_HydroNode_v5_0.se
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:hy-n="http://inspire.ec.europa.eu/schemas/hy-n/4.0" 
+xmlns:net="http://inspire.ec.europa.eu/schemas/net/4.0" xmlns:ogc="http://www.opengis.net/ogc" 
+xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:xlink="http://www.w3.org/1999/xlink" 
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd"
+version="1.1.0">
+  <se:Name>HY.Network.Default</se:Name>
+  <se:Description>
+    <se:Title>Hydrographic Network Default Style</se:Title>
+    <se:Abstract>Hydrographic network where the hydro node category depends to outlet, junction and source is rendered by solid blue (#33CCFF) lines with stroke width of 1 pixel and 3 pixel size filled light blue (#CCFFFF) circles with black (#000000) border. Hydrographic network where the hydro node category depends to flow constriction and regulation is rendered by 3 pixel size filled black circles (#000000). Hydrographic network where the hydro node category depends to boundary is rendered by 3 pixel size filled red circles (#FF0000) with black (#000000) border.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>hy-n:HydroNode</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Hydro node default</se:Title>
+    </se:Description>
+    <se:PointSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>net:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Graphic>
+        <se:Mark>
+          <se:WellKnownName>circle</se:WellKnownName>
+          <se:Fill>
+            <se:SvgParameter name="fill">#000000</se:SvgParameter>
+          </se:Fill>
+          <se:Stroke>
+            <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+          </se:Stroke>
+        </se:Mark>
+        <se:Size>3</se:Size>
+      </se:Graphic>
+    </se:PointSymbolizer>
+  </se:Rule>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Hydro node outlet, junction or source</se:Title>
+    </se:Description>
+    <ogc:Filter>
+      <ogc:Or>
+        <ogc:PropertyIsEqualTo>
+          <ogc:PropertyName>hy-n:hydroNodeCategory/@xlink:href</ogc:PropertyName>
+          <ogc:Literal>http://inspire.ec.europa.eu/codelist/HydroNodeCategoryValue/outlet</ogc:Literal>
+        </ogc:PropertyIsEqualTo>
+        <ogc:PropertyIsEqualTo>
+          <ogc:PropertyName>hy-n:hydroNodeCategory/@xlink:href</ogc:PropertyName>
+          <ogc:Literal>http://inspire.ec.europa.eu/codelist/HydroNodeCategoryValue/junction</ogc:Literal>
+        </ogc:PropertyIsEqualTo>
+        <ogc:PropertyIsEqualTo>
+          <ogc:PropertyName>hy-n:hydroNodeCategory/@xlink:href</ogc:PropertyName>
+          <ogc:Literal>http://inspire.ec.europa.eu/codelist/HydroNodeCategoryValue/source</ogc:Literal>
+        </ogc:PropertyIsEqualTo>
+      </ogc:Or>
+    </ogc:Filter>
+    <se:PointSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>net:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Graphic>
+        <se:Mark>
+          <se:WellKnownName>circle</se:WellKnownName>
+          <se:Fill>
+            <se:SvgParameter name="fill">#CCFFFF</se:SvgParameter>
+          </se:Fill>
+          <se:Stroke>
+            <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+          </se:Stroke>
+        </se:Mark>
+        <se:Size>3</se:Size>
+      </se:Graphic>
+    </se:PointSymbolizer>
+  </se:Rule>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Hydro node flow constriction or regulation</se:Title>
+    </se:Description>
+    <ogc:Filter>
+      <ogc:Or>
+        <ogc:PropertyIsEqualTo>
+          <ogc:PropertyName>hy-n:hydroNodeCategory/@xlink:href</ogc:PropertyName>
+          <ogc:Literal>http://inspire.ec.europa.eu/codelist/HydroNodeCategoryValue/flowConstriction</ogc:Literal>
+        </ogc:PropertyIsEqualTo>
+        <ogc:PropertyIsEqualTo>
+          <ogc:PropertyName>hy-n:hydroNodeCategory/@xlink:href</ogc:PropertyName>
+          <ogc:Literal>http://inspire.ec.europa.eu/codelist/HydroNodeCategoryValue/flowRegulation</ogc:Literal>
+        </ogc:PropertyIsEqualTo>
+      </ogc:Or>
+    </ogc:Filter>
+    <se:PointSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>net:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Graphic>
+        <se:Mark>
+          <se:WellKnownName>circle</se:WellKnownName>
+          <se:Fill>
+            <se:SvgParameter name="fill">#000000</se:SvgParameter>
+          </se:Fill>
+        </se:Mark>
+        <se:Size>3</se:Size>
+      </se:Graphic>
+    </se:PointSymbolizer>
+  </se:Rule>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Hydro node boundary</se:Title>
+    </se:Description>
+    <ogc:Filter>
+      <ogc:PropertyIsEqualTo>
+        <ogc:PropertyName>hy-n:hydroNodeCategory/@xlink:href</ogc:PropertyName>
+        <ogc:Literal>http://inspire.ec.europa.eu/codelist/HydroNodeCategoryValue/boundary</ogc:Literal>
+      </ogc:PropertyIsEqualTo>
+    </ogc:Filter>
+    <se:PointSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>net:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Graphic>
+        <se:Mark>
+          <se:WellKnownName>circle</se:WellKnownName>
+          <se:Fill>
+            <se:SvgParameter name="fill">#FF0000</se:SvgParameter>
+          </se:Fill>
+          <se:Stroke>
+            <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+          </se:Stroke>
+        </se:Mark>
+        <se:Size>3</se:Size>
+      </se:Graphic>
+    </se:PointSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/feature-styles/HY_N_WatercourseLink_v5_0.se
+++ b/feature-styles/HY_N_WatercourseLink_v5_0.se
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<se:FeatureTypeStyle xmlns:hy-n="http://inspire.ec.europa.eu/schemas/hy-n/4.0" 
-xmlns:net="http://inspire.ec.europa.eu/schemas/net/4.0" xmlns:ogc="http://www.opengis.net/ogc" 
+<se:FeatureTypeStyle xmlns:hy-n="http://inspire.ec.europa.eu/schemas/hy-n/5.0" 
+xmlns:net="http://inspire.ec.europa.eu/schemas/net/5.0" xmlns:ogc="http://www.opengis.net/ogc" 
 xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:xlink="http://www.w3.org/1999/xlink" 
 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd"

--- a/feature-styles/HY_N_WatercourseLink_v5_0.se
+++ b/feature-styles/HY_N_WatercourseLink_v5_0.se
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:hy-n="http://inspire.ec.europa.eu/schemas/hy-n/4.0" 
+xmlns:net="http://inspire.ec.europa.eu/schemas/net/4.0" xmlns:ogc="http://www.opengis.net/ogc" 
+xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:xlink="http://www.w3.org/1999/xlink" 
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd"
+version="1.1.0">
+  <se:Name>HY.Network.Default</se:Name>
+  <se:Description>
+    <se:Title>Hydrographic Network Default Style</se:Title>
+    <se:Abstract>Hydrographic network where the hydro node category depends to outlet, junction and source is rendered by solid blue (#33CCFF) lines with stroke width of 1 pixel and 3 pixel size filled light blue (#CCFFFF) circles with black (#000000) border. Hydrographic network where the hydro node category depends to flow constriction and regulation is rendered by 3 pixel size filled black circles (#000000). Hydrographic network where the hydro node category depends to boundary is rendered by 3 pixel size filled red circles (#FF0000) with black (#000000) border.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>hy-n:WatercourseLink</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Watercourse link</se:Title>
+    </se:Description>
+    <se:LineSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>net:centrelineGeometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#33CCFF</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+      </se:Stroke>
+    </se:LineSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/feature-styles/HY_P_Crossing_v5_0.se
+++ b/feature-styles/HY_P_Crossing_v5_0.se
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:hy-p="http://inspire.ec.europa.eu/schemas/hy-p/4.0" 
+xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" 
+xmlns:sld="http://www.opengis.net/sld" xmlns:xlink="http://www.w3.org/1999/xlink" 
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd"
+version="1.1.0">
+  <se:Name>HY.PhysicalWaters.ManMadeObject.Default</se:Name>
+  <se:Description>
+    <se:Title>Man-Made Objects Default Style</se:Title>
+    <se:Abstract>There are only depicted the fully functional objects. Punctual objects are depicted with symbols; if the geometry is a curve they are depicted in solid or dashed lines with different stroke width and different colours depending on the feature type; if the geometry is a surface it will be a filled polygon of solid colour adding or not some marks, depending on the feature type. Point geometries of crossings are rendered as a 10 sized picture. Line geometries of crossings are rendered as a grey (#999999) line and a stroke-width of 2 pixel. Polygon geometries of crossings are rendered using a light grey (#CCCCCC) fill and a dark grey (#999999) outline with a stroke width of 2 pixel. Point geometries of dams or weirs are rendered as a 12 sized cross with a light grey (#666666) color. Line geometries of dams or weirs are rendered as a light grey (#666666) line and a stroke-width of 3 pixel. Polygon geometries of dams or weirs are rendered using a dark grey (#999999) fill and a light grey (#666666) outline with a stroke width of 3 pixel. Point geometries of shoreline constructions are rendered as a 10 sized triangle with a light grey (#666666) color. Line geometries of shoreline constructions are rendered as a light grey (#666666) line and a stroke-width of 2 pixel. Polygon geometries of shoreline constructions are rendered using a dark grey (#999999) fill and a light grey (#666666) outline with a stroke width of 2 pixel. Point geometries of fords are rendered as a 3 sized square with a light red (#FFCCCC) color and light blue (#CCFFFF) border and a 50% transparence. Line geometries of fords are rendered as a light red (#FFCCCC) line and a stroke-width of 1 pixel. Polygon geometries of fords are rendered using a light red (#FFCCCC) fill and a 50% transparence. Point geometries of locks are rendered as a 8 sized cross with a light grey (#666666) color. Line geometries of locks are rendered as a light grey (#666666) line and a stroke-width of 1 pixel. Polygon geometries of locks are rendered using a dark grey (#999999) fill and a light grey (#666666) outline with a stroke width of 2 pixel. </se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>hy-p:Crossing</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Crossing</se:Title>
+    </se:Description>
+    <ogc:Filter>
+      <ogc:And>
+        <ogc:PropertyIsEqualTo>
+          <ogc:PropertyName>hy-p:condition/@xlink:href</ogc:PropertyName>
+          <ogc:Literal>http://inspire.ec.europa.eu/codelist/ConditionOfFacilityValue/functional</ogc:Literal>
+        </ogc:PropertyIsEqualTo>
+        <ogc:PropertyIsEqualTo>
+          <ogc:PropertyName>hy-p:type/@xlink:href</ogc:PropertyName>
+          <ogc:Literal>http://inspire.ec.europa.eu/codelist/CrossingTypeValue/bridge</ogc:Literal>
+        </ogc:PropertyIsEqualTo>
+        <ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsPoint">
+        		<ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+      </ogc:And>
+    </ogc:Filter>
+    <se:PointSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Graphic>
+        <se:Mark>
+          <se:WellKnownName>square</se:WellKnownName>
+          <se:Fill>
+            <se:SvgParameter name="fill">#ffffff</se:SvgParameter>
+          </se:Fill>
+          <se:Stroke>
+            <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+            <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+          </se:Stroke>
+        </se:Mark>
+        <se:Size>10.0</se:Size>
+      </se:Graphic>
+    </se:PointSymbolizer>
+    </se:Rule>
+      <se:Rule>
+    <se:Description>
+      <se:Title>Crossing</se:Title>
+    </se:Description>
+    <ogc:Filter>
+      <ogc:And>
+        <ogc:PropertyIsEqualTo>
+          <ogc:PropertyName>hy-p:condition/@xlink:href</ogc:PropertyName>
+          <ogc:Literal>http://inspire.ec.europa.eu/codelist/ConditionOfFacilityValue/functional</ogc:Literal>
+        </ogc:PropertyIsEqualTo>
+        <ogc:PropertyIsEqualTo>
+          <ogc:PropertyName>hy-p:type/@xlink:href</ogc:PropertyName>
+          <ogc:Literal>http://inspire.ec.europa.eu/codelist/CrossingTypeValue/bridge</ogc:Literal>
+        </ogc:PropertyIsEqualTo>
+        <ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsCurve">
+        		<ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+      </ogc:And>
+    </ogc:Filter>
+    <se:LineSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#999999</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">2</se:SvgParameter>
+      </se:Stroke>
+    </se:LineSymbolizer>
+    </se:Rule>
+      <se:Rule>
+    <se:Description>
+      <se:Title>Crossing</se:Title>
+    </se:Description>
+    <ogc:Filter>
+      <ogc:And>
+        <ogc:PropertyIsEqualTo>
+          <ogc:PropertyName>hy-p:condition/@xlink:href</ogc:PropertyName>
+          <ogc:Literal>http://inspire.ec.europa.eu/codelist/ConditionOfFacilityValue/functional</ogc:Literal>
+        </ogc:PropertyIsEqualTo>
+        <ogc:PropertyIsEqualTo>
+          <ogc:PropertyName>hy-p:type/@xlink:href</ogc:PropertyName>
+          <ogc:Literal>http://inspire.ec.europa.eu/codelist/CrossingTypeValue/bridge</ogc:Literal>
+        </ogc:PropertyIsEqualTo>
+        <ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsSurface">
+        		<ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+      </ogc:And>
+    </ogc:Filter>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Fill>
+        <se:SvgParameter name="fill">#CCCCCC</se:SvgParameter>
+      </se:Fill>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#999999</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">2</se:SvgParameter>
+      </se:Stroke>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/feature-styles/HY_P_Crossing_v5_0.se
+++ b/feature-styles/HY_P_Crossing_v5_0.se
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<se:FeatureTypeStyle xmlns:hy-p="http://inspire.ec.europa.eu/schemas/hy-p/4.0" 
+<se:FeatureTypeStyle xmlns:hy-p="http://inspire.ec.europa.eu/schemas/hy-p/5.0" 
 xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" 
 xmlns:sld="http://www.opengis.net/sld" xmlns:xlink="http://www.w3.org/1999/xlink" 
 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 

--- a/feature-styles/HY_P_DamOrWeir_v5_0.se
+++ b/feature-styles/HY_P_DamOrWeir_v5_0.se
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:hy-p="http://inspire.ec.europa.eu/schemas/hy-p/4.0" 
+xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" 
+xmlns:sld="http://www.opengis.net/sld" xmlns:xlink="http://www.w3.org/1999/xlink" 
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd"
+version="1.1.0">
+  <se:Name>HY.PhysicalWaters.ManMadeObject.Default</se:Name>
+  <se:Description>
+    <se:Title>Man-Made Objects Default Style</se:Title>
+    <se:Abstract>There are only depicted the fully functional objects. Punctual objects are depicted with symbols; if the geometry is a curve they are depicted in solid or dashed lines with different stroke width and different colours depending on the feature type; if the geometry is a surface it will be a filled polygon of solid colour adding or not some marks, depending on the feature type. Point geometries of crossings are rendered as a 10 sized picture. Line geometries of crossings are rendered as a grey (#999999) line and a stroke-width of 2 pixel. Polygon geometries of crossings are rendered using a light grey (#CCCCCC) fill and a dark grey (#999999) outline with a stroke width of 2 pixel. Point geometries of dams or weirs are rendered as a 12 sized cross with a light grey (#666666) color. Line geometries of dams or weirs are rendered as a light grey (#666666) line and a stroke-width of 3 pixel. Polygon geometries of dams or weirs are rendered using a dark grey (#999999) fill and a light grey (#666666) outline with a stroke width of 3 pixel. Point geometries of shoreline constructions are rendered as a 10 sized triangle with a light grey (#666666) color. Line geometries of shoreline constructions are rendered as a light grey (#666666) line and a stroke-width of 2 pixel. Polygon geometries of shoreline constructions are rendered using a dark grey (#999999) fill and a light grey (#666666) outline with a stroke width of 2 pixel. Point geometries of fords are rendered as a 3 sized square with a light red (#FFCCCC) color and light blue (#CCFFFF) border and a 50% transparence. Line geometries of fords are rendered as a light red (#FFCCCC) line and a stroke-width of 1 pixel. Polygon geometries of fords are rendered using a light red (#FFCCCC) fill and a 50% transparence. Point geometries of locks are rendered as a 8 sized cross with a light grey (#666666) color. Line geometries of locks are rendered as a light grey (#666666) line and a stroke-width of 1 pixel. Polygon geometries of locks are rendered using a dark grey (#999999) fill and a light grey (#666666) outline with a stroke width of 2 pixel. </se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>hy-p:DamOrWeir</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Dam or weir</se:Title>
+    </se:Description>
+    <ogc:Filter>
+    <ogc:And>
+      <ogc:PropertyIsEqualTo>
+        <ogc:PropertyName>hy-p:condition/@xlink:href</ogc:PropertyName>
+        <ogc:Literal>http://inspire.ec.europa.eu/codelist/ConditionOfFacilityValue/functional</ogc:Literal>
+      </ogc:PropertyIsEqualTo>
+      <ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsPoint">
+        		<ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+      </ogc:And>
+    </ogc:Filter>
+    <se:PointSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Graphic>
+        <se:Mark>
+          <se:WellKnownName>X</se:WellKnownName>
+          <se:Fill>
+            <se:SvgParameter name="fill">#666666</se:SvgParameter>
+          </se:Fill>
+        </se:Mark>
+        <se:Size>12.0</se:Size>
+      </se:Graphic>
+    </se:PointSymbolizer>
+    </se:Rule>
+    <se:Rule>
+    <se:Description>
+      <se:Title>Dam or weir</se:Title>
+    </se:Description>
+    <ogc:Filter>
+    <ogc:And>
+      <ogc:PropertyIsEqualTo>
+        <ogc:PropertyName>hy-p:condition/@xlink:href</ogc:PropertyName>
+        <ogc:Literal>http://inspire.ec.europa.eu/codelist/ConditionOfFacilityValue/functional</ogc:Literal>
+      </ogc:PropertyIsEqualTo>
+      <ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsCurve">
+        		<ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+      </ogc:And>
+    </ogc:Filter>
+    <se:LineSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#666666</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">3</se:SvgParameter>
+      </se:Stroke>
+    </se:LineSymbolizer>
+    </se:Rule>
+    <se:Rule>
+    <se:Description>
+      <se:Title>Dam or weir</se:Title>
+    </se:Description>
+    <ogc:Filter>
+    <ogc:And>
+      <ogc:PropertyIsEqualTo>
+        <ogc:PropertyName>hy-p:condition/@xlink:href</ogc:PropertyName>
+        <ogc:Literal>http://inspire.ec.europa.eu/codelist/ConditionOfFacilityValue/functional</ogc:Literal>
+      </ogc:PropertyIsEqualTo>
+      <ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsSurface">
+        		<ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+      </ogc:And>
+    </ogc:Filter>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Fill>
+        <se:SvgParameter name="fill">#999999</se:SvgParameter>
+      </se:Fill>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#666666</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">3</se:SvgParameter>
+      </se:Stroke>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/feature-styles/HY_P_DamOrWeir_v5_0.se
+++ b/feature-styles/HY_P_DamOrWeir_v5_0.se
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<se:FeatureTypeStyle xmlns:hy-p="http://inspire.ec.europa.eu/schemas/hy-p/4.0" 
+<se:FeatureTypeStyle xmlns:hy-p="http://inspire.ec.europa.eu/schemas/hy-p/5.0" 
 xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" 
 xmlns:sld="http://www.opengis.net/sld" xmlns:xlink="http://www.w3.org/1999/xlink" 
 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 

--- a/feature-styles/HY_P_DrainageBasin_v5_0.se
+++ b/feature-styles/HY_P_DrainageBasin_v5_0.se
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:hy-p="http://inspire.ec.europa.eu/schemas/hy-p/4.0" 
+xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" 
+xmlns:sld="http://www.opengis.net/sld" xmlns:xlink="http://www.w3.org/1999/xlink" 
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd"
+version="1.1.0">
+  <se:Name>HY.PhysicalWaters.Catchments.Default</se:Name>
+  <se:Description>
+    <se:Title>Catchments Default Style</se:Title>
+    <se:Abstract>Drainage Basin areas are portrayed by no filled polygons with a solid blue (#0066FF) border with stroke width of 4 pixel the RiverBasin features and with stroke width of 2 pixel the DrainageBasin ones.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>hy-p:DrainageBasin</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Drainage basin</se:Title>
+    </se:Description>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#0066FF</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">2</se:SvgParameter>
+      </se:Stroke>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/feature-styles/HY_P_DrainageBasin_v5_0.se
+++ b/feature-styles/HY_P_DrainageBasin_v5_0.se
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<se:FeatureTypeStyle xmlns:hy-p="http://inspire.ec.europa.eu/schemas/hy-p/4.0" 
+<se:FeatureTypeStyle xmlns:hy-p="http://inspire.ec.europa.eu/schemas/hy-p/5.0" 
 xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" 
 xmlns:sld="http://www.opengis.net/sld" xmlns:xlink="http://www.w3.org/1999/xlink" 
 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 

--- a/feature-styles/HY_P_Falls_v5_0.se
+++ b/feature-styles/HY_P_Falls_v5_0.se
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:hy-p="http://inspire.ec.europa.eu/schemas/hy-p/4.0" 
+xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" 
+xmlns:sld="http://www.opengis.net/sld" xmlns:xlink="http://www.w3.org/1999/xlink" 
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd"
+version="1.1.0">
+  <se:Name>HY.PhysicalWaters.HydroPointOfInterest.Default</se:Name>
+  <se:Description>
+    <se:Title>Hydrographic Points Of Interest Default Style</se:Title>
+    <se:Abstract>Fluvial points as rapids or falls are depicted with symbols; if the geometry is a curve they are depicted in aligned blue (#0066FF) marks (stars for Falls and crosses for Rapids); if the geometry is a surface it will be an area with blue (#0066FF) marks (stars for Falls and crosses for Rapids).</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>hy-p:Falls</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Falls</se:Title>
+    </se:Description>
+  	<ogc:Filter>
+       <ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsPoint">
+        		<ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+    </ogc:Filter>
+    <se:PointSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Graphic>
+        <se:Mark>
+          <se:WellKnownName>star</se:WellKnownName>
+          <se:Fill>
+            <se:SvgParameter name="fill">#0066FF</se:SvgParameter>
+          </se:Fill>
+           <se:Stroke>
+            <se:SvgParameter name="stroke">#0066FF</se:SvgParameter>
+          </se:Stroke>
+        </se:Mark>
+        <se:Size>10.0</se:Size>
+      </se:Graphic>
+    </se:PointSymbolizer>
+    </se:Rule>
+    <se:Rule>
+    <se:Description>
+      <se:Title>Falls</se:Title>
+    </se:Description>
+  	<ogc:Filter>
+       <ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsCurve">
+        		<ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+    </ogc:Filter>
+    <se:LineSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Stroke>
+        <se:GraphicStroke>
+          <se:Graphic>
+            <se:Mark>
+              <se:WellKnownName>star</se:WellKnownName>
+              <se:Fill>
+                <se:SvgParameter name="fill">#0066FF</se:SvgParameter>
+              </se:Fill>
+              <se:Stroke>
+            	<se:SvgParameter name="stroke">#0066FF</se:SvgParameter>
+          	</se:Stroke>
+            </se:Mark>
+            <se:Size>5.0</se:Size>
+          </se:Graphic>
+        </se:GraphicStroke>
+      </se:Stroke>
+    </se:LineSymbolizer>
+    </se:Rule>
+    <se:Rule>
+    <se:Description>
+      <se:Title>Falls</se:Title>
+    </se:Description>
+  	<ogc:Filter>
+       <ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsSurface">
+        		<ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+    </ogc:Filter>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Fill>
+        <se:GraphicFill>
+          <se:Graphic>
+            <se:Mark>
+              <se:WellKnownName>star</se:WellKnownName>
+              <se:Fill>
+                <se:SvgParameter name="fill">#0066FF</se:SvgParameter>
+              </se:Fill>
+              <se:Stroke>
+            	<se:SvgParameter name="stroke">#0066FF</se:SvgParameter>
+          	</se:Stroke>
+            </se:Mark>
+            <se:Size>5.0</se:Size>
+          </se:Graphic>
+        </se:GraphicFill>
+      </se:Fill>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/feature-styles/HY_P_Falls_v5_0.se
+++ b/feature-styles/HY_P_Falls_v5_0.se
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<se:FeatureTypeStyle xmlns:hy-p="http://inspire.ec.europa.eu/schemas/hy-p/4.0" 
+<se:FeatureTypeStyle xmlns:hy-p="http://inspire.ec.europa.eu/schemas/hy-p/5.0" 
 xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" 
 xmlns:sld="http://www.opengis.net/sld" xmlns:xlink="http://www.w3.org/1999/xlink" 
 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 

--- a/feature-styles/HY_P_Ford_v5_0.se
+++ b/feature-styles/HY_P_Ford_v5_0.se
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<se:FeatureTypeStyle xmlns:hy-p="http://inspire.ec.europa.eu/schemas/hy-p/4.0" 
+<se:FeatureTypeStyle xmlns:hy-p="http://inspire.ec.europa.eu/schemas/hy-p/5.0" 
 xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" 
 xmlns:sld="http://www.opengis.net/sld" xmlns:xlink="http://www.w3.org/1999/xlink" 
 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 

--- a/feature-styles/HY_P_Ford_v5_0.se
+++ b/feature-styles/HY_P_Ford_v5_0.se
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:hy-p="http://inspire.ec.europa.eu/schemas/hy-p/4.0" 
+xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" 
+xmlns:sld="http://www.opengis.net/sld" xmlns:xlink="http://www.w3.org/1999/xlink" 
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd"
+version="1.1.0">
+  <se:Name>HY.PhysicalWaters.ManMadeObject.Default</se:Name>
+  <se:Description>
+    <se:Title>Man-Made Objects Default Style</se:Title>
+    <se:Abstract>There are only depicted the fully functional objects. Punctual objects are depicted with symbols; if the geometry is a curve they are depicted in solid or dashed lines with different stroke width and different colours depending on the feature type; if the geometry is a surface it will be a filled polygon of solid colour adding or not some marks, depending on the feature type. Point geometries of crossings are rendered as a 10 sized picture. Line geometries of crossings are rendered as a grey (#999999) line and a stroke-width of 2 pixel. Polygon geometries of crossings are rendered using a light grey (#CCCCCC) fill and a dark grey (#999999) outline with a stroke width of 2 pixel. Point geometries of dams or weirs are rendered as a 12 sized cross with a light grey (#666666) color. Line geometries of dams or weirs are rendered as a light grey (#666666) line and a stroke-width of 3 pixel. Polygon geometries of dams or weirs are rendered using a dark grey (#999999) fill and a light grey (#666666) outline with a stroke width of 3 pixel. Point geometries of shoreline constructions are rendered as a 10 sized triangle with a light grey (#666666) color. Line geometries of shoreline constructions are rendered as a light grey (#666666) line and a stroke-width of 2 pixel. Polygon geometries of shoreline constructions are rendered using a dark grey (#999999) fill and a light grey (#666666) outline with a stroke width of 2 pixel. Point geometries of fords are rendered as a 3 sized square with a light red (#FFCCCC) color and light blue (#CCFFFF) border and a 50% transparence. Line geometries of fords are rendered as a light red (#FFCCCC) line and a stroke-width of 1 pixel. Polygon geometries of fords are rendered using a light red (#FFCCCC) fill and a 50% transparence. Point geometries of locks are rendered as a 8 sized cross with a light grey (#666666) color. Line geometries of locks are rendered as a light grey (#666666) line and a stroke-width of 1 pixel. Polygon geometries of locks are rendered using a dark grey (#999999) fill and a light grey (#666666) outline with a stroke width of 2 pixel. </se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>hy-p:Ford</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Ford</se:Title>
+    </se:Description>
+    <ogc:Filter>
+    <ogc:And>
+      <ogc:PropertyIsEqualTo>
+        <ogc:PropertyName>hy-p:condition/@xlink:href</ogc:PropertyName>
+        <ogc:Literal>http://inspire.ec.europa.eu/codelist/ConditionOfFacilityValue/functional</ogc:Literal>
+      </ogc:PropertyIsEqualTo>
+       <ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsPoint">
+        		<ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+    </ogc:And>
+    </ogc:Filter>
+    <se:PointSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Graphic>
+        <se:Mark>
+          <se:WellKnownName>square</se:WellKnownName>
+          <se:Fill>
+            <se:SvgParameter name="fill">#FFCCCC</se:SvgParameter>
+          </se:Fill>
+          <se:Stroke>
+            <se:SvgParameter name="stroke">#CCFFFF</se:SvgParameter>
+          </se:Stroke>
+        </se:Mark>
+        <se:Opacity>0.5</se:Opacity>
+        <se:Size>3</se:Size>
+      </se:Graphic>
+    </se:PointSymbolizer>
+    </se:Rule>
+    <se:Rule>
+    <se:Description>
+      <se:Title>Ford</se:Title>
+    </se:Description>
+    <ogc:Filter>
+    <ogc:And>
+      <ogc:PropertyIsEqualTo>
+        <ogc:PropertyName>hy-p:condition/@xlink:href</ogc:PropertyName>
+        <ogc:Literal>http://inspire.ec.europa.eu/codelist/ConditionOfFacilityValue/functional</ogc:Literal>
+      </ogc:PropertyIsEqualTo>
+       <ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsCurve">
+        		<ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+    </ogc:And>
+    </ogc:Filter>
+    <se:LineSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#FFCCCC</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+      </se:Stroke>
+    </se:LineSymbolizer>
+    </se:Rule>
+    <se:Rule>
+    <se:Description>
+      <se:Title>Ford</se:Title>
+    </se:Description>
+    <ogc:Filter>
+    <ogc:And>
+      <ogc:PropertyIsEqualTo>
+        <ogc:PropertyName>hy-p:condition/@xlink:href</ogc:PropertyName>
+        <ogc:Literal>http://inspire.ec.europa.eu/codelist/ConditionOfFacilityValue/functional</ogc:Literal>
+      </ogc:PropertyIsEqualTo>
+       <ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsSurface">
+        		<ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+    </ogc:And>
+    </ogc:Filter>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Fill>
+        <se:SvgParameter name="fill">#FFCCCC</se:SvgParameter>
+        <se:SvgParameter name="fill-opacity">0.5</se:SvgParameter>
+      </se:Fill>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/feature-styles/HY_P_LandWaterBoundary_v5_0.se
+++ b/feature-styles/HY_P_LandWaterBoundary_v5_0.se
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:hy-p="http://inspire.ec.europa.eu/schemas/hy-p/4.0" 
+xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" 
+xmlns:sld="http://www.opengis.net/sld" xmlns:xlink="http://www.w3.org/1999/xlink" 
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd"
+version="1.1.0">
+  <se:Name>HY.PhysicalWaters.LandWaterBoundary.Default</se:Name>
+  <se:Description>
+    <se:Title>Land Water Boundary Well-Defined Style</se:Title>
+    <se:Abstract>The contact line between a land mass and a water body is portrayed by a solid blue (#33CCFF) line with stroke width of 1 pixel.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>hy-p:LandWaterBoundary</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Land water boundary</se:Title>
+    </se:Description>
+    <ogc:Filter>
+    	 <ogc:PropertyIsEqualTo>
+        <ogc:PropertyName>hy-p:origin</ogc:PropertyName>
+        <ogc:Literal>natural</ogc:Literal>
+      </ogc:PropertyIsEqualTo>
+    </ogc:Filter>
+    <se:LineSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#33CCFF</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+      </se:Stroke>
+    </se:LineSymbolizer>
+  </se:Rule>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Land water boundary</se:Title>
+    </se:Description>
+    <ogc:Filter>
+    	 <ogc:PropertyIsEqualTo>
+        <ogc:PropertyName>hy-p:origin</ogc:PropertyName>
+        <ogc:Literal>manMade</ogc:Literal>
+      </ogc:PropertyIsEqualTo>
+    </ogc:Filter>
+    <se:LineSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+      </se:Stroke>
+    </se:LineSymbolizer>
+  </se:Rule>
+  
+</se:FeatureTypeStyle>

--- a/feature-styles/HY_P_LandWaterBoundary_v5_0.se
+++ b/feature-styles/HY_P_LandWaterBoundary_v5_0.se
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<se:FeatureTypeStyle xmlns:hy-p="http://inspire.ec.europa.eu/schemas/hy-p/4.0" 
+<se:FeatureTypeStyle xmlns:hy-p="http://inspire.ec.europa.eu/schemas/hy-p/5.0" 
 xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" 
 xmlns:sld="http://www.opengis.net/sld" xmlns:xlink="http://www.w3.org/1999/xlink" 
 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 

--- a/feature-styles/HY_P_Lock_v5_0.se
+++ b/feature-styles/HY_P_Lock_v5_0.se
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<se:FeatureTypeStyle xmlns:hy-p="http://inspire.ec.europa.eu/schemas/hy-p/4.0" xmlns:ogc="http://www.opengis.net/ogc" 
+<se:FeatureTypeStyle xmlns:hy-p="http://inspire.ec.europa.eu/schemas/hy-p/5.0" xmlns:ogc="http://www.opengis.net/ogc" 
 xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" 
 xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd"

--- a/feature-styles/HY_P_Lock_v5_0.se
+++ b/feature-styles/HY_P_Lock_v5_0.se
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:hy-p="http://inspire.ec.europa.eu/schemas/hy-p/4.0" xmlns:ogc="http://www.opengis.net/ogc" 
+xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" 
+xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd"
+version="1.1.0">
+  <se:Name>HY.PhysicalWaters.ManMadeObject.Default</se:Name>
+  <se:Description>
+    <se:Title>Man-Made Objects Default Style</se:Title>
+    <se:Abstract>There are only depicted the fully functional objects. Punctual objects are depicted with symbols; if the geometry is a curve they are depicted in solid or dashed lines with different stroke width and different colours depending on the feature type; if the geometry is a surface it will be a filled polygon of solid colour adding or not some marks, depending on the feature type. Point geometries of crossings are rendered as a 10 sized picture. Line geometries of crossings are rendered as a grey (#999999) line and a stroke-width of 2 pixel. Polygon geometries of crossings are rendered using a light grey (#CCCCCC) fill and a dark grey (#999999) outline with a stroke width of 2 pixel. Point geometries of dams or weirs are rendered as a 12 sized cross with a light grey (#666666) color. Line geometries of dams or weirs are rendered as a light grey (#666666) line and a stroke-width of 3 pixel. Polygon geometries of dams or weirs are rendered using a dark grey (#999999) fill and a light grey (#666666) outline with a stroke width of 3 pixel. Point geometries of shoreline constructions are rendered as a 10 sized triangle with a light grey (#666666) color. Line geometries of shoreline constructions are rendered as a light grey (#666666) line and a stroke-width of 2 pixel. Polygon geometries of shoreline constructions are rendered using a dark grey (#999999) fill and a light grey (#666666) outline with a stroke width of 2 pixel. Point geometries of fords are rendered as a 3 sized square with a light red (#FFCCCC) color and light blue (#CCFFFF) border and a 50% transparence. Line geometries of fords are rendered as a light red (#FFCCCC) line and a stroke-width of 1 pixel. Polygon geometries of fords are rendered using a light red (#FFCCCC) fill and a 50% transparence. Point geometries of locks are rendered as a 8 sized cross with a light grey (#666666) color. Line geometries of locks are rendered as a light grey (#666666) line and a stroke-width of 1 pixel. Polygon geometries of locks are rendered using a dark grey (#999999) fill and a light grey (#666666) outline with a stroke width of 2 pixel. </se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>hy-p:Lock</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Lock</se:Title>
+    </se:Description>
+    <ogc:Filter>
+    <ogc:And>
+      <ogc:PropertyIsEqualTo>
+        <ogc:PropertyName>hy-p:condition/@xlink:href</ogc:PropertyName>
+        <ogc:Literal>http://inspire.ec.europa.eu/codelist/ConditionOfFacilityValue/functional</ogc:Literal>
+      </ogc:PropertyIsEqualTo>
+      <ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsPoint">
+        		<ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+     </ogc:And>
+    </ogc:Filter>
+    <se:PointSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Graphic>
+        <se:Mark>
+          <se:WellKnownName>X</se:WellKnownName>
+          <se:Fill>
+            <se:SvgParameter name="fill">#666666</se:SvgParameter>
+          </se:Fill>
+        </se:Mark>
+        <se:Size>8</se:Size>
+      </se:Graphic>
+    </se:PointSymbolizer>
+    </se:Rule>
+    <se:Rule>
+    <se:Description>
+      <se:Title>Lock</se:Title>
+    </se:Description>
+    <ogc:Filter>
+    <ogc:And>
+      <ogc:PropertyIsEqualTo>
+        <ogc:PropertyName>hy-p:condition/@xlink:href</ogc:PropertyName>
+        <ogc:Literal>http://inspire.ec.europa.eu/codelist/ConditionOfFacilityValue/functional</ogc:Literal>
+      </ogc:PropertyIsEqualTo>
+      <ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsCurve">
+        		<ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+     </ogc:And>
+    </ogc:Filter>
+    <se:LineSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#666666</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+      </se:Stroke>
+    </se:LineSymbolizer>
+    </se:Rule>
+    <se:Rule>
+    <se:Description>
+      <se:Title>Lock</se:Title>
+    </se:Description>
+    <ogc:Filter>
+    <ogc:And>
+      <ogc:PropertyIsEqualTo>
+        <ogc:PropertyName>hy-p:condition/@xlink:href</ogc:PropertyName>
+        <ogc:Literal>http://inspire.ec.europa.eu/codelist/ConditionOfFacilityValue/functional</ogc:Literal>
+      </ogc:PropertyIsEqualTo>
+      <ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsSurface">
+        		<ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+     </ogc:And>
+    </ogc:Filter>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Fill>
+        <se:SvgParameter name="fill">#999999</se:SvgParameter>
+      </se:Fill>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#666666</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+      </se:Stroke>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/feature-styles/HY_P_Rapids_v5_0.se
+++ b/feature-styles/HY_P_Rapids_v5_0.se
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<se:FeatureTypeStyle xmlns:hy-p="http://inspire.ec.europa.eu/schemas/hy-p/4.0" xmlns:ogc="http://www.opengis.net/ogc" 
+<se:FeatureTypeStyle xmlns:hy-p="http://inspire.ec.europa.eu/schemas/hy-p/5.0" xmlns:ogc="http://www.opengis.net/ogc" 
 xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:xlink="http://www.w3.org/1999/xlink" 
 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd"

--- a/feature-styles/HY_P_Rapids_v5_0.se
+++ b/feature-styles/HY_P_Rapids_v5_0.se
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:hy-p="http://inspire.ec.europa.eu/schemas/hy-p/4.0" xmlns:ogc="http://www.opengis.net/ogc" 
+xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:xlink="http://www.w3.org/1999/xlink" 
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd"
+version="1.1.0">
+  <se:Name>HY.PhysicalWaters.HydroPointOfInterest.Default</se:Name>
+  <se:Description>
+    <se:Title>Hydrographic Points Of Interest Default Style</se:Title>
+    <se:Abstract>Fluvial points as rapids or falls are depicted with symbols; if the geometry is a curve they are depicted in aligned blue (#0066FF) 
+    marks (stars for Falls and crosses for Rapids); if the geometry is a surface it will be an area with blue (#0066FF) marks (stars for Falls and 
+    crosses for Rapids).</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>hy-p:Rapids</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Rapids</se:Title>
+    </se:Description>
+  	<ogc:Filter>
+       <ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsPoint">
+        		<ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+    </ogc:Filter>
+    <se:PointSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Graphic>
+        <se:Mark>
+          <se:WellKnownName>cross</se:WellKnownName>
+          <se:Fill>
+            <se:SvgParameter name="fill">#0066FF</se:SvgParameter>
+          </se:Fill>
+          <se:Stroke>
+            <se:SvgParameter name="stroke">#0066FF</se:SvgParameter>
+          </se:Stroke>
+        </se:Mark>
+        <se:Size>10.0</se:Size>
+      </se:Graphic>
+    </se:PointSymbolizer>
+    </se:Rule>
+    <se:Rule>
+    <se:Description>
+      <se:Title>Rapids</se:Title>
+    </se:Description>
+  	<ogc:Filter>
+       <ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsCurve">
+        		<ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+    </ogc:Filter>
+    <se:LineSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Stroke>
+        <se:GraphicStroke>
+          <se:Graphic>
+            <se:Mark>
+              <se:WellKnownName>cross</se:WellKnownName>
+              <se:Fill>
+                <se:SvgParameter name="fill">#0066FF</se:SvgParameter>
+              </se:Fill>
+              <se:Stroke>
+            <se:SvgParameter name="stroke">#0066FF</se:SvgParameter>
+          	</se:Stroke>
+            </se:Mark>
+            <se:Size>5.0</se:Size>
+          </se:Graphic>
+        </se:GraphicStroke>
+      </se:Stroke>
+    </se:LineSymbolizer>
+    </se:Rule>
+    <se:Rule>
+    <se:Description>
+      <se:Title>Rapids</se:Title>
+    </se:Description>
+  	<ogc:Filter>
+       <ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsSurface">
+        		<ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+    </ogc:Filter>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Fill>
+        <se:GraphicFill>
+          <se:Graphic>
+            <se:Mark>
+              <se:WellKnownName>cross</se:WellKnownName>
+              <se:Fill>
+                <se:SvgParameter name="fill">#0066FF</se:SvgParameter>
+              </se:Fill>
+              <se:Stroke>
+            	<se:SvgParameter name="stroke">#0066FF</se:SvgParameter>
+          	 </se:Stroke>
+            </se:Mark>
+            <se:Size>5.0</se:Size>
+          </se:Graphic>
+        </se:GraphicFill>
+      </se:Fill>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/feature-styles/HY_P_RiverBasin_v5_0.se
+++ b/feature-styles/HY_P_RiverBasin_v5_0.se
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:hy-p="http://inspire.ec.europa.eu/schemas/hy-p/4.0" xmlns:ogc="http://www.opengis.net/ogc" 
+xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:xlink="http://www.w3.org/1999/xlink" 
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd"
+version="1.1.0">
+  <se:Name>HY.PhysicalWaters.Catchments.Default</se:Name>
+  <se:Description>
+    <se:Title>Catchments Default Style</se:Title>
+    <se:Abstract>Drainage Basin areas are portrayed by no filled polygons with a solid blue (#0066FF) border with stroke width of 4 pixel the RiverBasin features and with stroke width of 2 pixel the DrainageBasin ones.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>hy-p:RiverBasin</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>River basin</se:Title>
+    </se:Description>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#0066FF</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">4</se:SvgParameter>
+      </se:Stroke>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/feature-styles/HY_P_RiverBasin_v5_0.se
+++ b/feature-styles/HY_P_RiverBasin_v5_0.se
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<se:FeatureTypeStyle xmlns:hy-p="http://inspire.ec.europa.eu/schemas/hy-p/4.0" xmlns:ogc="http://www.opengis.net/ogc" 
+<se:FeatureTypeStyle xmlns:hy-p="http://inspire.ec.europa.eu/schemas/hy-p/5.0" xmlns:ogc="http://www.opengis.net/ogc" 
 xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:xlink="http://www.w3.org/1999/xlink" 
 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd"

--- a/feature-styles/HY_P_ShoreLineConstruction_v5_0.se
+++ b/feature-styles/HY_P_ShoreLineConstruction_v5_0.se
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:hy-p="http://inspire.ec.europa.eu/schemas/hy-p/4.0" 
+xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" 
+xmlns:sld="http://www.opengis.net/sld" xmlns:xlink="http://www.w3.org/1999/xlink" 
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd"
+version="1.1.0">
+  <se:Name>HY.PhysicalWaters.ManMadeObject.Default</se:Name>
+  <se:Description>
+    <se:Title>Man-Made Objects Default Style</se:Title>
+    <se:Abstract>There are only depicted the fully functional objects. Punctual objects are depicted with symbols; if the geometry is a curve they are depicted in solid or dashed lines with different stroke width and different colours depending on the feature type; if the geometry is a surface it will be a filled polygon of solid colour adding or not some marks, depending on the feature type. Point geometries of crossings are rendered as a 10 sized picture. Line geometries of crossings are rendered as a grey (#999999) line and a stroke-width of 2 pixel. Polygon geometries of crossings are rendered using a light grey (#CCCCCC) fill and a dark grey (#999999) outline with a stroke width of 2 pixel. Point geometries of dams or weirs are rendered as a 12 sized cross with a light grey (#666666) color. Line geometries of dams or weirs are rendered as a light grey (#666666) line and a stroke-width of 3 pixel. Polygon geometries of dams or weirs are rendered using a dark grey (#999999) fill and a light grey (#666666) outline with a stroke width of 3 pixel. Point geometries of shoreline constructions are rendered as a 10 sized triangle with a light grey (#666666) color. Line geometries of shoreline constructions are rendered as a light grey (#666666) line and a stroke-width of 2 pixel. Polygon geometries of shoreline constructions are rendered using a dark grey (#999999) fill and a light grey (#666666) outline with a stroke width of 2 pixel. Point geometries of fords are rendered as a 3 sized square with a light red (#FFCCCC) color and light blue (#CCFFFF) border and a 50% transparence. Line geometries of fords are rendered as a light red (#FFCCCC) line and a stroke-width of 1 pixel. Polygon geometries of fords are rendered using a light red (#FFCCCC) fill and a 50% transparence. Point geometries of locks are rendered as a 8 sized cross with a light grey (#666666) color. Line geometries of locks are rendered as a light grey (#666666) line and a stroke-width of 1 pixel. Polygon geometries of locks are rendered using a dark grey (#999999) fill and a light grey (#666666) outline with a stroke width of 2 pixel. </se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>hy-p:ShorelineConstruction</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Shoreline construction</se:Title>
+    </se:Description>
+    <ogc:Filter>
+    <ogc:And>
+      <ogc:PropertyIsEqualTo>
+        <ogc:PropertyName>hy-p:condition/@xlink:href</ogc:PropertyName>
+        <ogc:Literal>http://inspire.ec.europa.eu/codelist/ConditionOfFacilityValue/functional</ogc:Literal>
+      </ogc:PropertyIsEqualTo>
+      <ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsPoint">
+        		<ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+    </ogc:And>
+    </ogc:Filter>
+    <se:PointSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Graphic>
+        <se:Mark>
+          <se:WellKnownName>triangle</se:WellKnownName>
+          <se:Fill>
+            <se:SvgParameter name="fill">#666666</se:SvgParameter>
+          </se:Fill>
+        </se:Mark>
+        <se:Size>10</se:Size>
+      </se:Graphic>
+    </se:PointSymbolizer>
+    </se:Rule>
+    <se:Rule>
+    <se:Description>
+      <se:Title>Shoreline construction</se:Title>
+    </se:Description>
+    <ogc:Filter>
+    <ogc:And>
+      <ogc:PropertyIsEqualTo>
+        <ogc:PropertyName>hy-p:condition/@xlink:href</ogc:PropertyName>
+        <ogc:Literal>http://inspire.ec.europa.eu/codelist/ConditionOfFacilityValue/functional</ogc:Literal>
+      </ogc:PropertyIsEqualTo>
+      <ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsCurve">
+        		<ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+    </ogc:And>
+    </ogc:Filter>
+    <se:LineSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#666666</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">2</se:SvgParameter>
+      </se:Stroke>
+    </se:LineSymbolizer>
+    </se:Rule>
+    <se:Rule>
+    <se:Description>
+      <se:Title>Shoreline construction</se:Title>
+    </se:Description>
+    <ogc:Filter>
+    <ogc:And>
+      <ogc:PropertyIsEqualTo>
+        <ogc:PropertyName>hy-p:condition/@xlink:href</ogc:PropertyName>
+        <ogc:Literal>http://inspire.ec.europa.eu/codelist/ConditionOfFacilityValue/functional</ogc:Literal>
+      </ogc:PropertyIsEqualTo>
+      <ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsSurface">
+        		<ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+    </ogc:And>
+    </ogc:Filter>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Fill>
+        <se:SvgParameter name="fill">#999999</se:SvgParameter>
+      </se:Fill>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#666666</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">2</se:SvgParameter>
+      </se:Stroke>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/feature-styles/HY_P_ShoreLineConstruction_v5_0.se
+++ b/feature-styles/HY_P_ShoreLineConstruction_v5_0.se
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<se:FeatureTypeStyle xmlns:hy-p="http://inspire.ec.europa.eu/schemas/hy-p/4.0" 
+<se:FeatureTypeStyle xmlns:hy-p="http://inspire.ec.europa.eu/schemas/hy-p/5.0" 
 xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" 
 xmlns:sld="http://www.opengis.net/sld" xmlns:xlink="http://www.w3.org/1999/xlink" 
 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 

--- a/feature-styles/HY_P_Shore_v5_0.se
+++ b/feature-styles/HY_P_Shore_v5_0.se
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:hy-p="http://inspire.ec.europa.eu/schemas/hy-p/4.0" xmlns:ogc="http://www.opengis.net/ogc" 
+xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" 
+xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd"
+version="1.1.0">
+  <se:Name>HY.PhysicalWaters.Shore.Default</se:Name>
+  <se:Description>
+    <se:Title>Shore Default Style</se:Title>
+    <se:Abstract>Shore areas are portrayed as pale yellow (#FFFFCC) surfaces.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>hy-p:Shore</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Shore</se:Title>
+    </se:Description>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Fill>
+        <se:SvgParameter name="fill">#FFFFCC</se:SvgParameter>
+      </se:Fill>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/feature-styles/HY_P_Shore_v5_0.se
+++ b/feature-styles/HY_P_Shore_v5_0.se
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<se:FeatureTypeStyle xmlns:hy-p="http://inspire.ec.europa.eu/schemas/hy-p/4.0" xmlns:ogc="http://www.opengis.net/ogc" 
+<se:FeatureTypeStyle xmlns:hy-p="http://inspire.ec.europa.eu/schemas/hy-p/5.0" xmlns:ogc="http://www.opengis.net/ogc" 
 xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" 
 xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd"

--- a/feature-styles/HY_P_StandingWater_ManMade_v5_0.se
+++ b/feature-styles/HY_P_StandingWater_ManMade_v5_0.se
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:hy-p="http://inspire.ec.europa.eu/schemas/hy-p/4.0" 
+xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" 
+xmlns:sld="http://www.opengis.net/sld" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd" 
+version="1.1.0">
+  <se:Name>HY.PhysicalWaters.Waterbodies.Man.Made</se:Name>
+  <se:Description>
+    <se:Title>Waterbodies Man-Made Default Style</se:Title>
+    <se:Abstract>Physical waters as watercourses or standing water are depicted taking into account if they are natural or man-made. Natural water bodies are depicted using a light blue (#CCFFFF) filled polygon and a solid blue (#33CCFF) border with stroke width of 1 pixel.Man-made water bodies are depicted using a light blue (#CCFFFF) filled polygon and a solid blue (#0066FF) border with stroke width of 1 pixel.Natural standing waters are rendered by 6 pixel size filled blue circles (#0066FF) on a light blue (#CCFFFF) filled polygon.Man-made standing waters are rendered by 6 pixel size filled blue circles (#0066FF) with a black (?) (#0000) border on a light blue (#0000) filled polygon with a black (?) (#0000) border and a stroke width of 1 pixel.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>hy-p:StandingWater</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Standing waters natural: points</se:Title>
+    </se:Description>
+    <ogc:Filter>
+    <ogc:And>
+      <ogc:PropertyIsEqualTo>
+        <ogc:PropertyName>hy-p:origin</ogc:PropertyName>
+        <ogc:Literal>natural</ogc:Literal>
+      </ogc:PropertyIsEqualTo>
+      <ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsPoint">
+        		<ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+      </ogc:And>
+    </ogc:Filter>
+    <se:PointSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Graphic>
+        <se:Mark>
+          <se:WellKnownName>circle</se:WellKnownName>
+          <se:Fill>
+            <se:SvgParameter name="fill">#0066FF</se:SvgParameter>
+          </se:Fill>
+          <se:Stroke>
+            <se:SvgParameter name="stroke">#0066FF</se:SvgParameter>
+          </se:Stroke>
+        </se:Mark>
+        <se:Size>6</se:Size>
+      </se:Graphic>
+    </se:PointSymbolizer>
+    </se:Rule>
+    <se:Rule>
+    <se:Description>
+      <se:Title>Standing waters natural: polygons</se:Title>
+    </se:Description>
+    <ogc:Filter>
+    <ogc:And>
+      <ogc:PropertyIsEqualTo>
+        <ogc:PropertyName>hy-p:origin</ogc:PropertyName>
+        <ogc:Literal>natural</ogc:Literal>
+      </ogc:PropertyIsEqualTo>
+      <ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsSurface">
+        		<ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+      </ogc:And>
+    </ogc:Filter>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Fill>
+        <se:SvgParameter name="fill">#CCFFFF</se:SvgParameter>
+      </se:Fill>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Standing waters man-made: points</se:Title>
+    </se:Description>
+    <ogc:Filter>
+    <ogc:And>
+      <ogc:PropertyIsEqualTo>
+        <ogc:PropertyName>hy-p:origin</ogc:PropertyName>
+        <ogc:Literal>manMade</ogc:Literal>
+      </ogc:PropertyIsEqualTo>
+      <ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsPoint">
+        		<ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+      </ogc:And>
+    </ogc:Filter>
+    <se:PointSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Graphic>
+        <se:Mark>
+          <se:WellKnownName>circle</se:WellKnownName>
+          <se:Fill>
+            <se:SvgParameter name="fill">#0066FF</se:SvgParameter>
+          </se:Fill>
+          <se:Stroke>
+            <se:SvgParameter name="stroke">#0000</se:SvgParameter>
+          </se:Stroke>
+        </se:Mark>
+        <se:Size>6</se:Size>
+      </se:Graphic>
+    </se:PointSymbolizer>
+    </se:Rule>
+    <se:Rule>
+       <se:Description>
+      <se:Title>Standing waters man-made: polygons</se:Title>
+    </se:Description>
+        <ogc:Filter>
+    <ogc:And>
+      <ogc:PropertyIsEqualTo>
+        <ogc:PropertyName>hy-p:origin</ogc:PropertyName>
+        <ogc:Literal>manMade</ogc:Literal>
+      </ogc:PropertyIsEqualTo>
+      <ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsSurface">
+        		<ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+      </ogc:And>
+    </ogc:Filter>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Fill>
+        <se:SvgParameter name="fill">#CCFFFF</se:SvgParameter>
+      </se:Fill>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#0000</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+      </se:Stroke>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/feature-styles/HY_P_StandingWater_ManMade_v5_0.se
+++ b/feature-styles/HY_P_StandingWater_ManMade_v5_0.se
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<se:FeatureTypeStyle xmlns:hy-p="http://inspire.ec.europa.eu/schemas/hy-p/4.0" 
+<se:FeatureTypeStyle xmlns:hy-p="http://inspire.ec.europa.eu/schemas/hy-p/5.0" 
 xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" 
 xmlns:sld="http://www.opengis.net/sld" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd" 

--- a/feature-styles/HY_P_StandingWater_v5_0.se
+++ b/feature-styles/HY_P_StandingWater_v5_0.se
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<se:FeatureTypeStyle xmlns:hy-p="http://inspire.ec.europa.eu/schemas/hy-p/4.0" xmlns:ogc="http://www.opengis.net/ogc" 
+<se:FeatureTypeStyle xmlns:hy-p="http://inspire.ec.europa.eu/schemas/hy-p/5.0" xmlns:ogc="http://www.opengis.net/ogc" 
 xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" 
 xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd" 

--- a/feature-styles/HY_P_StandingWater_v5_0.se
+++ b/feature-styles/HY_P_StandingWater_v5_0.se
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:hy-p="http://inspire.ec.europa.eu/schemas/hy-p/4.0" xmlns:ogc="http://www.opengis.net/ogc" 
+xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" 
+xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd" 
+version="1.1.0">
+  <se:Name>HY.PhysicalWaters.Waterbodies.Default</se:Name>
+  <se:Description>
+    <se:Title>Waterbodies Default Style</se:Title>
+    <se:Abstract>Physical waters as watercourses or standing water can be portrayed with different geometries depending on its dimensions and the level of detail or resolution. Lineal watercourses are depicted by solid blue (#33CCFF) lines with stroke width of 1 pixel and the superficial ones are depicted by filled blue light polygons (#CCFFFF) without border. Punctual standing waters are depicted by dark blue (#0066FF) circles with size of 6 pixel and the superficial ones are depicted by filled blue light polygons (#CCFFFF) without border.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>hy-p:StandingWater</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Standing water</se:Title>
+    </se:Description>
+    <ogc:Filter>
+    	<ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsPoint">
+        		<ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+   	</ogc:Filter>
+   	<se:PointSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Graphic>
+        <se:Mark>
+          <se:WellKnownName>circle</se:WellKnownName>
+          <se:Fill>
+            <se:SvgParameter name="fill">#0066FF</se:SvgParameter>
+          </se:Fill>
+          <se:Stroke>
+            <se:SvgParameter name="stroke">#0066FF</se:SvgParameter>
+          </se:Stroke>
+        </se:Mark>
+        <se:Size>6</se:Size>
+      </se:Graphic>
+    </se:PointSymbolizer>
+     </se:Rule>
+     <se:Rule>
+    <se:Description>
+      <se:Title>Standing water</se:Title>
+    </se:Description>
+     <ogc:Filter>
+    	<ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsSurface">
+        		<ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+   	</ogc:Filter>
+    <se:PolygonSymbolizer>
+   	<se:Geometry>
+    	<ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+    </se:Geometry>
+    <se:Fill>
+    	<se:SvgParameter name="fill">#CCFFFF</se:SvgParameter>
+    </se:Fill>
+   </se:PolygonSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/feature-styles/HY_P_WaterbodiesPersistence_v5_0.se
+++ b/feature-styles/HY_P_WaterbodiesPersistence_v5_0.se
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<se:FeatureTypeStyle xmlns:hy-p="http://inspire.ec.europa.eu/schemas/hy-p/4.0" 
+<se:FeatureTypeStyle xmlns:hy-p="http://inspire.ec.europa.eu/schemas/hy-p/5.0" 
 xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" 
 xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd"

--- a/feature-styles/HY_P_WaterbodiesPersistence_v5_0.se
+++ b/feature-styles/HY_P_WaterbodiesPersistence_v5_0.se
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:hy-p="http://inspire.ec.europa.eu/schemas/hy-p/4.0" 
+xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" 
+xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd"
+version="1.1.0">
+  <se:Name>HY.PhysicalWaters.Waterbodies.Persistence</se:Name>
+  <se:Description>
+    <se:Title>Water Bodies Persistence Default Style</se:Title>
+    <se:Abstract>Physical waters as watercourses or standing water are depicted taking into account their water persistence. Intermittent water bodies are depicted using a dashed (10 to 5) blue (#33CCFF) line with a stroke width of 1 pixel and a non filled polygon with a dashed (10 to 5) blue (#33CCFF) line with a stroke width of 1 pixel. Ephemeral or dry waterbodies are depicted using a dashed (5 to 5) blue (#33CCFF) line with a strole width of 1 pixel and a non filled polygon with a dashed (5 to 5) blue (#33CCFF) line with a stroke width of 1 pixel. Perennial standing waters are depicted using a 6 pixel size filled solid blue circles (#0066FF) on a light blue (#CCFFFF) filled polygon. Intermittent standing waters are depicted using a non filled polygon with a dashed (10 to 5) blue (#33CCFF) line with a stroke width of 1 pixel. Ephemeral or dry standing waters are depicted using a non filled polygon with a dashed (5 to 5) blue (#33CCFF) line with a stroke width of 1 pixel.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>hy-p:StandingWater</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Standing waters persistence: perennial points</se:Title>
+    </se:Description>
+    <ogc:Filter>
+    <ogc:And>
+      <ogc:PropertyIsEqualTo>
+        <ogc:PropertyName>hy-p:persistence/@xlink:href</ogc:PropertyName>
+        <ogc:Literal>http://inspire.ec.europa.eu/codelist/HydrologicalPersistenceValue/perennial</ogc:Literal>
+      </ogc:PropertyIsEqualTo>
+   	  <ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsPoint">
+        		<ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       </ogc:PropertyIsEqualTo>
+    </ogc:And>
+    </ogc:Filter>
+    <se:PointSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Graphic>
+        <se:Mark>
+          <se:WellKnownName>circle</se:WellKnownName>
+          <se:Fill>
+            <se:SvgParameter name="fill">#0066FF</se:SvgParameter>
+          </se:Fill>
+          <se:Stroke>
+            <se:SvgParameter name="stroke">#0066FF</se:SvgParameter>
+          </se:Stroke>
+        </se:Mark>
+        <se:Size>6</se:Size>
+      </se:Graphic>
+    </se:PointSymbolizer>
+    </se:Rule>
+    <se:Rule>
+    <se:Description>
+      <se:Title>Standing waters persistence: perennial polygons</se:Title>
+    </se:Description>
+    <ogc:Filter>
+    <ogc:And>
+      <ogc:PropertyIsEqualTo>
+        <ogc:PropertyName>hy-p:persistence/@xlink:href</ogc:PropertyName>
+        <ogc:Literal>http://inspire.ec.europa.eu/codelist/HydrologicalPersistenceValue/perennial</ogc:Literal>
+      </ogc:PropertyIsEqualTo>
+   	  <ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsSurface">
+        		<ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       </ogc:PropertyIsEqualTo>
+    </ogc:And>
+    </ogc:Filter>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Fill>
+        <se:SvgParameter name="fill">#CCFFFF</se:SvgParameter>
+      </se:Fill>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Standing waters persistence: intermittent polygons</se:Title>
+    </se:Description>
+    <ogc:Filter>
+      <ogc:PropertyIsEqualTo>
+        <ogc:PropertyName>hy-p:persistence/@xlink:href</ogc:PropertyName>
+        <ogc:Literal>http://inspire.ec.europa.eu/codelist/HydrologicalPersistenceValue/intermittent</ogc:Literal>
+      </ogc:PropertyIsEqualTo>
+    </ogc:Filter>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#33CCFF</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+        <se:SvgParameter name="stroke-dasharray">10 5 10 5</se:SvgParameter>
+      </se:Stroke>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Standing waters persistence: ephemeral or dry polygons</se:Title>
+    </se:Description>
+    <ogc:Filter>
+      <ogc:Or>
+        <ogc:PropertyIsEqualTo>
+          <ogc:PropertyName>hy-p:persistence/@xlink:href</ogc:PropertyName>
+          <ogc:Literal>http://inspire.ec.europa.eu/codelist/HydrologicalPersistenceValue/ephemeral</ogc:Literal>
+        </ogc:PropertyIsEqualTo>
+        <ogc:PropertyIsEqualTo>
+          <ogc:PropertyName>hy-p:persistence/@xlink:href</ogc:PropertyName>
+          <ogc:Literal>http://inspire.ec.europa.eu/codelist/HydrologicalPersistenceValue/dry</ogc:Literal>
+        </ogc:PropertyIsEqualTo>
+      </ogc:Or>
+    </ogc:Filter>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#33CCFF</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+        <se:SvgParameter name="stroke-dasharray">5 5 5 5</se:SvgParameter>
+      </se:Stroke>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/feature-styles/HY_P_WatercoursePersistence_v5_0.se
+++ b/feature-styles/HY_P_WatercoursePersistence_v5_0.se
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<se:FeatureTypeStyle xmlns:hy-p="http://inspire.ec.europa.eu/schemas/hy-p/4.0" xmlns:ogc="http://www.opengis.net/ogc" 
+<se:FeatureTypeStyle xmlns:hy-p="http://inspire.ec.europa.eu/schemas/hy-p/5.0" xmlns:ogc="http://www.opengis.net/ogc" 
 xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:xlink="http://www.w3.org/1999/xlink" 
 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd"

--- a/feature-styles/HY_P_WatercoursePersistence_v5_0.se
+++ b/feature-styles/HY_P_WatercoursePersistence_v5_0.se
@@ -1,0 +1,220 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:hy-p="http://inspire.ec.europa.eu/schemas/hy-p/4.0" xmlns:ogc="http://www.opengis.net/ogc" 
+xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:xlink="http://www.w3.org/1999/xlink" 
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd"
+version="1.1.0">
+  <se:Name>HY.PhysicalWaters.Waterbodies.Persistence</se:Name>
+  <se:Description>
+    <se:Title>Water Bodies Persistence Default Style</se:Title>
+    <se:Abstract>Physical waters as watercourses or standing water are depicted taking into account their water persistence. Intermittent water bodies are depicted using a dashed (10 to 5) blue (#33CCFF) line with a strole width of 1 pixel and a non filled polygon with a dashed (10 to 5) blue (#33CCFF) line with a stroke width of 1 pixel. Ephemeral or dry waterbodies are depicted using a dashed (5 to 5) blue (#33CCFF) line with a strole width of 1 pixel and a non filled polygon with a dashed (5 to 5) blue (#33CCFF) line with a stroke width of 1 pixel. Perennial standing waters are depicted using a 6 pixel size filled solid blue circles (#0066FF) on a light blue (#CCFFFF) filled polygon. Intermittent standing waters are depicted using a non filled polygon with a dashed (10 to 5) blue (#33CCFF) line with a stroke width of 1 pixel. Ephemeral or dry standing waters are depicted using a non filled polygon with a dashed (5 to 5) blue (#33CCFF) line with a stroke width of 1 pixel.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>hy-p:Watercourse</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Waterbodies persistence: perennial lines</se:Title>
+    </se:Description>
+    <ogc:Filter>
+      <ogc:And>
+        <ogc:PropertyIsEqualTo>
+          <ogc:PropertyName>hy-p:persistence/@xlink:href</ogc:PropertyName>
+          <ogc:Literal>http://inspire.ec.europa.eu/codelist/HydrologicalPersistenceValue/perennial</ogc:Literal>
+        </ogc:PropertyIsEqualTo>
+        <ogc:PropertyIsEqualTo>
+          <ogc:PropertyName>hy-p:delineationKnown</ogc:PropertyName>
+          <ogc:Literal>true</ogc:Literal>
+        </ogc:PropertyIsEqualTo>
+        <ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsCurve">
+        		<ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+      </ogc:And>
+    </ogc:Filter>
+    <se:LineSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#33CCFF</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+      </se:Stroke>
+    </se:LineSymbolizer>
+    </se:Rule>
+    <se:Rule>
+     <se:Description>
+      <se:Title>Waterbodies persistence: perennial polygons</se:Title>
+    </se:Description>
+    <ogc:Filter>
+      <ogc:And>
+        <ogc:PropertyIsEqualTo>
+          <ogc:PropertyName>hy-p:persistence/@xlink:href</ogc:PropertyName>
+          <ogc:Literal>http://inspire.ec.europa.eu/codelist/HydrologicalPersistenceValue/perennial</ogc:Literal>
+        </ogc:PropertyIsEqualTo>
+        <ogc:PropertyIsEqualTo>
+          <ogc:PropertyName>hy-p:delineationKnown</ogc:PropertyName>
+          <ogc:Literal>true</ogc:Literal>
+        </ogc:PropertyIsEqualTo>
+        <ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsSurface">
+        		<ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+      </ogc:And>
+    </ogc:Filter>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Fill>
+        <se:SvgParameter name="fill">#CCFFFF</se:SvgParameter>
+      </se:Fill>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Waterbodies persistence: intermittent lines</se:Title>
+    </se:Description>
+   <ogc:Filter>
+      <ogc:And>
+        <ogc:PropertyIsEqualTo>
+          <ogc:PropertyName>hy-p:persistence/@xlink:href</ogc:PropertyName>
+          <ogc:Literal>http://inspire.ec.europa.eu/codelist/HydrologicalPersistenceValue/intermittent</ogc:Literal>
+        </ogc:PropertyIsEqualTo>
+        <ogc:PropertyIsEqualTo>
+          <ogc:PropertyName>hy-p:delineationKnown</ogc:PropertyName>
+          <ogc:Literal>true</ogc:Literal>
+        </ogc:PropertyIsEqualTo>
+        <ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsCurve">
+        		<ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+      </ogc:And>
+    </ogc:Filter>
+    <se:LineSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#33CCFF</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+        <se:SvgParameter name="stroke-dasharray">10 5 10 5</se:SvgParameter>
+      </se:Stroke>
+    </se:LineSymbolizer>
+    </se:Rule>
+    <se:Rule>
+      <se:Description>
+      <se:Title>Waterbodies persistence: intermittent polygons</se:Title>
+    </se:Description>
+   <ogc:Filter>
+      <ogc:And>
+        <ogc:PropertyIsEqualTo>
+          <ogc:PropertyName>hy-p:persistence/@xlink:href</ogc:PropertyName>
+          <ogc:Literal>http://inspire.ec.europa.eu/codelist/HydrologicalPersistenceValue/intermittent</ogc:Literal>
+        </ogc:PropertyIsEqualTo>
+        <ogc:PropertyIsEqualTo>
+          <ogc:PropertyName>hy-p:delineationKnown</ogc:PropertyName>
+          <ogc:Literal>true</ogc:Literal>
+        </ogc:PropertyIsEqualTo>
+        <ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsSurface">
+        		<ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+      </ogc:And>
+    </ogc:Filter>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#33CCFF</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+        <se:SvgParameter name="stroke-dasharray">10 5 10 5</se:SvgParameter>
+      </se:Stroke>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Waterbodies persistence: ephemeral or dry lines</se:Title>
+    </se:Description>
+    <ogc:Filter>
+      <ogc:And>
+      <ogc:PropertyIsEqualTo>
+          <ogc:PropertyName>hy-p:delineationKnown</ogc:PropertyName>
+          <ogc:Literal>true</ogc:Literal>
+        </ogc:PropertyIsEqualTo>
+        <ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsCurve">
+        		<ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+        <ogc:Or>
+        <ogc:PropertyIsEqualTo>
+          <ogc:PropertyName>hy-p:persistence/@xlink:href</ogc:PropertyName>
+          <ogc:Literal>http://inspire.ec.europa.eu/codelist/HydrologicalPersistenceValue/dry</ogc:Literal>
+        </ogc:PropertyIsEqualTo>
+        <ogc:PropertyIsEqualTo>
+          <ogc:PropertyName>hy-p:persistence/@xlink:href</ogc:PropertyName>
+          <ogc:Literal>http://inspire.ec.europa.eu/codelist/HydrologicalPersistenceValue/ephemeral</ogc:Literal>
+        </ogc:PropertyIsEqualTo>
+        </ogc:Or>
+      </ogc:And>
+    </ogc:Filter>
+    <se:LineSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#33CCFF</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+        <se:SvgParameter name="stroke-dasharray">5 5 5 5</se:SvgParameter>
+      </se:Stroke>
+    </se:LineSymbolizer>
+    </se:Rule>
+    <se:Rule>
+    <se:Description>
+      <se:Title>Waterbodies persistence: ephemeral or dry polygons</se:Title>
+    </se:Description>
+    <ogc:Filter>
+      <ogc:And>
+      <ogc:PropertyIsEqualTo>
+          <ogc:PropertyName>hy-p:delineationKnown</ogc:PropertyName>
+          <ogc:Literal>true</ogc:Literal>
+        </ogc:PropertyIsEqualTo>
+        <ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsSurface">
+        		<ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+        <ogc:Or>
+        <ogc:PropertyIsEqualTo>
+          <ogc:PropertyName>hy-p:persistence/@xlink:href</ogc:PropertyName>
+          <ogc:Literal>http://inspire.ec.europa.eu/codelist/HydrologicalPersistenceValue/dry</ogc:Literal>
+        </ogc:PropertyIsEqualTo>
+        <ogc:PropertyIsEqualTo>
+          <ogc:PropertyName>hy-p:persistence/@xlink:href</ogc:PropertyName>
+          <ogc:Literal>http://inspire.ec.europa.eu/codelist/HydrologicalPersistenceValue/ephemeral</ogc:Literal>
+        </ogc:PropertyIsEqualTo>
+        </ogc:Or>
+      </ogc:And>
+    </ogc:Filter>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#33CCFF</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+        <se:SvgParameter name="stroke-dasharray">5 5 5 5</se:SvgParameter>
+      </se:Stroke>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/feature-styles/HY_P_Watercourse_ManMade_v5_0.se
+++ b/feature-styles/HY_P_Watercourse_ManMade_v5_0.se
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<se:FeatureTypeStyle xmlns:hy-p="http://inspire.ec.europa.eu/schemas/hy-p/4.0" xmlns:ogc="http://www.opengis.net/ogc" 
+<se:FeatureTypeStyle xmlns:hy-p="http://inspire.ec.europa.eu/schemas/hy-p/5.0" xmlns:ogc="http://www.opengis.net/ogc" 
 xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:xlink="http://www.w3.org/1999/xlink" 
 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd"

--- a/feature-styles/HY_P_Watercourse_ManMade_v5_0.se
+++ b/feature-styles/HY_P_Watercourse_ManMade_v5_0.se
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:hy-p="http://inspire.ec.europa.eu/schemas/hy-p/4.0" xmlns:ogc="http://www.opengis.net/ogc" 
+xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:xlink="http://www.w3.org/1999/xlink" 
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd"
+version="1.1.0">
+  <se:Name>HY.PhysicalWaters.Waterbodies.Man.Made</se:Name>
+  <se:Description>
+    <se:Title>Waterbodies Man-Made Default Style</se:Title>
+    <se:Abstract>Physical waters as watercourses or standing water are depicted taking into account if they are natural or man-made. Natural water bodies are depicted using a light blue (#CCFFFF) filled polygon and a solid blue (#33CCFF) border with stroke width of 1 pixel.Man-made water bodies are depicted using a light blue (#CCFFFF) filled polygon and a solid blue (#0066FF) border with stroke width of 1 pixel.Natural standing waters are rendered by 6 pixel size filled blue circles (#0066FF) on a light blue (#CCFFFF) filled polygon.Man-made standing waters are rendered by 6 pixel size filled blue circles (#0066FF) with a black (?) (#0000) border on a light blue (#0000) filled polygon with a black (?) (#0000) border and a stroke width of 1 pixel.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>hy-p:Watercourse</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Waterbodies natural: lines</se:Title>
+    </se:Description>
+    <ogc:Filter>
+      <ogc:And>
+        <ogc:PropertyIsEqualTo>
+          <ogc:PropertyName>hy-p:delineationKnown</ogc:PropertyName>
+          <ogc:Literal>true</ogc:Literal>
+        </ogc:PropertyIsEqualTo>
+        <ogc:PropertyIsEqualTo>
+          <ogc:PropertyName>hy-p:origin</ogc:PropertyName>
+          <ogc:Literal>natural</ogc:Literal>
+        </ogc:PropertyIsEqualTo>
+        <ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsCurve">
+        		<ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+      </ogc:And>
+    </ogc:Filter>
+    <se:LineSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#33CCFF</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+      </se:Stroke>
+    </se:LineSymbolizer>
+    </se:Rule>
+    <se:Rule>
+     <se:Description>
+      <se:Title>Waterbodies natural: polygons</se:Title>
+    </se:Description>
+    <ogc:Filter>
+      <ogc:And>
+        <ogc:PropertyIsEqualTo>
+          <ogc:PropertyName>hy-p:delineationKnown</ogc:PropertyName>
+          <ogc:Literal>true</ogc:Literal>
+        </ogc:PropertyIsEqualTo>
+        <ogc:PropertyIsEqualTo>
+          <ogc:PropertyName>hy-p:origin</ogc:PropertyName>
+          <ogc:Literal>natural</ogc:Literal>
+        </ogc:PropertyIsEqualTo>
+        <ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsSurface">
+        		<ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+      </ogc:And>
+    </ogc:Filter>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Fill>
+        <se:SvgParameter name="fill">#CCFFFF</se:SvgParameter>
+      </se:Fill>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Waterbodies man-made: lines</se:Title>
+    </se:Description>
+    <ogc:Filter>
+      <ogc:And>
+        <ogc:PropertyIsEqualTo>
+          <ogc:PropertyName>hy-p:delineationKnown</ogc:PropertyName>
+          <ogc:Literal>true</ogc:Literal>
+        </ogc:PropertyIsEqualTo>
+        <ogc:PropertyIsEqualTo>
+          <ogc:PropertyName>hy-p:origin</ogc:PropertyName>
+          <ogc:Literal>manMade</ogc:Literal>
+        </ogc:PropertyIsEqualTo>
+        <ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsCurve">
+        		<ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+      </ogc:And>
+    </ogc:Filter>
+    <se:LineSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#0066FF</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+      </se:Stroke>
+    </se:LineSymbolizer>
+    </se:Rule>
+    <se:Rule>
+        <se:Description>
+      <se:Title>Waterbodies man-made: polygons</se:Title>
+    </se:Description>
+    <ogc:Filter>
+      <ogc:And>
+        <ogc:PropertyIsEqualTo>
+          <ogc:PropertyName>hy-p:delineationKnown</ogc:PropertyName>
+          <ogc:Literal>true</ogc:Literal>
+        </ogc:PropertyIsEqualTo>
+        <ogc:PropertyIsEqualTo>
+          <ogc:PropertyName>hy-p:origin</ogc:PropertyName>
+          <ogc:Literal>manMade</ogc:Literal>
+        </ogc:PropertyIsEqualTo>
+        <ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsSurface">
+        		<ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+      </ogc:And>
+    </ogc:Filter>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Fill>
+        <se:SvgParameter name="fill">#CCFFFF</se:SvgParameter>
+      </se:Fill>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#0000</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+      </se:Stroke>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/feature-styles/HY_P_Watercourse_v5_0.se
+++ b/feature-styles/HY_P_Watercourse_v5_0.se
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:hy-p="http://inspire.ec.europa.eu/schemas/hy-p/4.0" 
+xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" 
+xmlns:sld="http://www.opengis.net/sld" xmlns:xlink="http://www.w3.org/1999/xlink" 
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0"
+xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd">
+  <se:Name>HY.PhysicalWaters.Waterbodies.Default</se:Name>
+  <se:Description>
+    <se:Title>Waterbodies Default Style</se:Title>
+    <se:Abstract>Physical waters as watercourses or standing water can be portrayed with different geometries depending on its dimensions and the level of detail or resolution. Lineal watercourses are depicted by solid blue (#33CCFF) lines with stroke width of 1 pixel and the superficial ones are depicted by filled blue light polygons (#CCFFFF) without border. Punctual standing waters are depicted by dark blue (#0066FF) circles with size of 6 pixel and the superficial ones are depicted by filled blue light polygons (#CCFFFF) without border.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>hy-p:Watercourse</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Watercourse</se:Title>
+    </se:Description>
+    <ogc:Filter>
+      	<ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsCurve">
+        		<ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+    </ogc:Filter>
+    <se:LineSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#33CCFF</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+      </se:Stroke>
+    </se:LineSymbolizer>
+     </se:Rule>
+     <se:Rule>
+     <se:Description>
+      <se:Title>Watercourse</se:Title>
+    </se:Description>
+    <ogc:Filter>
+      	<ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsSurface">
+        		<ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+    </ogc:Filter>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Fill>
+        <se:SvgParameter name="fill">#CCFFFF</se:SvgParameter>
+      </se:Fill>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/feature-styles/HY_P_Watercourse_v5_0.se
+++ b/feature-styles/HY_P_Watercourse_v5_0.se
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<se:FeatureTypeStyle xmlns:hy-p="http://inspire.ec.europa.eu/schemas/hy-p/4.0" 
+<se:FeatureTypeStyle xmlns:hy-p="http://inspire.ec.europa.eu/schemas/hy-p/5.0" 
 xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" 
 xmlns:sld="http://www.opengis.net/sld" xmlns:xlink="http://www.w3.org/1999/xlink" 
 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0"

--- a/feature-styles/HY_P_Wetland_v5_0.se
+++ b/feature-styles/HY_P_Wetland_v5_0.se
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:hy-p="http://inspire.ec.europa.eu/schemas/hy-p/4.0" 
+xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" 
+xmlns:sld="http://www.opengis.net/sld" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd"
+version="1.1.0">
+  <se:Name>HY.PhysicalWaters.Wetland.Default</se:Name>
+  <se:Description>
+    <se:Title>Wetland Default Style</se:Title>
+    <se:Abstract>Wetlands are depicted with blue-green (#00CCCC) filled polygons.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>hy-p:Wetland</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Wetlands</se:Title>
+    </se:Description>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Fill>
+        <se:SvgParameter name="fill">#00CCCC</se:SvgParameter>
+      </se:Fill>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/feature-styles/HY_P_Wetland_v5_0.se
+++ b/feature-styles/HY_P_Wetland_v5_0.se
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<se:FeatureTypeStyle xmlns:hy-p="http://inspire.ec.europa.eu/schemas/hy-p/4.0" 
+<se:FeatureTypeStyle xmlns:hy-p="http://inspire.ec.europa.eu/schemas/hy-p/5.0" 
 xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" 
 xmlns:sld="http://www.opengis.net/sld" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd"

--- a/feature-styles/LC_LandCoverPoints_v5_0.se
+++ b/feature-styles/LC_LandCoverPoints_v5_0.se
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:lcv="http://inspire.ec.europa.eu/schemas/lcv/4.0" xmlns:net="http://inspire.ec.europa.eu/schemas/net/4.0" xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0" xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd">
+  <se:Name>LC.LandCoverPoints.Default</se:Name>
+  <se:Description>
+    <se:Title>LandCoverPoints Default Style</se:Title>
+    <se:Abstract>This Style defines the default INSPIRE style for Land Cover data supported by a set of points. As there is no required nomenclature, only the geometry is represented, ie as a circle with a size of 3 pixels, with a black (#000000) fill and a black outline (#000000).</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>lcv:LandCoverUnit</se:FeatureTypeName> 
+  <se:Rule>
+  	<se:Description>
+      <se:Title>Land cover unit</se:Title>
+    </se:Description>
+    <ogc:Filter>
+    	<ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsPoint">
+            	<ogc:PropertyName>lcv:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+     	</ogc:PropertyIsEqualTo>
+   	</ogc:Filter>
+    <se:PointSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>lcv:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Graphic>
+        <se:Mark>
+          <se:WellKnownName>circle</se:WellKnownName>
+          <se:Fill>
+            <se:SvgParameter name="fill">#000000</se:SvgParameter>
+          </se:Fill>
+          <se:Stroke>
+            <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+          </se:Stroke>
+        </se:Mark>
+        <se:Size>3</se:Size>
+      </se:Graphic>
+    </se:PointSymbolizer>
+  </se:Rule>  
+ </se:FeatureTypeStyle>   
+   

--- a/feature-styles/LC_LandCoverPoints_v5_0.se
+++ b/feature-styles/LC_LandCoverPoints_v5_0.se
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<se:FeatureTypeStyle xmlns:lcv="http://inspire.ec.europa.eu/schemas/lcv/4.0" xmlns:net="http://inspire.ec.europa.eu/schemas/net/4.0" xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0" xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd">
+<se:FeatureTypeStyle xmlns:lcv="http://inspire.ec.europa.eu/schemas/lcv/5.0" xmlns:net="http://inspire.ec.europa.eu/schemas/net/5.0" xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0" xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd">
   <se:Name>LC.LandCoverPoints.Default</se:Name>
   <se:Description>
     <se:Title>LandCoverPoints Default Style</se:Title>

--- a/feature-styles/LC_LandCoverSurfaces_v5_0.se
+++ b/feature-styles/LC_LandCoverSurfaces_v5_0.se
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<se:FeatureTypeStyle xmlns:lcv="http://inspire.ec.europa.eu/schemas/lcv/4.0" 
-xmlns:net="http://inspire.ec.europa.eu/schemas/net/4.0" 
+<se:FeatureTypeStyle xmlns:lcv="http://inspire.ec.europa.eu/schemas/lcv/5.0" 
+xmlns:net="http://inspire.ec.europa.eu/schemas/net/5.0" 
 xmlns:ogc="http://www.opengis.net/ogc" 
 xmlns:se="http://www.opengis.net/se" 
 xmlns:sld="http://www.opengis.net/sld" 

--- a/feature-styles/LC_LandCoverSurfaces_v5_0.se
+++ b/feature-styles/LC_LandCoverSurfaces_v5_0.se
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:lcv="http://inspire.ec.europa.eu/schemas/lcv/4.0" 
+xmlns:net="http://inspire.ec.europa.eu/schemas/net/4.0" 
+xmlns:ogc="http://www.opengis.net/ogc" 
+xmlns:se="http://www.opengis.net/se" 
+xmlns:sld="http://www.opengis.net/sld" 
+xmlns:xlink="http://www.w3.org/1999/xlink" 
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+version="1.1.0"
+xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd">
+  <se:Name>LC.LandCoverSurfaces.Default</se:Name>
+  <se:Description>
+    <se:Title>LandCoverSurfaces Default Style</se:Title>
+    <se:Abstract>This Style defines the default INSPIRE style for Land Cover data supported by a set of non overlapping polygons. As there is no required nomenclature, only the geometry is represented, ie only polygons with a white (#FFFFFF) fill and a black outline (#000000) of 3 pixels width. </se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>lcv:LandCoverUnit</se:FeatureTypeName> 
+  <se:Rule>
+  	<se:Description>
+      <se:Title>Land cover unit</se:Title>
+    </se:Description>
+    <ogc:Filter>
+    	<ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsSurface">
+            	<ogc:PropertyName>lcv:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+     	</ogc:PropertyIsEqualTo>
+   	</ogc:Filter>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>lcv:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Fill>
+      	<se:SvgParameter name="fill">#FFFFFF</se:SvgParameter>
+      </se:Fill>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">0.5</se:SvgParameter>
+      </se:Stroke>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+ </se:FeatureTypeStyle>

--- a/feature-styles/PS_ProtectedSites_v5_0.se
+++ b/feature-styles/PS_ProtectedSites_v5_0.se
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:PS="urn:xinspire:specification:ProtectedSites:3.1" xmlns:ogc="http://www.opengis.net/ogc" xmlns:ps="http://inspire.ec.europa.eu/schemas/ps/4.0" xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0" xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd">
+  <se:Name>PS.ProtectedSite.Default</se:Name>
+  <se:Description>
+    <se:Title>Protected Sites Default Style</se:Title>
+    <se:Abstract>Point geometries are rendered as a square with a size of 6 pixels, with a 50% grey (#808080) fill and a black (#000000) outline. Line geometries are rendered as a solid black line with a stroke width of 1 pixel. Polygon geometries are rendered using a 50% grey (#808080) fill and a solid black outline with a stroke width of 1 pixel.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>ps:ProtectedSite</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Protected sites: polygons</se:Title>
+    </se:Description>
+    <ogc:Filter>
+    	<ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsSurface">
+        		<ogc:PropertyName>ps:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+   	</ogc:Filter>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>ps:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Fill>
+        <se:SvgParameter name="fill">#808080</se:SvgParameter>
+      </se:Fill>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+      </se:Stroke>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Protected sites: lines</se:Title>
+    </se:Description>
+    <ogc:Filter>
+    	<ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsCurve">
+        		<ogc:PropertyName>ps:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+   	</ogc:Filter>
+    <se:LineSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>ps:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+      </se:Stroke>
+    </se:LineSymbolizer>
+  </se:Rule>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Protected sites: points</se:Title>
+    </se:Description>
+    <ogc:Filter>
+    	<ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsPoint">
+        		<ogc:PropertyName>ps:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+   	</ogc:Filter>
+    <se:PointSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>ps:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Graphic>
+        <se:Mark>
+          <se:WellKnownName>square</se:WellKnownName>
+          <se:Fill>
+            <se:SvgParameter name="fill">#808080</se:SvgParameter>
+          </se:Fill>
+          <se:Stroke>
+            <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+            <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+          </se:Stroke>
+        </se:Mark>
+        <se:Size>6</se:Size>
+      </se:Graphic>
+    </se:PointSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/feature-styles/PS_ProtectedSites_v5_0.se
+++ b/feature-styles/PS_ProtectedSites_v5_0.se
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<se:FeatureTypeStyle xmlns:PS="urn:xinspire:specification:ProtectedSites:3.1" xmlns:ogc="http://www.opengis.net/ogc" xmlns:ps="http://inspire.ec.europa.eu/schemas/ps/4.0" xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0" xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd">
+<se:FeatureTypeStyle xmlns:PS="urn:xinspire:specification:ProtectedSites:3.1" xmlns:ogc="http://www.opengis.net/ogc" xmlns:ps="http://inspire.ec.europa.eu/schemas/ps/5.0" xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0" xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd">
   <se:Name>PS.ProtectedSite.Default</se:Name>
   <se:Description>
     <se:Title>Protected Sites Default Style</se:Title>

--- a/feature-styles/TN_A_AerodromeArea_v5_0.se
+++ b/feature-styles/TN_A_AerodromeArea_v5_0.se
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<se:FeatureTypeStyle xmlns:net="http://inspire.ec.europa.eu/schemas/net/4.0" xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:tn-a="http://inspire.ec.europa.eu/schemas/tn-a/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
+<se:FeatureTypeStyle xmlns:net="http://inspire.ec.europa.eu/schemas/net/5.0" xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:tn-a="http://inspire.ec.europa.eu/schemas/tn-a/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
   <se:Name>TN.AirTransportNetwork.AerodromeArea.Default</se:Name>
   <se:Description>
     <se:Title>Aerodrome Area Default Style</se:Title>

--- a/feature-styles/TN_A_AerodromeArea_v5_0.se
+++ b/feature-styles/TN_A_AerodromeArea_v5_0.se
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:net="http://inspire.ec.europa.eu/schemas/net/4.0" xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:tn-a="http://inspire.ec.europa.eu/schemas/tn-a/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
+  <se:Name>TN.AirTransportNetwork.AerodromeArea.Default</se:Name>
+  <se:Description>
+    <se:Title>Aerodrome Area Default Style</se:Title>
+    <se:Abstract>The geometry is rendered using a 50% Blue (#0000CD) fill and a solid Blue (#0000CD) outline with a stroke width of 1 pixel.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>tn-a:AerodromeArea</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Aerodrome area</se:Title>
+    </se:Description>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>net:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Fill>
+        <se:SvgParameter name="fill">#0000CD</se:SvgParameter>
+        <se:SvgParameter name="fill-opacity">0.5</se:SvgParameter>
+      </se:Fill>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#0000CD</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+      </se:Stroke>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/feature-styles/TN_A_AerodromeNode_v5_0.se
+++ b/feature-styles/TN_A_AerodromeNode_v5_0.se
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" 
+xmlns:sld="http://www.opengis.net/sld" xmlns:net="http://inspire.ec.europa.eu/schemas/net/4.0" 
+xmlns:tn-a="http://inspire.ec.europa.eu/schemas/tn-a/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" 
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd" version="1.1.0">
+  <se:Name>TN.AirTransportNetwork.AerodromeNode.Default</se:Name>
+  <se:Description>
+    <se:Title>Aerodrome Node Default Style</se:Title>
+    <se:Abstract>The geometry is rendered using a yellow (#FFFF00) fill.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>tn-a:AerodromeNode</se:FeatureTypeName>
+  <se:Rule>
+  <se:Description>
+      <se:Title>Aerodrome node</se:Title>
+    </se:Description>
+    <se:PointSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>net:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Graphic>
+        <se:Mark>
+          <se:WellKnownName>square</se:WellKnownName>
+          <se:Fill>
+            <se:SvgParameter name="fill">#FFFF00</se:SvgParameter>
+          </se:Fill>
+          <se:Stroke>
+            <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+            <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+          </se:Stroke>
+        </se:Mark>
+        <se:Size>6</se:Size>
+      </se:Graphic>
+    </se:PointSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/feature-styles/TN_A_AerodromeNode_v5_0.se
+++ b/feature-styles/TN_A_AerodromeNode_v5_0.se
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <se:FeatureTypeStyle xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" 
-xmlns:sld="http://www.opengis.net/sld" xmlns:net="http://inspire.ec.europa.eu/schemas/net/4.0" 
+xmlns:sld="http://www.opengis.net/sld" xmlns:net="http://inspire.ec.europa.eu/schemas/net/5.0" 
 xmlns:tn-a="http://inspire.ec.europa.eu/schemas/tn-a/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" 
 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd" version="1.1.0">

--- a/feature-styles/TN_A_AirRouteLink_v5_0.se
+++ b/feature-styles/TN_A_AirRouteLink_v5_0.se
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<se:FeatureTypeStyle xmlns:net="http://inspire.ec.europa.eu/schemas/net/4.0" xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:tn-a="http://inspire.ec.europa.eu/schemas/tn-a/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
+<se:FeatureTypeStyle xmlns:net="http://inspire.ec.europa.eu/schemas/net/5.0" xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:tn-a="http://inspire.ec.europa.eu/schemas/tn-a/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
   <se:Name>TN.AirTransportNetwork.AirLink.Default</se:Name>
   <se:Description>
     <se:Title>Air Link Default Style</se:Title>

--- a/feature-styles/TN_A_AirRouteLink_v5_0.se
+++ b/feature-styles/TN_A_AirRouteLink_v5_0.se
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:net="http://inspire.ec.europa.eu/schemas/net/4.0" xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:tn-a="http://inspire.ec.europa.eu/schemas/tn-a/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
+  <se:Name>TN.AirTransportNetwork.AirLink.Default</se:Name>
+  <se:Description>
+    <se:Title>Air Link Default Style</se:Title>
+    <se:Abstract>The geometry is rendered as a solid Maroon (#800000)line with a stroke width of 3 pixel . Ends are rounded and have a 2 pixel black (#000000) casing.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>tn-a:AirRouteLink</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Air link</se:Title>
+    </se:Description>
+    <se:LineSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>net:centrelineGeometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">7</se:SvgParameter>
+        <se:SvgParameter name="stroke-linejoin">bevel</se:SvgParameter>
+        <se:SvgParameter name="stroke-linecap">round</se:SvgParameter>
+      </se:Stroke>
+    </se:LineSymbolizer>
+    <se:LineSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>net:centrelineGeometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#800000</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">3</se:SvgParameter>
+        <se:SvgParameter name="stroke-linejoin">bevel</se:SvgParameter>
+        <se:SvgParameter name="stroke-linecap">round</se:SvgParameter>
+      </se:Stroke>
+    </se:LineSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/feature-styles/TN_A_AirspaceArea_v5_0.se
+++ b/feature-styles/TN_A_AirspaceArea_v5_0.se
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:tn-a="http://inspire.ec.europa.eu/schemas/tn-a/4.0" 
+xmlns:net="http://inspire.ec.europa.eu/schemas/net/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" 
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd" version="1.1.0">
+  <se:Name>TN.AirTransportNetwork.AirSpaceArea.Default</se:Name>
+  <se:Description>
+    <se:Title>Air Space Area Default Style</se:Title>
+    <se:Abstract>The geometry is rendered using a 25% Magenta (#8B008B) fill and a solid Magenta (#8B008B) outline with a stroke width of 2 pixel.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>tn-a:AirspaceArea</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Air space area</se:Title>
+    </se:Description>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>net:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Fill>
+        <se:SvgParameter name="fill">#8B008B</se:SvgParameter>
+        <se:SvgParameter name="fill-opacity">0.25</se:SvgParameter>
+      </se:Fill>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#808080</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">2</se:SvgParameter>
+      </se:Stroke>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/feature-styles/TN_A_AirspaceArea_v5_0.se
+++ b/feature-styles/TN_A_AirspaceArea_v5_0.se
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <se:FeatureTypeStyle xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:tn-a="http://inspire.ec.europa.eu/schemas/tn-a/4.0" 
-xmlns:net="http://inspire.ec.europa.eu/schemas/net/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" 
+xmlns:net="http://inspire.ec.europa.eu/schemas/net/5.0" xmlns:xlink="http://www.w3.org/1999/xlink" 
 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd" version="1.1.0">
   <se:Name>TN.AirTransportNetwork.AirSpaceArea.Default</se:Name>
   <se:Description>

--- a/feature-styles/TN_A_ApronArea_v5_0.se
+++ b/feature-styles/TN_A_ApronArea_v5_0.se
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:net="http://inspire.ec.europa.eu/schemas/net/4.0" xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:tn-a="http://inspire.ec.europa.eu/schemas/tn-a/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
+  <se:Name>TN.AirTransportNetwork.ApronArea.Default</se:Name>
+  <se:Description>
+    <se:Title>Apron Area Default Style</se:Title>
+    <se:Abstract>The geometry is rendered using a 50% grey (#808080) fill and a solid black outline with a stroke width of 1 pixel.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>tn-a:ApronArea</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Apron area</se:Title>
+    </se:Description>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>net:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Fill>
+        <se:SvgParameter name="fill">#808080</se:SvgParameter>
+        <se:SvgParameter name="fill-opacity">0.5</se:SvgParameter>
+      </se:Fill>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+      </se:Stroke>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/feature-styles/TN_A_ApronArea_v5_0.se
+++ b/feature-styles/TN_A_ApronArea_v5_0.se
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<se:FeatureTypeStyle xmlns:net="http://inspire.ec.europa.eu/schemas/net/4.0" xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:tn-a="http://inspire.ec.europa.eu/schemas/tn-a/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
+<se:FeatureTypeStyle xmlns:net="http://inspire.ec.europa.eu/schemas/net/5.0" xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:tn-a="http://inspire.ec.europa.eu/schemas/tn-a/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
   <se:Name>TN.AirTransportNetwork.ApronArea.Default</se:Name>
   <se:Description>
     <se:Title>Apron Area Default Style</se:Title>

--- a/feature-styles/TN_A_DesignatedPoint_v5_0.se
+++ b/feature-styles/TN_A_DesignatedPoint_v5_0.se
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" 
+xmlns:sld="http://www.opengis.net/sld" xmlns:net="http://inspire.ec.europa.eu/schemas/net/4.0" 
+xmlns:tn-a="http://inspire.ec.europa.eu/schemas/tn-a/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" 
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd" version="1.1.0">
+  <se:Name>TN.AirTransportNetwork.DesignatedPoint.Default</se:Name>
+  <se:Description>
+    <se:Title>Designated Point Default Style</se:Title>
+    <se:Abstract>The geometry is rendered using an orange (#FF4500) fill.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>tn-a:DesignatedPoint</se:FeatureTypeName>
+  <se:Rule>
+  <se:Description>
+      <se:Title>Designated point</se:Title>
+    </se:Description>
+   <se:PointSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>net:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Graphic>
+        <se:Mark>
+          <se:WellKnownName>circle</se:WellKnownName>
+          <se:Fill>
+            <se:SvgParameter name="fill">#FF4500</se:SvgParameter>
+          </se:Fill>
+          <se:Stroke>
+            <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+            <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+          </se:Stroke>
+        </se:Mark>
+        <se:Size>6</se:Size>
+      </se:Graphic>
+    </se:PointSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/feature-styles/TN_A_DesignatedPoint_v5_0.se
+++ b/feature-styles/TN_A_DesignatedPoint_v5_0.se
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <se:FeatureTypeStyle xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" 
-xmlns:sld="http://www.opengis.net/sld" xmlns:net="http://inspire.ec.europa.eu/schemas/net/4.0" 
+xmlns:sld="http://www.opengis.net/sld" xmlns:net="http://inspire.ec.europa.eu/schemas/net/5.0" 
 xmlns:tn-a="http://inspire.ec.europa.eu/schemas/tn-a/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" 
 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd" version="1.1.0">

--- a/feature-styles/TN_A_Navaid_v5_0.se
+++ b/feature-styles/TN_A_Navaid_v5_0.se
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" 
+xmlns:sld="http://www.opengis.net/sld" xmlns:net="http://inspire.ec.europa.eu/schemas/net/4.0" 
+xmlns:tn-a="http://inspire.ec.europa.eu/schemas/tn-a/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" 
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd" version="1.1.0">
+  <se:Name>TN.AirTransportNetwork.Navaid.Default</se:Name>
+  <se:Description>
+    <se:Title>Navaid Default Style</se:Title>
+    <se:Abstract>The geometry is rendered using a dark blue (#00008B) fill.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>tn-a:Navaid</se:FeatureTypeName>
+   <se:Rule>
+   <se:Description>
+      <se:Title>Navaid</se:Title>
+    </se:Description>
+    <se:PointSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>net:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Graphic>
+        <se:Mark>
+          <se:WellKnownName>circle</se:WellKnownName>
+          <se:Fill>
+            <se:SvgParameter name="fill">#00008B</se:SvgParameter>
+          </se:Fill>
+          <se:Stroke>
+            <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+            <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+          </se:Stroke>
+        </se:Mark>
+        <se:Size>6</se:Size>
+      </se:Graphic>
+    </se:PointSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/feature-styles/TN_A_Navaid_v5_0.se
+++ b/feature-styles/TN_A_Navaid_v5_0.se
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <se:FeatureTypeStyle xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" 
-xmlns:sld="http://www.opengis.net/sld" xmlns:net="http://inspire.ec.europa.eu/schemas/net/4.0" 
+xmlns:sld="http://www.opengis.net/sld" xmlns:net="http://inspire.ec.europa.eu/schemas/net/5.0" 
 xmlns:tn-a="http://inspire.ec.europa.eu/schemas/tn-a/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" 
 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd" version="1.1.0">

--- a/feature-styles/TN_A_ProcedureLink_v5_0.se
+++ b/feature-styles/TN_A_ProcedureLink_v5_0.se
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<se:FeatureTypeStyle xmlns:net="http://inspire.ec.europa.eu/schemas/net/4.0" xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:tn-a="http://inspire.ec.europa.eu/schemas/tn-a/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
+<se:FeatureTypeStyle xmlns:net="http://inspire.ec.europa.eu/schemas/net/5.0" xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:tn-a="http://inspire.ec.europa.eu/schemas/tn-a/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
   <se:Name>TN.AirTransportNetwork.ProcedureLink.Default</se:Name>
   <se:Description>
     <se:Title>Air Link Default Style</se:Title>

--- a/feature-styles/TN_A_ProcedureLink_v5_0.se
+++ b/feature-styles/TN_A_ProcedureLink_v5_0.se
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:net="http://inspire.ec.europa.eu/schemas/net/4.0" xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:tn-a="http://inspire.ec.europa.eu/schemas/tn-a/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
+  <se:Name>TN.AirTransportNetwork.ProcedureLink.Default</se:Name>
+  <se:Description>
+    <se:Title>Air Link Default Style</se:Title>
+    <se:Abstract>The geometry is rendered as a solid Maroon (#800000)line with a stroke width of 3 pixel . Ends are rounded and have a 2 pixel black (#000000) casing.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>tn-a:ProcedureLink</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Air link</se:Title>
+    </se:Description>
+    <se:LineSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>net:centrelineGeometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">7</se:SvgParameter>
+        <se:SvgParameter name="stroke-linejoin">bevel</se:SvgParameter>
+        <se:SvgParameter name="stroke-linecap">round</se:SvgParameter>
+      </se:Stroke>
+    </se:LineSymbolizer>
+    <se:LineSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>net:centrelineGeometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#800000</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">3</se:SvgParameter>
+        <se:SvgParameter name="stroke-linejoin">bevel</se:SvgParameter>
+        <se:SvgParameter name="stroke-linecap">round</se:SvgParameter>
+      </se:Stroke>
+    </se:LineSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/feature-styles/TN_A_RunwayArea_v5_0.se
+++ b/feature-styles/TN_A_RunwayArea_v5_0.se
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" 
+xmlns:sld="http://www.opengis.net/sld" xmlns:net="http://inspire.ec.europa.eu/schemas/net/4.0" 
+xmlns:tn-a="http://inspire.ec.europa.eu/schemas/tn-a/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" 
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd" version="1.1.0">
+  <se:Name>TN.AirTransportNetwork.RunwayArea.Default</se:Name>
+  <se:Description>
+    <se:Title>Runway Area Default Style</se:Title>
+    <se:Abstract>The geometry is rendered using a White (#FFFFFF) fill and a solid Blue (#0000CD)outline with a stroke width of 2 pixel.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>tn-a:RunwayArea</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Runway area</se:Title>
+    </se:Description>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>net:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Fill>
+        <se:SvgParameter name="fill">#FFFFFF</se:SvgParameter>
+      </se:Fill>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#0000CD</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">2</se:SvgParameter>
+      </se:Stroke>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/feature-styles/TN_A_RunwayArea_v5_0.se
+++ b/feature-styles/TN_A_RunwayArea_v5_0.se
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <se:FeatureTypeStyle xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" 
-xmlns:sld="http://www.opengis.net/sld" xmlns:net="http://inspire.ec.europa.eu/schemas/net/4.0" 
+xmlns:sld="http://www.opengis.net/sld" xmlns:net="http://inspire.ec.europa.eu/schemas/net/5.0" 
 xmlns:tn-a="http://inspire.ec.europa.eu/schemas/tn-a/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" 
 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd" version="1.1.0">

--- a/feature-styles/TN_A_RunwayCentrelinePoint_v5_0.se
+++ b/feature-styles/TN_A_RunwayCentrelinePoint_v5_0.se
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <se:FeatureTypeStyle xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" 
-xmlns:sld="http://www.opengis.net/sld" xmlns:net="http://inspire.ec.europa.eu/schemas/net/4.0" 
+xmlns:sld="http://www.opengis.net/sld" xmlns:net="http://inspire.ec.europa.eu/schemas/net/5.0" 
 xmlns:tn-a="http://inspire.ec.europa.eu/schemas/tn-a/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" 
 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd" version="1.1.0">

--- a/feature-styles/TN_A_RunwayCentrelinePoint_v5_0.se
+++ b/feature-styles/TN_A_RunwayCentrelinePoint_v5_0.se
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" 
+xmlns:sld="http://www.opengis.net/sld" xmlns:net="http://inspire.ec.europa.eu/schemas/net/4.0" 
+xmlns:tn-a="http://inspire.ec.europa.eu/schemas/tn-a/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" 
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd" version="1.1.0">
+  <se:Name>TN.AirTransportNetwork.RunwayCentrelinePoint.Default</se:Name>
+  <se:Description>
+    <se:Title>Runway Centreline Point Default Style</se:Title>
+    <se:Abstract>The geometry is rendered using a red (#FF0000) fill.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>tn-a:RunwayCentrelinePoint</se:FeatureTypeName>
+  <se:Rule>
+  <se:Description>
+      <se:Title>Runway centreline point</se:Title>
+    </se:Description>
+    <se:PointSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>net:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Graphic>
+        <se:Mark>
+          <se:WellKnownName>triangle</se:WellKnownName>
+          <se:Fill>
+            <se:SvgParameter name="fill">#FF0000</se:SvgParameter>
+          </se:Fill>
+          <se:Stroke>
+            <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+            <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+          </se:Stroke>
+        </se:Mark>
+        <se:Size>6</se:Size>
+      </se:Graphic>
+    </se:PointSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/feature-styles/TN_A_TaxiwayArea_v5_0.se
+++ b/feature-styles/TN_A_TaxiwayArea_v5_0.se
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<se:FeatureTypeStyle xmlns:net="http://inspire.ec.europa.eu/schemas/net/4.0" xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:tn-a="http://inspire.ec.europa.eu/schemas/tn-a/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
+<se:FeatureTypeStyle xmlns:net="http://inspire.ec.europa.eu/schemas/net/5.0" xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:tn-a="http://inspire.ec.europa.eu/schemas/tn-a/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
   <se:Name>TN.AirTransportNetwork.TaxiwayArea.Default</se:Name>
   <se:Description>
     <se:Title>Taxiway Area Default Style</se:Title>

--- a/feature-styles/TN_A_TaxiwayArea_v5_0.se
+++ b/feature-styles/TN_A_TaxiwayArea_v5_0.se
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:net="http://inspire.ec.europa.eu/schemas/net/4.0" xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:tn-a="http://inspire.ec.europa.eu/schemas/tn-a/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
+  <se:Name>TN.AirTransportNetwork.TaxiwayArea.Default</se:Name>
+  <se:Description>
+    <se:Title>Taxiway Area Default Style</se:Title>
+    <se:Abstract>The geometry is rendered using a Blue (#B0E0E6) fill and a solid black outline with a stroke width of 1 pixel.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>tn-a:TaxiwayArea</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Taxiway area</se:Title>
+    </se:Description>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>net:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Fill>
+        <se:SvgParameter name="fill">#B0E0E6</se:SvgParameter>
+      </se:Fill>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+      </se:Stroke>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/feature-styles/TN_A_TouchDownLiftOff_v5_0.se
+++ b/feature-styles/TN_A_TouchDownLiftOff_v5_0.se
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" 
+xmlns:sld="http://www.opengis.net/sld" xmlns:net="http://inspire.ec.europa.eu/schemas/net/4.0" 
+xmlns:tn-a="http://inspire.ec.europa.eu/schemas/tn-a/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" 
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd" version="1.1.0">
+  <se:Name>TN.AirTransportNetwork.TouchDownLiftOff.Default</se:Name>
+  <se:Description>
+    <se:Title>Touch Down Lift Off Default Style</se:Title>
+    <se:Abstract>The geometry is rendered using a purple (#CC8899) fill.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>tn-a:TouchDownLiftOff</se:FeatureTypeName>
+  <se:Rule>
+  <se:Description>
+      <se:Title>Touch down lift off</se:Title>
+    </se:Description>
+    <se:PointSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>net:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Graphic>
+        <se:Mark>
+          <se:WellKnownName>star</se:WellKnownName>
+          <se:Fill>
+            <se:SvgParameter name="fill">#CC8899</se:SvgParameter>
+          </se:Fill>
+          <se:Stroke>
+            <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+            <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+          </se:Stroke>
+        </se:Mark>
+        <se:Size>6</se:Size>
+      </se:Graphic>
+    </se:PointSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/feature-styles/TN_A_TouchDownLiftOff_v5_0.se
+++ b/feature-styles/TN_A_TouchDownLiftOff_v5_0.se
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <se:FeatureTypeStyle xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" 
-xmlns:sld="http://www.opengis.net/sld" xmlns:net="http://inspire.ec.europa.eu/schemas/net/4.0" 
+xmlns:sld="http://www.opengis.net/sld" xmlns:net="http://inspire.ec.europa.eu/schemas/net/5.0" 
 xmlns:tn-a="http://inspire.ec.europa.eu/schemas/tn-a/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" 
 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd" version="1.1.0">

--- a/feature-styles/TN_C_CablewayLink_v5_0.se
+++ b/feature-styles/TN_C_CablewayLink_v5_0.se
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:net="http://inspire.ec.europa.eu/schemas/net/4.0" xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:tn-c="http://inspire.ec.europa.eu/schemas/tn-c/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
+  <se:Name>TN.CableTransportNetwork.CablewayLink.Default</se:Name>
+  <se:Description>
+    <se:Title>Cableway Link Default Style</se:Title>
+    <se:Abstract> The geometry is rendered as a solid magenta line with a stroke width of 3 pixel (#B10787). Ends are rounded and have a 2 pixel black casing (#000000).</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>tn-c:CablewayLink</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Cableway link</se:Title>
+    </se:Description>
+    <se:LineSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>net:centrelineGeometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">7</se:SvgParameter>
+        <se:SvgParameter name="stroke-linejoin">bevel</se:SvgParameter>
+        <se:SvgParameter name="stroke-linecap">round</se:SvgParameter>
+      </se:Stroke>
+    </se:LineSymbolizer>
+    <se:LineSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>net:centrelineGeometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#B10787</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">3</se:SvgParameter>
+        <se:SvgParameter name="stroke-linejoin">bevel</se:SvgParameter>
+        <se:SvgParameter name="stroke-linecap">round</se:SvgParameter>
+      </se:Stroke>
+    </se:LineSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/feature-styles/TN_C_CablewayLink_v5_0.se
+++ b/feature-styles/TN_C_CablewayLink_v5_0.se
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<se:FeatureTypeStyle xmlns:net="http://inspire.ec.europa.eu/schemas/net/4.0" xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:tn-c="http://inspire.ec.europa.eu/schemas/tn-c/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
+<se:FeatureTypeStyle xmlns:net="http://inspire.ec.europa.eu/schemas/net/5.0" xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:tn-c="http://inspire.ec.europa.eu/schemas/tn-c/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
   <se:Name>TN.CableTransportNetwork.CablewayLink.Default</se:Name>
   <se:Description>
     <se:Title>Cableway Link Default Style</se:Title>

--- a/feature-styles/TN_MarkerPost_v5_0.se
+++ b/feature-styles/TN_MarkerPost_v5_0.se
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" 
+xmlns:tn="http://inspire.ec.europa.eu/schemas/tn/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
+  <se:Name>TN.CommonTransportElements.MarkerPost.Default</se:Name>
+  <se:Description>
+    <se:Title>Marker Post Default Style</se:Title>
+    <se:Abstract>The geometry is rendered as a circle with a size of 3 pixels, with a red (#FF0000) fill and a black outline (#000000).</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>tn:MarkerPost</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Marker post</se:Title>
+    </se:Description>
+    <se:PointSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>tn:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Graphic>
+        <se:Mark>
+          <se:WellKnownName>circle</se:WellKnownName>
+          <se:Fill>
+            <se:SvgParameter name="fill">#FF0000</se:SvgParameter>
+          </se:Fill>
+          <se:Stroke>
+            <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+            <se:SvgParameter name="stroke-width">0.5</se:SvgParameter>
+          </se:Stroke>
+        </se:Mark>
+        <se:Size>3</se:Size>
+      </se:Graphic>
+    </se:PointSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/feature-styles/TN_RA_RailwayArea_v5_0.se
+++ b/feature-styles/TN_RA_RailwayArea_v5_0.se
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:net="http://inspire.ec.europa.eu/schemas/net/4.0" xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:tn-ra="http://inspire.ec.europa.eu/schemas/tn-ra/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
+  <se:Name>TN.RailTransportNetwork.RailwayArea.Default</se:Name>
+  <se:Description>
+    <se:Title>Railway Area Default Style</se:Title>
+    <se:Abstract>The geometry is rendered using a Brown (#8B4513) fill and a solid black (#000000) outline with a stroke width of 1 pixel.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>tn-ra:RailwayArea</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Railway area</se:Title>
+    </se:Description>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>net:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Fill>
+        <se:SvgParameter name="fill">#8B4513</se:SvgParameter>
+      </se:Fill>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+      </se:Stroke>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/feature-styles/TN_RA_RailwayArea_v5_0.se
+++ b/feature-styles/TN_RA_RailwayArea_v5_0.se
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<se:FeatureTypeStyle xmlns:net="http://inspire.ec.europa.eu/schemas/net/4.0" xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:tn-ra="http://inspire.ec.europa.eu/schemas/tn-ra/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
+<se:FeatureTypeStyle xmlns:net="http://inspire.ec.europa.eu/schemas/net/5.0" xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:tn-ra="http://inspire.ec.europa.eu/schemas/tn-ra/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
   <se:Name>TN.RailTransportNetwork.RailwayArea.Default</se:Name>
   <se:Description>
     <se:Title>Railway Area Default Style</se:Title>

--- a/feature-styles/TN_RA_RailwayLink_v5_0.se
+++ b/feature-styles/TN_RA_RailwayLink_v5_0.se
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<se:FeatureTypeStyle xmlns:net="http://inspire.ec.europa.eu/schemas/net/4.0" xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:tn-ra="http://inspire.ec.europa.eu/schemas/tn-ra/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
+<se:FeatureTypeStyle xmlns:net="http://inspire.ec.europa.eu/schemas/net/5.0" xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:tn-ra="http://inspire.ec.europa.eu/schemas/tn-ra/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
   <se:Name>TN.RailTransportNetwork.RailwayLink.Default</se:Name>
   <se:Description>
     <se:Title>Railway Link Default Style</se:Title>

--- a/feature-styles/TN_RA_RailwayLink_v5_0.se
+++ b/feature-styles/TN_RA_RailwayLink_v5_0.se
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:net="http://inspire.ec.europa.eu/schemas/net/4.0" xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:tn-ra="http://inspire.ec.europa.eu/schemas/tn-ra/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
+  <se:Name>TN.RailTransportNetwork.RailwayLink.Default</se:Name>
+  <se:Description>
+    <se:Title>Railway Link Default Style</se:Title>
+    <se:Abstract>The geometry is rendered as a solid Black (#000000) line with a stroke width of 3 pixel. Ends are rounded and have a 2 pixel black (#000000) casing.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>tn-ra:RailwayLink</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Railway link</se:Title>
+    </se:Description>
+    <se:LineSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>net:centrelineGeometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">5</se:SvgParameter>
+        <se:SvgParameter name="stroke-linejoin">bevel</se:SvgParameter>
+        <se:SvgParameter name="stroke-linecap">round</se:SvgParameter>
+      </se:Stroke>
+    </se:LineSymbolizer>
+    <se:LineSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>net:centrelineGeometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">2</se:SvgParameter>
+        <se:SvgParameter name="stroke-linejoin">bevel</se:SvgParameter>
+        <se:SvgParameter name="stroke-linecap">round</se:SvgParameter>
+      </se:Stroke>
+    </se:LineSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/feature-styles/TN_RA_RailwayStationArea_v5_0.se
+++ b/feature-styles/TN_RA_RailwayStationArea_v5_0.se
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <se:FeatureTypeStyle xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" 
-xmlns:net="http://inspire.ec.europa.eu/schemas/net/4.0"
+xmlns:net="http://inspire.ec.europa.eu/schemas/net/5.0"
 xmlns:sld="http://www.opengis.net/sld" xmlns:tn-ra="http://inspire.ec.europa.eu/schemas/tn-ra/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
   <se:Name>TN.RailTransportNetwork.RailwayStationArea.Default</se:Name>
   <se:Description>

--- a/feature-styles/TN_RA_RailwayStationArea_v5_0.se
+++ b/feature-styles/TN_RA_RailwayStationArea_v5_0.se
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" 
+xmlns:net="http://inspire.ec.europa.eu/schemas/net/4.0"
+xmlns:sld="http://www.opengis.net/sld" xmlns:tn-ra="http://inspire.ec.europa.eu/schemas/tn-ra/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
+  <se:Name>TN.RailTransportNetwork.RailwayStationArea.Default</se:Name>
+  <se:Description>
+    <se:Title>Railway Station Area Default Style</se:Title>
+    <se:Abstract>The geometry is rendered using a Brown (#8B4513) fill and a solid black (#000000) outline with a stroke width of 1 pixel.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>tn-ra:RailwayStationArea</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Railway station area</se:Title>
+    </se:Description>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>net:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Fill>
+        <se:SvgParameter name="fill">#8B4513</se:SvgParameter>
+      </se:Fill>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+      </se:Stroke>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/feature-styles/TN_RA_RailwayYardArea_v5_0.se
+++ b/feature-styles/TN_RA_RailwayYardArea_v5_0.se
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <se:FeatureTypeStyle xmlns:ogc="http://www.opengis.net/ogc" 
 xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" 
-xmlns:net="http://inspire.ec.europa.eu/schemas/net/4.0"
+xmlns:net="http://inspire.ec.europa.eu/schemas/net/5.0"
 xmlns:tn-ra="http://inspire.ec.europa.eu/schemas/tn-ra/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
   <se:Name>TN.RailTransportNetwork.RailwayYardArea.Default</se:Name>
   <se:Description>

--- a/feature-styles/TN_RA_RailwayYardArea_v5_0.se
+++ b/feature-styles/TN_RA_RailwayYardArea_v5_0.se
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:ogc="http://www.opengis.net/ogc" 
+xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" 
+xmlns:net="http://inspire.ec.europa.eu/schemas/net/4.0"
+xmlns:tn-ra="http://inspire.ec.europa.eu/schemas/tn-ra/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
+  <se:Name>TN.RailTransportNetwork.RailwayYardArea.Default</se:Name>
+  <se:Description>
+    <se:Title>Railway Yard Area Default Style</se:Title>
+    <se:Abstract>The geometry is rendered using a Brown (#8B4513) fill and a solid black (#000000) outline with a stroke width of 1 pixel.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>tn-ra:RailwayYardArea</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Railway yard area</se:Title>
+    </se:Description>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>net:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Fill>
+        <se:SvgParameter name="fill">#8B4513</se:SvgParameter>
+      </se:Fill>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+      </se:Stroke>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/feature-styles/TN_RO_RoadArea_v5_0.se
+++ b/feature-styles/TN_RO_RoadArea_v5_0.se
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<se:FeatureTypeStyle xmlns:net="http://inspire.ec.europa.eu/schemas/net/4.0" xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:tn-ro="http://inspire.ec.europa.eu/schemas/tn-ro/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
+<se:FeatureTypeStyle xmlns:net="http://inspire.ec.europa.eu/schemas/net/5.0" xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:tn-ro="http://inspire.ec.europa.eu/schemas/tn-ro/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
   <se:Name>TN.RoadTransportNetwork.RoadArea.Default</se:Name>
   <se:Description>
     <se:Title>Road Area Default Style</se:Title>

--- a/feature-styles/TN_RO_RoadArea_v5_0.se
+++ b/feature-styles/TN_RO_RoadArea_v5_0.se
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:net="http://inspire.ec.europa.eu/schemas/net/4.0" xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:tn-ro="http://inspire.ec.europa.eu/schemas/tn-ro/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
+  <se:Name>TN.RoadTransportNetwork.RoadArea.Default</se:Name>
+  <se:Description>
+    <se:Title>Road Area Default Style</se:Title>
+    <se:Abstract>The geometry is rendered using a grey (#A9A9A9) fill and a solid black (#000000) outline with a stroke width of 1 pixel.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>tn-ro:RoadArea</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Road area</se:Title>
+    </se:Description>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>net:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Fill>
+        <se:SvgParameter name="fill">#A9A9A9</se:SvgParameter>
+      </se:Fill>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+      </se:Stroke>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/feature-styles/TN_RO_RoadLink_v5_0.se
+++ b/feature-styles/TN_RO_RoadLink_v5_0.se
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:net="http://inspire.ec.europa.eu/schemas/net/4.0" xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:tn-ro="http://inspire.ec.europa.eu/schemas/tn-ro/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
+  <se:Name>TN.RoadTransportNetwork.RoadLink.Default</se:Name>
+  <se:Description>
+    <se:Title>Road Link Default Style</se:Title>
+    <se:Abstract>The geometry is rendered as a solid Green (#008000) line with a stroke width of 3 pixel. Ends are rounded and have a 2 pixel black (#000000) casing.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>tn-ro:RoadLink</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Road link</se:Title>
+    </se:Description>
+    <se:LineSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>net:centrelineGeometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">5</se:SvgParameter>
+        <se:SvgParameter name="stroke-linejoin">bevel</se:SvgParameter>
+        <se:SvgParameter name="stroke-linecap">round</se:SvgParameter>
+      </se:Stroke>
+    </se:LineSymbolizer>
+    <se:LineSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>net:centrelineGeometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#008000</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">2</se:SvgParameter>
+        <se:SvgParameter name="stroke-linejoin">bevel</se:SvgParameter>
+        <se:SvgParameter name="stroke-linecap">round</se:SvgParameter>
+      </se:Stroke>
+    </se:LineSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/feature-styles/TN_RO_RoadLink_v5_0.se
+++ b/feature-styles/TN_RO_RoadLink_v5_0.se
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<se:FeatureTypeStyle xmlns:net="http://inspire.ec.europa.eu/schemas/net/4.0" xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:tn-ro="http://inspire.ec.europa.eu/schemas/tn-ro/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
+<se:FeatureTypeStyle xmlns:net="http://inspire.ec.europa.eu/schemas/net/5.0" xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:tn-ro="http://inspire.ec.europa.eu/schemas/tn-ro/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
   <se:Name>TN.RoadTransportNetwork.RoadLink.Default</se:Name>
   <se:Description>
     <se:Title>Road Link Default Style</se:Title>

--- a/feature-styles/TN_RO_RoadNode_v5_0.se
+++ b/feature-styles/TN_RO_RoadNode_v5_0.se
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <se:FeatureTypeStyle
 version="1.1.0"   
-xmlns:net="http://inspire.ec.europa.eu/schemas/net/4.0" 
+xmlns:net="http://inspire.ec.europa.eu/schemas/net/5.0" 
 xmlns:ogc="http://www.opengis.net/ogc" 
 xmlns:se="http://www.opengis.net/se" 
 xmlns:sld="http://www.opengis.net/sld" 

--- a/feature-styles/TN_RO_RoadNode_v5_0.se
+++ b/feature-styles/TN_RO_RoadNode_v5_0.se
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle
+version="1.1.0"   
+xmlns:net="http://inspire.ec.europa.eu/schemas/net/4.0" 
+xmlns:ogc="http://www.opengis.net/ogc" 
+xmlns:se="http://www.opengis.net/se" 
+xmlns:sld="http://www.opengis.net/sld" 
+xmlns:tn-ro="http://inspire.ec.europa.eu/schemas/tn-ro/4.0" 
+xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd">
+      <se:Name>TN.RoadTransportNetwork.RoadNode.Default</se:Name>
+	  <se:Description>
+		<se:Title>Road Node Default Style</se:Title>
+		<se:Abstract>The geometry is rendered using a red (#FF0000) fill and a solid black (#000000) outline with a stroke width of 1 pixel.</se:Abstract>
+	  </se:Description>
+		  <se:FeatureTypeName>tn-ro:RoadNode</se:FeatureTypeName>
+		  <se:Rule>
+			<se:Description>
+			  <se:Title>Road node</se:Title>
+			</se:Description>
+			<se:PointSymbolizer>
+			  <se:Geometry>
+				<ogc:PropertyName>net:geometry</ogc:PropertyName>
+			  </se:Geometry>
+			     <se:Graphic>
+					<se:Mark>
+						<se:WellKnownName>circle</se:WellKnownName>
+						<se:Fill>
+							<se:SvgParameter name="fill">#FF0000</se:SvgParameter>
+						</se:Fill>
+						<se:Stroke>
+							<se:SvgParameter name="stroke">#000000</se:SvgParameter>
+							<se:SvgParameter name="stroke-width">1</se:SvgParameter>
+						</se:Stroke>
+					</se:Mark>
+					<se:Size>3</se:Size>
+				</se:Graphic>
+			</se:PointSymbolizer>
+		  </se:Rule>
+		</se:FeatureTypeStyle>

--- a/feature-styles/TN_RO_RoadServiceArea_v5_0.se
+++ b/feature-styles/TN_RO_RoadServiceArea_v5_0.se
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<se:FeatureTypeStyle xmlns:net="http://inspire.ec.europa.eu/schemas/net/4.0" xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:tn-ro="http://inspire.ec.europa.eu/schemas/tn-ro/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
+<se:FeatureTypeStyle xmlns:net="http://inspire.ec.europa.eu/schemas/net/5.0" xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:tn-ro="http://inspire.ec.europa.eu/schemas/tn-ro/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
   <se:Name>TN.RoadTransportNetwork.RoadServiceArea.Default</se:Name>
   <se:Description>
     <se:Title>Road Service Area Default Style</se:Title>

--- a/feature-styles/TN_RO_RoadServiceArea_v5_0.se
+++ b/feature-styles/TN_RO_RoadServiceArea_v5_0.se
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:net="http://inspire.ec.europa.eu/schemas/net/4.0" xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:tn-ro="http://inspire.ec.europa.eu/schemas/tn-ro/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
+  <se:Name>TN.RoadTransportNetwork.RoadServiceArea.Default</se:Name>
+  <se:Description>
+    <se:Title>Road Service Area Default Style</se:Title>
+    <se:Abstract>The geometry is rendered using a grey (#A9A9A9) fill and a solid black (#000000) outline with a stroke width of 1 pixel.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>tn-ro:RoadServiceArea</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Road service area</se:Title>
+    </se:Description>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>net:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Fill>
+        <se:SvgParameter name="fill">#A9A9A9</se:SvgParameter>
+      </se:Fill>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+      </se:Stroke>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/feature-styles/TN_RO_VehicleTrafficArea_v5_0.se
+++ b/feature-styles/TN_RO_VehicleTrafficArea_v5_0.se
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<se:FeatureTypeStyle xmlns:net="http://inspire.ec.europa.eu/schemas/net/4.0" xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:tn-ro="http://inspire.ec.europa.eu/schemas/tn-ro/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
+<se:FeatureTypeStyle xmlns:net="http://inspire.ec.europa.eu/schemas/net/5.0" xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:tn-ro="http://inspire.ec.europa.eu/schemas/tn-ro/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
   <se:Name>TN.RoadTransportNetwork.VehicleTrafficArea.Default</se:Name>
   <se:Description>
     <se:Title>Vehicle Traffic Area Default Style</se:Title>

--- a/feature-styles/TN_RO_VehicleTrafficArea_v5_0.se
+++ b/feature-styles/TN_RO_VehicleTrafficArea_v5_0.se
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:net="http://inspire.ec.europa.eu/schemas/net/4.0" xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:tn-ro="http://inspire.ec.europa.eu/schemas/tn-ro/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
+  <se:Name>TN.RoadTransportNetwork.VehicleTrafficArea.Default</se:Name>
+  <se:Description>
+    <se:Title>Vehicle Traffic Area Default Style</se:Title>
+    <se:Abstract>The geometry is rendered using a grey (#A9A9A9) fill and a solid black (#000000) outline with a stroke width of 1 pixel.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>tn-ro:VehicleTrafficArea</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Vehicle traffic area</se:Title>
+    </se:Description>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>net:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Fill>
+        <se:SvgParameter name="fill">#A9A9A9</se:SvgParameter>
+      </se:Fill>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+      </se:Stroke>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/feature-styles/TN_TransportArea_v5_0.se
+++ b/feature-styles/TN_TransportArea_v5_0.se
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:tn="http://inspire.ec.europa.eu/schemas/tn/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
+  <se:Name>TN.CommonTransportElements.TransportArea.Default</se:Name>
+  <se:Description>
+    <se:Title>Transport Area Default Style</se:Title>
+    <se:Abstract>The geometry is rendered using a grey (#A9A9A9) fill and a solid black (#000000) outline with a stroke width of 1 pixel.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>tn:TransportArea</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Transport area</se:Title>
+    </se:Description>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>tn:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Fill>
+        <se:SvgParameter name="fill">#A9A9A9</se:SvgParameter>
+      </se:Fill>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+      </se:Stroke>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/feature-styles/TN_TransportLink_v5_0.se
+++ b/feature-styles/TN_TransportLink_v5_0.se
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:net="http://inspire.ec.europa.eu/schemas/net/4.0" xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:tn="http://inspire.ec.europa.eu/schemas/tn/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
+  <se:Name>TN.CommonTransportElements.TransportLink.Default</se:Name>
+  <se:Description>
+    <se:Title>Transport Link Default Style</se:Title>
+    <se:Abstract>The geometry is rendered as a solid Black line with a stroke width of 3 pixel (#000000). Ends are rounded and have a 2 pixel black casing (#000000).</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>tn:TransportLink</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Transport link</se:Title>
+    </se:Description>
+    <se:LineSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>net:centrelineGeometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">7</se:SvgParameter>
+        <se:SvgParameter name="stroke-linejoin">bevel</se:SvgParameter>
+        <se:SvgParameter name="stroke-linecap">round</se:SvgParameter>
+      </se:Stroke>
+    </se:LineSymbolizer>
+    <se:LineSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>net:centrelineGeometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">3</se:SvgParameter>
+        <se:SvgParameter name="stroke-linejoin">bevel</se:SvgParameter>
+        <se:SvgParameter name="stroke-linecap">round</se:SvgParameter>
+      </se:Stroke>
+    </se:LineSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/feature-styles/TN_TransportNode_v5_0.se
+++ b/feature-styles/TN_TransportNode_v5_0.se
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:tn="http://inspire.ec.europa.eu/schemas/tn/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
+  <se:Name>TN.CommonTransportElements.TransportNode.Default</se:Name>
+  <se:Description>
+    <se:Title>Transport Node Default Style</se:Title>
+    <se:Abstract>The geometry is rendered as a circle with a size of 3 pixels, with a red (#FF0000) fill and a black outline (#000000).</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>tn:TransportNode</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Transport node</se:Title>
+    </se:Description>
+    <se:PointSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>tn:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Graphic>
+        <se:Mark>
+          <se:WellKnownName>circle</se:WellKnownName>
+          <se:Fill>
+            <se:SvgParameter name="fill">#FF0000</se:SvgParameter>
+          </se:Fill>
+          <se:Stroke>
+            <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+            <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+          </se:Stroke>
+        </se:Mark>
+        <se:Size>3</se:Size>
+      </se:Graphic>
+    </se:PointSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/feature-styles/TN_W_Beacon_v5_0.se
+++ b/feature-styles/TN_W_Beacon_v5_0.se
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" 
+xmlns:net="http://inspire.ec.europa.eu/schemas/net/4.0"
+xmlns:tn="http://inspire.ec.europa.eu/schemas/tn/4.0"
+xmlns:sld="http://www.opengis.net/sld" xmlns:tn-w="http://inspire.ec.europa.eu/schemas/tn-w/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" 
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
+  <se:Name>TN.WaterTransportNetwork.Beacon.Default</se:Name>
+  <se:Description>
+    <se:Title>Beacon Default Style</se:Title>
+    <se:Abstract>The geometry is rendered as a circle with a size of 3 pixels, with an orange (#FF6600) fill and a black outline (#000000).</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>tn-w:Beacon</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Beacon</se:Title>
+    </se:Description>
+    <se:PointSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>tn:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Graphic>
+        <se:Mark>
+          <se:WellKnownName>circle</se:WellKnownName>
+          <se:Fill>
+            <se:SvgParameter name="fill">#FF6600</se:SvgParameter>
+          </se:Fill>
+          <se:Stroke>
+            <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+            <se:SvgParameter name="stroke-width">0.5</se:SvgParameter>
+          </se:Stroke>
+        </se:Mark>
+        <se:Size>3</se:Size>
+      </se:Graphic>
+    </se:PointSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/feature-styles/TN_W_Beacon_v5_0.se
+++ b/feature-styles/TN_W_Beacon_v5_0.se
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <se:FeatureTypeStyle xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" 
-xmlns:net="http://inspire.ec.europa.eu/schemas/net/4.0"
-xmlns:tn="http://inspire.ec.europa.eu/schemas/tn/4.0"
-xmlns:sld="http://www.opengis.net/sld" xmlns:tn-w="http://inspire.ec.europa.eu/schemas/tn-w/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" 
+xmlns:net="http://inspire.ec.europa.eu/schemas/net/5.0"
+xmlns:tn="http://inspire.ec.europa.eu/schemas/tn/5.0"
+xmlns:sld="http://www.opengis.net/sld" xmlns:tn-w="http://inspire.ec.europa.eu/schemas/tn-w/5.0" xmlns:xlink="http://www.w3.org/1999/xlink" 
 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
   <se:Name>TN.WaterTransportNetwork.Beacon.Default</se:Name>
   <se:Description>

--- a/feature-styles/TN_W_Buoy_v5_0.se
+++ b/feature-styles/TN_W_Buoy_v5_0.se
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" 
+xmlns:net="http://inspire.ec.europa.eu/schemas/net/4.0"
+xmlns:tn-w="http://inspire.ec.europa.eu/schemas/tn-w/4.0"
+xmlns:sld="http://www.opengis.net/sld" xmlns:tn="http://inspire.ec.europa.eu/schemas/tn/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
+  <se:Name>TN.WaterTransportNetwork.Buoy.Default</se:Name>
+  <se:Description>
+    <se:Title>Buoy Default Style</se:Title>
+    <se:Abstract>The geometry is rendered as a circle with a size of 3 pixels, with a green (#008000) fill and a black outline (#000000).</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>tn-w:Buoy</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Buoy</se:Title>
+    </se:Description>
+    <se:PointSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>tn:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Graphic>
+        <se:Mark>
+          <se:WellKnownName>circle</se:WellKnownName>
+          <se:Fill>
+            <se:SvgParameter name="fill">#008000</se:SvgParameter>
+          </se:Fill>
+          <se:Stroke>
+            <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+            <se:SvgParameter name="stroke-width">0.5</se:SvgParameter>
+          </se:Stroke>
+        </se:Mark>
+        <se:Size>3</se:Size>
+      </se:Graphic>
+    </se:PointSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/feature-styles/TN_W_Buoy_v5_0.se
+++ b/feature-styles/TN_W_Buoy_v5_0.se
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <se:FeatureTypeStyle xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" 
-xmlns:net="http://inspire.ec.europa.eu/schemas/net/4.0"
-xmlns:tn-w="http://inspire.ec.europa.eu/schemas/tn-w/4.0"
-xmlns:sld="http://www.opengis.net/sld" xmlns:tn="http://inspire.ec.europa.eu/schemas/tn/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
+xmlns:net="http://inspire.ec.europa.eu/schemas/net/5.0"
+xmlns:tn-w="http://inspire.ec.europa.eu/schemas/tn-w/5.0"
+xmlns:sld="http://www.opengis.net/sld" xmlns:tn="http://inspire.ec.europa.eu/schemas/tn/5.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
   <se:Name>TN.WaterTransportNetwork.Buoy.Default</se:Name>
   <se:Description>
     <se:Title>Buoy Default Style</se:Title>

--- a/feature-styles/TN_W_FairwayArea_v5_0.se
+++ b/feature-styles/TN_W_FairwayArea_v5_0.se
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <se:FeatureTypeStyle xmlns:ogc="http://www.opengis.net/ogc" 
 xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" 
-xmlns:net="http://inspire.ec.europa.eu/schemas/net/4.0"
-xmlns:tn-w="http://inspire.ec.europa.eu/schemas/tn-w/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
+xmlns:net="http://inspire.ec.europa.eu/schemas/net/5.0"
+xmlns:tn-w="http://inspire.ec.europa.eu/schemas/tn-w/5.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
   <se:Name>TN.WaterTransportNetwork.FairwayArea.Default</se:Name>
   <se:Description>
     <se:Title>Fairway Area Default Style</se:Title>

--- a/feature-styles/TN_W_FairwayArea_v5_0.se
+++ b/feature-styles/TN_W_FairwayArea_v5_0.se
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:ogc="http://www.opengis.net/ogc" 
+xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" 
+xmlns:net="http://inspire.ec.europa.eu/schemas/net/4.0"
+xmlns:tn-w="http://inspire.ec.europa.eu/schemas/tn-w/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
+  <se:Name>TN.WaterTransportNetwork.FairwayArea.Default</se:Name>
+  <se:Description>
+    <se:Title>Fairway Area Default Style</se:Title>
+    <se:Abstract>The geometry is rendered using a Blue (#4169E1) fill and a solid black (#000000) outline with a stroke width of 1 pixel.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>tn-w:FairwayArea</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Fairway area</se:Title>
+    </se:Description>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>net:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Fill>
+        <se:SvgParameter name="fill">#4169E1</se:SvgParameter>
+      </se:Fill>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+      </se:Stroke>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/feature-styles/TN_W_PortArea_v5_0.se
+++ b/feature-styles/TN_W_PortArea_v5_0.se
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" 
+xmlns:net="http://inspire.ec.europa.eu/schemas/net/4.0"
+xmlns:sld="http://www.opengis.net/sld" xmlns:tn-w="http://inspire.ec.europa.eu/schemas/tn-w/4.0" 
+xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
+  <se:Name>TN.WaterTransportNetwork.PortArea.Default</se:Name>
+  <se:Description>
+    <se:Title>Port Area Default Style</se:Title>
+    <se:Abstract>The geometry is rendered using a Grey (#696969) fill and a solid black (#000000) outline with a stroke width of 1 pixel.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>tn-w:PortArea</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Port area</se:Title>
+    </se:Description>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>net:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Fill>
+        <se:SvgParameter name="fill">#696969</se:SvgParameter>
+      </se:Fill>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+      </se:Stroke>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/feature-styles/TN_W_PortArea_v5_0.se
+++ b/feature-styles/TN_W_PortArea_v5_0.se
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <se:FeatureTypeStyle xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" 
-xmlns:net="http://inspire.ec.europa.eu/schemas/net/4.0"
-xmlns:sld="http://www.opengis.net/sld" xmlns:tn-w="http://inspire.ec.europa.eu/schemas/tn-w/4.0" 
+xmlns:net="http://inspire.ec.europa.eu/schemas/net/5.0"
+xmlns:sld="http://www.opengis.net/sld" xmlns:tn-w="http://inspire.ec.europa.eu/schemas/tn-w/5.0" 
 xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
   <se:Name>TN.WaterTransportNetwork.PortArea.Default</se:Name>
   <se:Description>

--- a/feature-styles/TN_W_TrafficSeparationSchemeCrossing_v5_0.se
+++ b/feature-styles/TN_W_TrafficSeparationSchemeCrossing_v5_0.se
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <se:FeatureTypeStyle xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" 
-xmlns:tn-w="http://inspire.ec.europa.eu/schemas/tn-w/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" 
-xmlns:net="http://inspire.ec.europa.eu/schemas/net/4.0"
+xmlns:tn-w="http://inspire.ec.europa.eu/schemas/tn-w/5.0" xmlns:xlink="http://www.w3.org/1999/xlink" 
+xmlns:net="http://inspire.ec.europa.eu/schemas/net/5.0"
 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
   <se:Name>TN.WaterTransportNetwork.TrafficSeparationSchemeCrossing.Default</se:Name>
   <se:Description>

--- a/feature-styles/TN_W_TrafficSeparationSchemeCrossing_v5_0.se
+++ b/feature-styles/TN_W_TrafficSeparationSchemeCrossing_v5_0.se
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" 
+xmlns:tn-w="http://inspire.ec.europa.eu/schemas/tn-w/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" 
+xmlns:net="http://inspire.ec.europa.eu/schemas/net/4.0"
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
+  <se:Name>TN.WaterTransportNetwork.TrafficSeparationSchemeCrossing.Default</se:Name>
+  <se:Description>
+    <se:Title>Traffic Separation Scheme Crossing Default Style</se:Title>
+    <se:Abstract>The geometry is rendered using an opaque yellow (#FFCC00) fill and a solid yellow (#FFCC00) outline with a stroke width of 1 pixel.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>tn-w:TrafficSeparationSchemeCrossing</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Traffic separation scheme crossing</se:Title>
+    </se:Description>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>net:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Fill>
+        <se:SvgParameter name="fill">#FFCC00</se:SvgParameter>
+         <se:SvgParameter name="fill-opacity">0.5</se:SvgParameter>
+      </se:Fill>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#FFCC00</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+      </se:Stroke>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/feature-styles/TN_W_TrafficSeparationSchemeSeparator_v5_0.se
+++ b/feature-styles/TN_W_TrafficSeparationSchemeSeparator_v5_0.se
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" 
+xmlns:sld="http://www.opengis.net/sld" xmlns:tn-w="http://inspire.ec.europa.eu/schemas/tn-w/4.0" 
+xmlns:net="http://inspire.ec.europa.eu/schemas/net/4.0"
+xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
+  <se:Name>TN.WaterTransportNetwork.TrafficSeparationSchemeSeparator.Default</se:Name>
+  <se:Description>
+    <se:Title>Traffic Separation Scheme Separator Default Style</se:Title>
+    <se:Abstract>The geometry is rendered using an opaque red (#FF0000) fill and a solid red (#FF0000) outline with a stroke width of 1 pixel.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>tn-w:TrafficSeparationSchemeSeparator</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Traffic separation scheme separator</se:Title>
+    </se:Description>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>net:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Fill>
+        <se:SvgParameter name="fill">#FF0000</se:SvgParameter>
+        <se:SvgParameter name="fill-opacity">0.5</se:SvgParameter> 
+      </se:Fill>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#FF0000</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+      </se:Stroke>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/feature-styles/TN_W_TrafficSeparationSchemeSeparator_v5_0.se
+++ b/feature-styles/TN_W_TrafficSeparationSchemeSeparator_v5_0.se
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <se:FeatureTypeStyle xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" 
-xmlns:sld="http://www.opengis.net/sld" xmlns:tn-w="http://inspire.ec.europa.eu/schemas/tn-w/4.0" 
-xmlns:net="http://inspire.ec.europa.eu/schemas/net/4.0"
+xmlns:sld="http://www.opengis.net/sld" xmlns:tn-w="http://inspire.ec.europa.eu/schemas/tn-w/5.0" 
+xmlns:net="http://inspire.ec.europa.eu/schemas/net/5.0"
 xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
   <se:Name>TN.WaterTransportNetwork.TrafficSeparationSchemeSeparator.Default</se:Name>
   <se:Description>

--- a/feature-styles/TN_W_WaterwayLink_v5_0.se
+++ b/feature-styles/TN_W_WaterwayLink_v5_0.se
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<se:FeatureTypeStyle xmlns:net="http://inspire.ec.europa.eu/schemas/net/4.0" xmlns:ogc="http://www.opengis.net/ogc" 
-xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:tn-w="http://inspire.ec.europa.eu/schemas/tn-w/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
+<se:FeatureTypeStyle xmlns:net="http://inspire.ec.europa.eu/schemas/net/5.0" xmlns:ogc="http://www.opengis.net/ogc" 
+xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:tn-w="http://inspire.ec.europa.eu/schemas/tn-w/5.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
   <se:Name>TN.WaterTransportNetwork.WaterwayLink.Default</se:Name>
   <se:Description>
     <se:Title>Waterway Link Default Style</se:Title>

--- a/feature-styles/TN_W_WaterwayLink_v5_0.se
+++ b/feature-styles/TN_W_WaterwayLink_v5_0.se
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:net="http://inspire.ec.europa.eu/schemas/net/4.0" xmlns:ogc="http://www.opengis.net/ogc" 
+xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:tn-w="http://inspire.ec.europa.eu/schemas/tn-w/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
+  <se:Name>TN.WaterTransportNetwork.WaterwayLink.Default</se:Name>
+  <se:Description>
+    <se:Title>Waterway Link Default Style</se:Title>
+    <se:Abstract>The geometry is rendered as a solid violet (#EE82EE) line with a stroke width of 3 pixel. Ends are rounded and have a 2 pixel black (#000000) casing.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>tn-w:WaterwayLink</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Waterway link</se:Title>
+    </se:Description>
+    <se:LineSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>net:centrelineGeometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">5</se:SvgParameter>
+        <se:SvgParameter name="stroke-linejoin">bevel</se:SvgParameter>
+        <se:SvgParameter name="stroke-linecap">round</se:SvgParameter>
+      </se:Stroke>
+    </se:LineSymbolizer>
+    <se:LineSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>net:centrelineGeometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#EE82EE</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">2</se:SvgParameter>
+        <se:SvgParameter name="stroke-linejoin">bevel</se:SvgParameter>
+        <se:SvgParameter name="stroke-linecap">round</se:SvgParameter>
+      </se:Stroke>
+    </se:LineSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/feature-styles/US_EnvironmentalManagementFacility_v5_0.se
+++ b/feature-styles/US_EnvironmentalManagementFacility_v5_0.se
@@ -1,0 +1,230 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:us-emf="http://inspire.ec.europa.eu/schemas/us-emf/4.0"
+xmlns:act-core="http://inspire.ec.europa.eu/schemas/act-core/4.0"
+xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se"
+xmlns:sld="http://www.opengis.net/sld" xmlns:xlink="http://www.w3.org/1999/xlink"
+xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd"
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
+	<se:Name>US.EnvironmentalManagementFacility</se:Name>
+	<se:Description>
+    	<se:Title>Environmental Management Facility</se:Title>
+    	<se:Abstract>Point geometries are rendered as a triangle with a size of 5 pixels, with a 50% grey (#808080) fill and a black outline. Line geometries are rendered as a solid black line with a stroke width of 1 pixel.
+		Polygon geometries are rendered using a 50% grey (#808080) fill and a solid black outline with a stroke width of 1 pixel. Installation and site styles are applied when present in data.</se:Abstract>
+	</se:Description>
+	<se:FeatureTypeName>us-emf:EnvironmentalManagementFacility</se:FeatureTypeName>
+  	<se:Rule>
+			<se:Description>
+	      <se:Title>Environmental management facility default</se:Title>
+	    </se:Description>
+  	<ogc:Filter>
+    	<ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsSurface">
+        		<ogc:PropertyName>act-core:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+   		</ogc:Filter>
+	    <se:PolygonSymbolizer>
+	      <se:Geometry>
+	        <ogc:PropertyName>act-core:geometry</ogc:PropertyName>
+	      </se:Geometry>
+	      <se:Fill>
+	      	<se:SvgParameter name="fill">#808080</se:SvgParameter>
+	      	<se:SvgParameter name="fill-opacity">0.50</se:SvgParameter>
+	      </se:Fill>
+	      <se:Stroke>
+	        <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+	        <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+	      </se:Stroke>
+	    </se:PolygonSymbolizer>
+	  </se:Rule>
+	  <se:Rule>
+			<se:Description>
+	      <se:Title>Environmental management facility default</se:Title>
+	    </se:Description>
+		<ogc:Filter>
+    		<ogc:PropertyIsEqualTo>
+        		<ogc:Function name="IsPoint">
+        			<ogc:PropertyName>act-core:geometry</ogc:PropertyName>
+       			</ogc:Function>
+       			<ogc:Literal>true</ogc:Literal>
+       		</ogc:PropertyIsEqualTo>
+   		</ogc:Filter>
+	    <se:PointSymbolizer>
+	      <se:Geometry>
+	        <ogc:PropertyName>act-core:geometry</ogc:PropertyName>
+	      </se:Geometry>
+	      <se:Graphic>
+	        <se:Mark>
+	          <se:WellKnownName>triangle</se:WellKnownName>
+	          <se:Fill>
+	            <se:SvgParameter name="fill">#808080</se:SvgParameter>
+	            <se:SvgParameter name="fill-opacity">0.50</se:SvgParameter>
+	          </se:Fill>
+	          <se:Stroke>
+	            <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+	            <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+	          </se:Stroke>
+	        </se:Mark>
+	        <se:Size>5</se:Size>
+	      </se:Graphic>
+	    </se:PointSymbolizer>
+	</se:Rule>
+	<se:Rule>
+		<se:Description>
+			<se:Title>Environmental management facility default</se:Title>
+		</se:Description>
+		<ogc:Filter>
+    		<ogc:PropertyIsEqualTo>
+        		<ogc:Function name="IsCurve">
+        			<ogc:PropertyName>act-core:geometry</ogc:PropertyName>
+       			</ogc:Function>
+       			<ogc:Literal>true</ogc:Literal>
+       		</ogc:PropertyIsEqualTo>
+   		</ogc:Filter>
+	    <se:LineSymbolizer>
+	      <se:Geometry>
+	        <ogc:PropertyName>act-core:geometry</ogc:PropertyName>
+	      </se:Geometry>
+	      <se:Stroke>
+	      	<se:SvgParameter name="stroke">#000000</se:SvgParameter>
+	        <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+	      </se:Stroke>
+	    </se:LineSymbolizer>
+  	</se:Rule>
+		<se:Rule>
+	   <se:Description>
+      <se:Title>Installation</se:Title>
+    </se:Description>
+    <ogc:Filter>
+    	<ogc:And>
+    		<ogc:PropertyIsEqualTo>
+        		<ogc:Function name="IsPoint">
+        			<ogc:PropertyName>act-core:geometry</ogc:PropertyName>
+       			</ogc:Function>
+       			<ogc:Literal>true</ogc:Literal>
+       		</ogc:PropertyIsEqualTo>
+		<ogc:PropertyIsEqualTo>
+				<ogc:PropertyName>us-emf:type/@xlink:href</ogc:PropertyName>
+				<ogc:Literal>http://inspire.ec.europa.eu/codelist/EnvironmentalManagementFacilityTypeValue/installation</ogc:Literal>
+			</ogc:PropertyIsEqualTo>
+		 </ogc:And>
+   	</ogc:Filter>
+	    <se:PointSymbolizer>
+	      <se:Geometry>
+	        <ogc:PropertyName>act-core:geometry</ogc:PropertyName>
+	      </se:Geometry>
+	      <se:Graphic>
+	        <se:Mark>
+	          <se:WellKnownName>triangle</se:WellKnownName>
+	          <se:Fill>
+	            <se:SvgParameter name="fill">#808080</se:SvgParameter>
+	          </se:Fill>
+	          <se:Stroke>
+	            <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+	            <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+	          </se:Stroke>
+	        </se:Mark>
+	        <se:Size>5</se:Size>
+	      </se:Graphic>
+	    </se:PointSymbolizer>
+		</se:Rule>
+		<se:Rule>
+  	 <se:Description>
+      <se:Title>Site</se:Title>
+    </se:Description>
+  	<ogc:Filter>
+    	<ogc:And>
+    		<ogc:PropertyIsEqualTo>
+        		<ogc:Function name="IsSurface">
+        			<ogc:PropertyName>act-core:geometry</ogc:PropertyName>
+       			</ogc:Function>
+       			<ogc:Literal>true</ogc:Literal>
+       		</ogc:PropertyIsEqualTo>
+		<ogc:PropertyIsEqualTo>
+				<ogc:PropertyName>us-emf:type/@xlink:href</ogc:PropertyName>
+				<ogc:Literal>http://inspire.ec.europa.eu/codelist/EnvironmentalManagementFacilityTypeValue/site</ogc:Literal>
+			</ogc:PropertyIsEqualTo>
+		 </ogc:And>
+   	</ogc:Filter>
+	    <se:PolygonSymbolizer>
+	      <se:Geometry>
+	        <ogc:PropertyName>act-core:geometry</ogc:PropertyName>
+	      </se:Geometry>
+	      <se:Fill>
+	      	<se:SvgParameter name="fill">#808080</se:SvgParameter>
+	      	<se:SvgParameter name="fill-opacity">0.50</se:SvgParameter>
+	      </se:Fill>
+	      <se:Stroke>
+	        <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+	        <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+	      </se:Stroke>
+	    </se:PolygonSymbolizer>
+	  </se:Rule>
+	  <se:Rule>
+	   <se:Description>
+      <se:Title>Site</se:Title>
+    </se:Description>
+		<ogc:Filter>
+    	<ogc:And>
+    		<ogc:PropertyIsEqualTo>
+        		<ogc:Function name="IsPoint">
+        			<ogc:PropertyName>act-core:geometry</ogc:PropertyName>
+       			</ogc:Function>
+       			<ogc:Literal>true</ogc:Literal>
+       		</ogc:PropertyIsEqualTo>
+		<ogc:PropertyIsEqualTo>
+				<ogc:PropertyName>us-emf:type/@xlink:href</ogc:PropertyName>
+				<ogc:Literal>http://inspire.ec.europa.eu/codelist/EnvironmentalManagementFacilityTypeValue/site</ogc:Literal>
+			</ogc:PropertyIsEqualTo>
+		 </ogc:And>
+   	</ogc:Filter>
+	    <se:PointSymbolizer>
+	      <se:Geometry>
+	        <ogc:PropertyName>act-core:geometry</ogc:PropertyName>
+	      </se:Geometry>
+	      <se:Graphic>
+	        <se:Mark>
+	          <se:WellKnownName>triangle</se:WellKnownName>
+	          <se:Fill>
+	            <se:SvgParameter name="fill">#808080</se:SvgParameter>
+	            <se:SvgParameter name="fill-opacity">0.50</se:SvgParameter>
+	          </se:Fill>
+	          <se:Stroke>
+	            <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+	            <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+	          </se:Stroke>
+	        </se:Mark>
+	        <se:Size>5</se:Size>
+	      </se:Graphic>
+	    </se:PointSymbolizer>
+	</se:Rule>
+	<se:Rule>
+	 <se:Description>
+      <se:Title>Site</se:Title>
+    </se:Description>
+	<ogc:Filter>
+    	<ogc:And>
+    		<ogc:PropertyIsEqualTo>
+        		<ogc:Function name="IsCurve">
+        			<ogc:PropertyName>act-core:geometry</ogc:PropertyName>
+       			</ogc:Function>
+       			<ogc:Literal>true</ogc:Literal>
+       		</ogc:PropertyIsEqualTo>
+		<ogc:PropertyIsEqualTo>
+				<ogc:PropertyName>us-emf:type/@xlink:href</ogc:PropertyName>
+				<ogc:Literal>http://inspire.ec.europa.eu/codelist/EnvironmentalManagementFacilityTypeValue/site</ogc:Literal>
+			</ogc:PropertyIsEqualTo>
+		 </ogc:And>
+   	</ogc:Filter>
+	    <se:LineSymbolizer>
+	      <se:Geometry>
+	        <ogc:PropertyName>act-core:geometry</ogc:PropertyName>
+	      </se:Geometry>
+	      <se:Stroke>
+	      	<se:SvgParameter name="stroke">#000000</se:SvgParameter>
+	        <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+	      </se:Stroke>
+	    </se:LineSymbolizer>
+  	</se:Rule>
+  	</se:FeatureTypeStyle>

--- a/feature-styles/US_GovernmentalService_v5_0.se
+++ b/feature-styles/US_GovernmentalService_v5_0.se
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<se:FeatureTypeStyle  xmlns:us="http://inspire.ec.europa.eu/schemas/us-govserv/4.0" 
-xmlns:net="http://inspire.ec.europa.eu/schemas/net/4.0" 
+<se:FeatureTypeStyle  xmlns:us="http://inspire.ec.europa.eu/schemas/us-govserv/5.0" 
+xmlns:net="http://inspire.ec.europa.eu/schemas/net/5.0" 
 xmlns:ogc="http://www.opengis.net/ogc" 
 xmlns:se="http://www.opengis.net/se" 
 xmlns:sld="http://www.opengis.net/sld" 

--- a/feature-styles/US_GovernmentalService_v5_0.se
+++ b/feature-styles/US_GovernmentalService_v5_0.se
@@ -1,0 +1,178 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle  xmlns:us="http://inspire.ec.europa.eu/schemas/us-govserv/4.0" 
+xmlns:net="http://inspire.ec.europa.eu/schemas/net/4.0" 
+xmlns:ogc="http://www.opengis.net/ogc" 
+xmlns:se="http://www.opengis.net/se" 
+xmlns:sld="http://www.opengis.net/sld" 
+xmlns:gml="http://www.opengis.net/gml/3.2"
+xmlns:xlink="http://www.w3.org/1999/xlink" 
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+version="1.1.0" 
+xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd">
+  <se:Name>US.AdministrativeAndSocialGovernmentalServices.Default</se:Name>
+  <se:Description>
+    <se:Title>Administrative and Social Governmental Services Default Style</se:Title>
+    <se:Abstract>The location of the service shall be portrayed as point symbols.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>us:GovernmentalService</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Administrative and social governmental services default</se:Title>
+    </se:Description>
+    <ogc:Filter>
+    	<ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsSurface">
+        		<ogc:PropertyName>us:areaOfResponsibility/us:AreaOfResponsibilityType/us:areaOfResponsibilityByPolygon</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+   	</ogc:Filter>
+   	<se:MinScaleDenominator>1.0</se:MinScaleDenominator>
+    <se:MaxScaleDenominator>500000.0</se:MaxScaleDenominator>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>us:areaOfResponsibility/us:AreaOfResponsibilityType/us:areaOfResponsibilityByPolygon</ogc:PropertyName>
+      </se:Geometry>
+      <se:Fill>
+        <se:SvgParameter name="fill">#808080</se:SvgParameter>
+      </se:Fill>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+      </se:Stroke>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Administrative and social governmental services default</se:Title>
+    </se:Description>
+    <ogc:Filter>
+    	<ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsSurface">
+        		<ogc:PropertyName>us:areaOfResponsibility/us:AreaOfResponsibilityType/us:areaOfResponsibilityByAdministrativeUnit/au:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+   	</ogc:Filter>
+   	  <se:MinScaleDenominator>1.0</se:MinScaleDenominator>
+    <se:MaxScaleDenominator>500000.0</se:MaxScaleDenominator>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>us:areaOfResponsibility/us:AreaOfResponsibilityType/us:areaOfResponsibilityByAdministrativeUnit/au:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Fill>
+        <se:SvgParameter name="fill">#000000</se:SvgParameter>
+      </se:Fill>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+      </se:Stroke>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+    <se:Rule>
+  <se:Description>
+      <se:Title>Administrative and social governmental services default</se:Title>
+    </se:Description>
+    <se:MinScaleDenominator>1.0</se:MinScaleDenominator>
+    <se:MaxScaleDenominator>500000.0</se:MaxScaleDenominator>
+    <se:PointSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>us:serviceLocation/us:ServiceLocationType/us:serviceLocationByGeometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Graphic>
+        <se:Mark>
+          <se:WellKnownName>circle</se:WellKnownName>
+          <se:Fill>
+            <se:SvgParameter name="fill">#FF0000</se:SvgParameter>
+          </se:Fill>
+          <se:Stroke>
+            <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+            <se:SvgParameter name="stroke-width">0.5</se:SvgParameter>
+          </se:Stroke>
+        </se:Mark>
+        <se:Size>6</se:Size>
+      </se:Graphic>
+    </se:PointSymbolizer>
+  </se:Rule> 
+  
+<!--  
+  <se:Rule>
+  <se:Description>
+      <se:Title>Administrative and social governmental services - Education - point symbol</se:Title>
+    </se:Description>
+    <ogc:Filter>
+		<ogc:PropertyIsEqualTo> 
+			<ogc:PropertyName>us:serviceType/@xlink:href</ogc:PropertyName>
+			<ogc:Literal>http://inspire.ec.europa.eu/codelist/ServiceTypeValue/administrationForEducation</ogc:Literal>
+		</ogc:PropertyIsEqualTo>
+	</ogc:Filter>
+    <se:MinScaleDenominator>1.0</se:MinScaleDenominator>
+    <se:MaxScaleDenominator>500000.0</se:MaxScaleDenominator>
+    <se:PointSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>us:serviceLocation/us:ServiceLocationType/us:serviceLocationByGeometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Graphic>
+        <se:ExternalGraphic>
+        	<se:OnlineResource xlink:type="simple"
+        	xlink:href="https://wetransform.box.com/s/4wwic9yuphf8yxhinzatkqm6a2et3gg8"/>
+        	<se:Format>image/svg</se:Format>
+        </se:ExternalGraphic>
+        <se:Size>20</se:Size>
+      </se:Graphic>
+    </se:PointSymbolizer>
+  </se:Rule>
+ <se:Rule>
+    <se:Description>
+      <se:Title>Administrative and social governmental services - Education - point symbol</se:Title>
+    </se:Description>
+    <ogc:Filter>
+		<ogc:PropertyIsEqualTo> 
+			<ogc:PropertyName>us:serviceType/@xlink:href</ogc:PropertyName>
+			<ogc:Literal>http://inspire.ec.europa.eu/codelist/ServiceTypeValue/administrationForEducation</ogc:Literal>
+		</ogc:PropertyIsEqualTo>
+	</ogc:Filter>
+    <se:MinScaleDenominator>1.0</se:MinScaleDenominator>
+    <se:MaxScaleDenominator>500000.0</se:MaxScaleDenominator>
+    <se:PointSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>us:serviceLocation/us:ServiceLocationType/us:serviceLocationByGeometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Graphic>
+        <se:ExternalGraphic>
+        	<se:OnlineResource xlink:type="simple"
+        	xlink:href="https://wetransform.box.com/s/4wwic9yuphf8yxhinzatkqm6a2et3gg8"/>
+        	<se:Format>image/svg</se:Format>
+        </se:ExternalGraphic>
+        <se:Size>20</se:Size>
+      </se:Graphic>
+    </se:PointSymbolizer>
+  </se:Rule>
+    <se:Rule>
+    <se:Description>
+      <se:Title>Administrative and social governmental services - Police - point symbol</se:Title>
+    </se:Description>
+    <ogc:Filter>
+		<ogc:PropertyIsEqualTo> 
+			<ogc:PropertyName>us:serviceType/@xlink:href</ogc:PropertyName>
+			<ogc:Literal>http://inspire.ec.europa.eu/codelist/ServiceTypeValue/policeService</ogc:Literal>
+		</ogc:PropertyIsEqualTo>
+	</ogc:Filter>
+    <se:MinScaleDenominator>1.0</se:MinScaleDenominator>
+    <se:MaxScaleDenominator>500000.0</se:MaxScaleDenominator>
+    <se:PointSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>us:serviceLocation/us:ServiceLocationType/us:serviceLocationByGeometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Graphic>
+        <se:ExternalGraphic>
+        	<se:OnlineResource xlink:type="simple"
+        	xlink:href="https://upload.wikimedia.org/wikipedia/commons/thumb/b/ba/Flag_of_Germany.svg/800px-Flag_of_Germany.svg.png"/>
+        	<se:Format>image/png</se:Format>
+        </se:ExternalGraphic>
+        <se:Size>20</se:Size>
+      </se:Graphic>
+    </se:PointSymbolizer>
+  </se:Rule>
+  -->
+</se:FeatureTypeStyle>

--- a/feature-styles/US_UtilityNetworkAppurtenance_v5_0.se
+++ b/feature-styles/US_UtilityNetworkAppurtenance_v5_0.se
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" 
+xmlns:sld="http://www.opengis.net/sld" xmlns:net="http://inspire.ec.europa.eu/schemas/net/4.0" 
+xmlns:us-net-common="http://inspire.ec.europa.eu/schemas/us-net-common/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" 
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd" version="1.1.0">
+  <se:Name>US.UtilityNetworkAppurtenance.Default</se:Name>
+  <se:Description>
+    <se:Title>Appurtenance Default Style</se:Title>
+    <se:Abstract>The geometry is rendered using a yellow (#FFFF00) fill.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>us-net-common:Appurtenance</se:FeatureTypeName>
+  <se:Rule>
+  <se:Description>
+      <se:Title>Appurtenance</se:Title>
+    </se:Description>
+    <se:PointSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>net:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Graphic>
+        <se:Mark>
+          <se:WellKnownName>square</se:WellKnownName>
+          <se:Fill>
+            <se:SvgParameter name="fill">#FFFF00</se:SvgParameter>
+          </se:Fill>
+          <se:Stroke>
+            <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+            <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+          </se:Stroke>
+        </se:Mark>
+        <se:Size>10</se:Size>
+      </se:Graphic>
+    </se:PointSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/feature-styles/US_UtilityNetworkAppurtenance_v5_0.se
+++ b/feature-styles/US_UtilityNetworkAppurtenance_v5_0.se
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <se:FeatureTypeStyle xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" 
-xmlns:sld="http://www.opengis.net/sld" xmlns:net="http://inspire.ec.europa.eu/schemas/net/4.0" 
-xmlns:us-net-common="http://inspire.ec.europa.eu/schemas/us-net-common/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" 
+xmlns:sld="http://www.opengis.net/sld" xmlns:net="http://inspire.ec.europa.eu/schemas/net/5.0" 
+xmlns:us-net-common="http://inspire.ec.europa.eu/schemas/us-net-common/5.0" xmlns:xlink="http://www.w3.org/1999/xlink" 
 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd" version="1.1.0">
   <se:Name>US.UtilityNetworkAppurtenance.Default</se:Name>

--- a/feature-styles/US_UtilityNetworkLink_v5_0.se
+++ b/feature-styles/US_UtilityNetworkLink_v5_0.se
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<se:FeatureTypeStyle xmlns:net="http://inspire.ec.europa.eu/schemas/net/4.0" 
+<se:FeatureTypeStyle xmlns:net="http://inspire.ec.europa.eu/schemas/net/5.0" 
 xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" 
-xmlns:sld="http://www.opengis.net/sld" xmlns:us-net-common="http://inspire.ec.europa.eu/schemas/us-net-common/4.0" 
+xmlns:sld="http://www.opengis.net/sld" xmlns:us-net-common="http://inspire.ec.europa.eu/schemas/us-net-common/5.0" 
 xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
   <se:Name>US.UtilityNetworkLink.Default</se:Name>
   <se:Description>

--- a/feature-styles/US_UtilityNetworkLink_v5_0.se
+++ b/feature-styles/US_UtilityNetworkLink_v5_0.se
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:net="http://inspire.ec.europa.eu/schemas/net/4.0" 
+xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" 
+xmlns:sld="http://www.opengis.net/sld" xmlns:us-net-common="http://inspire.ec.europa.eu/schemas/us-net-common/4.0" 
+xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
+  <se:Name>US.UtilityNetworkLink.Default</se:Name>
+  <se:Description>
+    <se:Title>Utility Link Default Style</se:Title>
+    <se:Abstract>The geometry is rendered as a solid maroon (#800000)line with a stroke width of 3 pixel. Ends are rounded and have a 2 pixel black (#000000) casing.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>us-net-common:UtilityLink</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Utility link</se:Title>
+    </se:Description>
+    <se:LineSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>net:centrelineGeometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">7</se:SvgParameter>
+        <se:SvgParameter name="stroke-linejoin">bevel</se:SvgParameter>
+        <se:SvgParameter name="stroke-linecap">round</se:SvgParameter>
+      </se:Stroke>
+    </se:LineSymbolizer>
+    <se:LineSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>net:centrelineGeometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#800000</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">3</se:SvgParameter>
+        <se:SvgParameter name="stroke-linejoin">bevel</se:SvgParameter>
+        <se:SvgParameter name="stroke-linecap">round</se:SvgParameter>
+      </se:Stroke>
+    </se:LineSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/generated/config.xmi
+++ b/generated/config.xmi
@@ -1,123 +1,150 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<styleconfig:StyleModel xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:ad_4.0="http://inspire.ec.europa.eu/schemas/ad/4.0" xmlns:am_4.0="http://inspire.ec.europa.eu/schemas/am/4.0" xmlns:au_4.0="http://inspire.ec.europa.eu/schemas/au/4.0" xmlns:br_4.0="http://inspire.ec.europa.eu/schemas/br/4.0" xmlns:bu-core2d_4.0="http://inspire.ec.europa.eu/schemas/bu-core2d/4.0" xmlns:cp_4.0="http://inspire.ec.europa.eu/schemas/cp/4.0" xmlns:ef_4.0="http://inspire.ec.europa.eu/schemas/ef/4.0" xmlns:el-tin_4.0="http://inspire.ec.europa.eu/schemas/el-tin/4.0" xmlns:el-vec_4.0="http://inspire.ec.europa.eu/schemas/el-vec/4.0" xmlns:elu_4.0="http://inspire.ec.europa.eu/schemas/elu/4.0" xmlns:er-v_4.0="http://inspire.ec.europa.eu/schemas/er-v/4.0" xmlns:ge-core_4.0="http://inspire.ec.europa.eu/schemas/ge-core/4.0" xmlns:gn_4.0="http://inspire.ec.europa.eu/schemas/gn/4.0" xmlns:hh_4.0="http://inspire.ec.europa.eu/schemas/hh/4.0" xmlns:hy-n_4.0="http://inspire.ec.europa.eu/schemas/hy-n/4.0" xmlns:hy-p_4.0="http://inspire.ec.europa.eu/schemas/hy-p/4.0" xmlns:lcv_4.0="http://inspire.ec.europa.eu/schemas/lcv/4.0" xmlns:mu_3.0="http://inspire.ec.europa.eu/schemas/mu/3.0" xmlns:nz-core_4.0="http://inspire.ec.europa.eu/schemas/nz-core/4.0" xmlns:pf_4.0="http://inspire.ec.europa.eu/schemas/pf/4.0" xmlns:plu_4.0="http://inspire.ec.europa.eu/schemas/plu/4.0" xmlns:ps_4.0="http://inspire.ec.europa.eu/schemas/ps/4.0" xmlns:ps_5.0="http://inspire.ec.europa.eu/schemas/ps/5.0" xmlns:samplingSpatial_2.0="http://www.opengis.net/samplingSpatial/2.0" xmlns:sd_4.0="http://inspire.ec.europa.eu/schemas/sd/4.0" xmlns:styleconfig="http://to.wetf.styling.models/model/styles" xmlns:su-grid_4.0="https://inspire.ec.europa.eu/schemas/su-grid/4.0" xmlns:su-vector_4.0="http://inspire.ec.europa.eu/schemas/su-vector/4.0" xmlns:tn-a_4.0="http://inspire.ec.europa.eu/schemas/tn-a/4.0" xmlns:tn-c_4.0="http://inspire.ec.europa.eu/schemas/tn-c/4.0" xmlns:tn-ra_4.0="http://inspire.ec.europa.eu/schemas/tn-ra/4.0" xmlns:tn-ro_4.0="http://inspire.ec.europa.eu/schemas/tn-ro/4.0" xmlns:tn-w_4.0="http://inspire.ec.europa.eu/schemas/tn-w/4.0" xmlns:tn_4.0="http://inspire.ec.europa.eu/schemas/tn/4.0" xmlns:us-emf_4.0="http://inspire.ec.europa.eu/schemas/us-emf/4.0" xmlns:us-govserv_4.0="http://inspire.ec.europa.eu/schemas/us-govserv/4.0" xmlns:us-net-common_4.0="http://inspire.ec.europa.eu/schemas/us-net-common/4.0">
+<styleconfig:StyleModel xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:ad_4.0="http://inspire.ec.europa.eu/schemas/ad/4.0" xmlns:am_4.0="http://inspire.ec.europa.eu/schemas/am/4.0" xmlns:au_4.0="http://inspire.ec.europa.eu/schemas/au/4.0" xmlns:br_4.0="http://inspire.ec.europa.eu/schemas/br/4.0" xmlns:bu-core2d_4.0="http://inspire.ec.europa.eu/schemas/bu-core2d/4.0" xmlns:cp_4.0="http://inspire.ec.europa.eu/schemas/cp/4.0" xmlns:ef_4.0="http://inspire.ec.europa.eu/schemas/ef/4.0" xmlns:el-tin_4.0="http://inspire.ec.europa.eu/schemas/el-tin/4.0" xmlns:el-vec_4.0="http://inspire.ec.europa.eu/schemas/el-vec/4.0" xmlns:elu_4.0="http://inspire.ec.europa.eu/schemas/elu/4.0" xmlns:er-v_4.0="http://inspire.ec.europa.eu/schemas/er-v/4.0" xmlns:ge-core_4.0="http://inspire.ec.europa.eu/schemas/ge-core/4.0" xmlns:gn_4.0="http://inspire.ec.europa.eu/schemas/gn/4.0" xmlns:hh_4.0="http://inspire.ec.europa.eu/schemas/hh/4.0" xmlns:hh_5.0="http://inspire.ec.europa.eu/schemas/hh/5.0" xmlns:hy-n_4.0="http://inspire.ec.europa.eu/schemas/hy-n/4.0" xmlns:hy-n_5.0="http://inspire.ec.europa.eu/schemas/hy-n/5.0" xmlns:hy-p_4.0="http://inspire.ec.europa.eu/schemas/hy-p/4.0" xmlns:hy-p_5.0="http://inspire.ec.europa.eu/schemas/hy-p/5.0" xmlns:lcv_4.0="http://inspire.ec.europa.eu/schemas/lcv/4.0" xmlns:lcv_5.0="http://inspire.ec.europa.eu/schemas/lcv/5.0" xmlns:mu_3.0="http://inspire.ec.europa.eu/schemas/mu/3.0" xmlns:nz-core_4.0="http://inspire.ec.europa.eu/schemas/nz-core/4.0" xmlns:pf_4.0="http://inspire.ec.europa.eu/schemas/pf/4.0" xmlns:plu_4.0="http://inspire.ec.europa.eu/schemas/plu/4.0" xmlns:ps_4.0="http://inspire.ec.europa.eu/schemas/ps/4.0" xmlns:ps_5.0="http://inspire.ec.europa.eu/schemas/ps/5.0" xmlns:samplingSpatial_2.0="http://www.opengis.net/samplingSpatial/2.0" xmlns:sd_4.0="http://inspire.ec.europa.eu/schemas/sd/4.0" xmlns:styleconfig="http://to.wetf.styling.models/model/styles" xmlns:su-grid_4.0="https://inspire.ec.europa.eu/schemas/su-grid/4.0" xmlns:su-vector_4.0="http://inspire.ec.europa.eu/schemas/su-vector/4.0" xmlns:tn-a_4.0="http://inspire.ec.europa.eu/schemas/tn-a/4.0" xmlns:tn-a_5.0="http://inspire.ec.europa.eu/schemas/tn-a/5.0" xmlns:tn-c_4.0="http://inspire.ec.europa.eu/schemas/tn-c/4.0" xmlns:tn-c_5.0="http://inspire.ec.europa.eu/schemas/tn-c/5.0" xmlns:tn-ra_4.0="http://inspire.ec.europa.eu/schemas/tn-ra/4.0" xmlns:tn-ra_5.0="http://inspire.ec.europa.eu/schemas/tn-ra/5.0" xmlns:tn-ro_4.0="http://inspire.ec.europa.eu/schemas/tn-ro/4.0" xmlns:tn-ro_5.0="http://inspire.ec.europa.eu/schemas/tn-ro/5.0" xmlns:tn-w_4.0="http://inspire.ec.europa.eu/schemas/tn-w/4.0" xmlns:tn-w_5.0="http://inspire.ec.europa.eu/schemas/tn-w/5.0" xmlns:tn_4.0="http://inspire.ec.europa.eu/schemas/tn/4.0" xmlns:tn_5.0="http://inspire.ec.europa.eu/schemas/tn/5.0" xmlns:us-emf_4.0="http://inspire.ec.europa.eu/schemas/us-emf/4.0" xmlns:us-emf_5.0="http://inspire.ec.europa.eu/schemas/us-emf/5.0" xmlns:us-govserv_4.0="http://inspire.ec.europa.eu/schemas/us-govserv/4.0" xmlns:us-govserv_5.0="http://inspire.ec.europa.eu/schemas/us-govserv/5.0" xmlns:us-net-common_4.0="http://inspire.ec.europa.eu/schemas/us-net-common/4.0" xmlns:us-net-common_5.0="http://inspire.ec.europa.eu/schemas/us-net-common/5.0">
   <tags name="inspire"/>
   <tags name="inspire_wetransform"/>
   <tags name="production"/>
-  <layerConfig name="AD_Address" registryId="http://inspire.ec.europa.eu/layer/AD.Address" tags="//@tags.0 //@tags.2" layerName="AD.Address" styleConfig="//@styleConfig.67">
+  <layerConfig name="AD_Address" registryId="http://inspire.ec.europa.eu/layer/AD.Address" tags="//@tags.0 //@tags.2" layerName="AD.Address" styleConfig="//@styleConfig.83">
     <title lang="en" text="Addresses"/>
     <title text="Addressen"/>
     <objectType>ad_4.0:Address</objectType>
   </layerConfig>
-  <layerConfig name="AU_AdministrativeBoundary" registryId="http://inspire.ec.europa.eu/layer/AU.AdministrativeBoundary" tags="//@tags.2 //@tags.0" layerName="AU.AdministrativeBoundary" styleConfig="//@styleConfig.68">
+  <layerConfig name="AU_AdministrativeBoundary" registryId="http://inspire.ec.europa.eu/layer/AU.AdministrativeBoundary" tags="//@tags.2 //@tags.0" layerName="AU.AdministrativeBoundary" styleConfig="//@styleConfig.84">
     <title lang="en" text="Administrative boundary"/>
     <title text="Verwaltungsgrenze"/>
     <objectType>au_4.0:AdministrativeBoundary</objectType>
   </layerConfig>
-  <layerConfig name="AU_AdministrativeUnit" registryId="http://inspire.ec.europa.eu/layer/AU.AdministrativeUnit" tags="//@tags.2 //@tags.0" layerName="AU.AdministrativeUnit" styleConfig="//@styleConfig.69">
+  <layerConfig name="AU_AdministrativeUnit" registryId="http://inspire.ec.europa.eu/layer/AU.AdministrativeUnit" tags="//@tags.2 //@tags.0" layerName="AU.AdministrativeUnit" styleConfig="//@styleConfig.85">
     <title lang="en" text="Administrative unit"/>
     <title text="Verwaltungseinheit"/>
     <objectType>au_4.0:AdministrativeUnit</objectType>
   </layerConfig>
-  <layerConfig name="AU_Baseline" registryId="http://inspire.ec.europa.eu/layer/AU.Baseline" layerName="AU.Baseline" styleConfig="//@styleConfig.70">
+  <layerConfig name="AU_Baseline" registryId="http://inspire.ec.europa.eu/layer/AU.Baseline" layerName="AU.Baseline" styleConfig="//@styleConfig.86">
     <title lang="en" text="Baseline"/>
     <title text="Basislinie"/>
     <objectType>mu_3.0:Baseline</objectType>
   </layerConfig>
-  <layerConfig name="AU_Condominium" registryId="http://inspire.ec.europa.eu/layer/AU.Condominium" layerName="AU.Condominium" styleConfig="//@styleConfig.71">
+  <layerConfig name="AU_Condominium" registryId="http://inspire.ec.europa.eu/layer/AU.Condominium" layerName="AU.Condominium" styleConfig="//@styleConfig.87">
     <title lang="en" text="Condominium"/>
     <title text="Kondominium"/>
     <objectType>au_4.0:Condominium</objectType>
   </layerConfig>
-  <layerConfig name="AU_ContiguousZone" registryId="http://inspire.ec.europa.eu/layer/AU.ContiguousZone" layerName="AU.ContiguousZone" styleConfig="//@styleConfig.72">
+  <layerConfig name="AU_ContiguousZone" registryId="http://inspire.ec.europa.eu/layer/AU.ContiguousZone" layerName="AU.ContiguousZone" styleConfig="//@styleConfig.88">
     <title lang="en" text="Contiguous zone"/>
     <title text="Anschlusszone"/>
     <objectType>mu_3.0:ContiguousZone</objectType>
   </layerConfig>
-  <layerConfig name="AU_ContinentalShelf" registryId="http://inspire.ec.europa.eu/layer/AU.ContinentalShelf" layerName="AU.ContinentalShelf" styleConfig="//@styleConfig.73">
+  <layerConfig name="AU_ContinentalShelf" registryId="http://inspire.ec.europa.eu/layer/AU.ContinentalShelf" layerName="AU.ContinentalShelf" styleConfig="//@styleConfig.89">
     <title lang="en" text="Continental shelf"/>
     <title text="Festlandsockel"/>
     <objectType>mu_3.0:ContinentalShelf</objectType>
   </layerConfig>
-  <layerConfig name="AU_ExclusiveEconomicZone" registryId="http://inspire.ec.europa.eu/layer/AU.ExclusiveEconomicZone" layerName="AU.ExclusiveEconomicZone" styleConfig="//@styleConfig.74">
+  <layerConfig name="AU_ExclusiveEconomicZone" registryId="http://inspire.ec.europa.eu/layer/AU.ExclusiveEconomicZone" layerName="AU.ExclusiveEconomicZone" styleConfig="//@styleConfig.90">
     <title lang="en" text="Exclusive economic zone"/>
     <title text="Ausschließliche Wirtschaftszone"/>
     <objectType>mu_3.0:ExclusiveEconomicZone</objectType>
   </layerConfig>
-  <layerConfig name="AU_InternalWaters" registryId="http://inspire.ec.europa.eu/layer/AU.InternalWaters" layerName="AU.InternalWaters" styleConfig="//@styleConfig.75">
+  <layerConfig name="AU_InternalWaters" registryId="http://inspire.ec.europa.eu/layer/AU.InternalWaters" layerName="AU.InternalWaters" styleConfig="//@styleConfig.91">
     <title lang="en" text="Internal waters"/>
     <title text="Innere Gewässer"/>
     <objectType>mu_3.0:InternalWaters</objectType>
   </layerConfig>
-  <layerConfig name="AU_MaritimeBoundary" registryId="http://inspire.ec.europa.eu/layer/AU.MaritimeBoundary" layerName="AU.MaritimeBoundary" styleConfig="//@styleConfig.76">
+  <layerConfig name="AU_MaritimeBoundary" registryId="http://inspire.ec.europa.eu/layer/AU.MaritimeBoundary" layerName="AU.MaritimeBoundary" styleConfig="//@styleConfig.92">
     <title lang="en" text="Maritime boundary"/>
     <title text="Seegrenze"/>
     <objectType>mu_3.0:MaritimeBoundary</objectType>
   </layerConfig>
-  <layerConfig name="AU_TerritorialSea" registryId="http://inspire.ec.europa.eu/layer/AU.TerritorialSea" layerName="AU.TerritorialSea" styleConfig="//@styleConfig.77">
+  <layerConfig name="AU_TerritorialSea" registryId="http://inspire.ec.europa.eu/layer/AU.TerritorialSea" layerName="AU.TerritorialSea" styleConfig="//@styleConfig.93">
     <title lang="en" text="Territorial sea"/>
     <title text="Küstenmeer"/>
     <objectType>mu_3.0:TerritorialSea</objectType>
   </layerConfig>
-  <layerConfig name="CP_CadastralBoundary" registryId="http://inspire.ec.europa.eu/layer/CP.CadastralBoundary" tags="//@tags.2 //@tags.0" layerName="CP.CadastralBoundary" styleConfig="//@styleConfig.78">
+  <layerConfig name="CP_CadastralBoundary" registryId="http://inspire.ec.europa.eu/layer/CP.CadastralBoundary" tags="//@tags.2 //@tags.0" layerName="CP.CadastralBoundary" styleConfig="//@styleConfig.94">
     <title lang="en" text="Cadastral Boundary"/>
     <title text="Flurstücksgrenze"/>
     <objectType>cp_4.0:CadastralBoundary</objectType>
   </layerConfig>
-  <layerConfig name="CP_Cadastr" registryId="http://inspire.ec.europa.eu/layer/CP.CadastralParcel" tags="//@tags.2 //@tags.0" layerName="CP.CadastralParcel.BoundariesOnly" styleConfig="//@styleConfig.79">
+  <layerConfig name="CP_Cadastr" registryId="http://inspire.ec.europa.eu/layer/CP.CadastralParcel" tags="//@tags.2 //@tags.0" layerName="CP.CadastralParcel.BoundariesOnly" styleConfig="//@styleConfig.95">
     <title lang="en" text="Cadastral Parcel (Boundary only)"/>
     <objectType>cp_4.0:CadastralParcel</objectType>
   </layerConfig>
-  <layerConfig name="CP_CadastralParcel" registryId="http://inspire.ec.europa.eu/layer/CP.CadastralParcel" tags="//@tags.2 //@tags.0" layerName="CP.CadastralParcel" styleConfig="//@styleConfig.80">
+  <layerConfig name="CP_CadastralParcel" registryId="http://inspire.ec.europa.eu/layer/CP.CadastralParcel" tags="//@tags.2 //@tags.0" layerName="CP.CadastralParcel" styleConfig="//@styleConfig.96">
     <title lang="en" text="Cadastral Parcel"/>
     <title text="Flurstück"/>
     <objectType>cp_4.0:CadastralParcel</objectType>
   </layerConfig>
-  <layerConfig name="CP_Cadastr_1" registryId="http://inspire.ec.europa.eu/layer/CP.CadastralParcel" tags="//@tags.2 //@tags.0" layerName="CP.CadastralParcel.LabelOnReferencePoint" styleConfig="//@styleConfig.81">
+  <layerConfig name="CP_Cadastr_1" registryId="http://inspire.ec.europa.eu/layer/CP.CadastralParcel" tags="//@tags.2 //@tags.0" layerName="CP.CadastralParcel.LabelOnReferencePoint" styleConfig="//@styleConfig.97">
     <title lang="en" text="Cadastral Parcel (LabelOnReferencePoint)"/>
     <objectType>cp_4.0:CadastralParcel</objectType>
   </layerConfig>
-  <layerConfig name="CP_Cadastr_2" registryId="http://inspire.ec.europa.eu/layer/CP.CadastralParcel" tags="//@tags.2 //@tags.0" layerName="CP.CadastralParcel.ReferencePointOnly" styleConfig="//@styleConfig.82">
+  <layerConfig name="CP_Cadastr_2" registryId="http://inspire.ec.europa.eu/layer/CP.CadastralParcel" tags="//@tags.2 //@tags.0" layerName="CP.CadastralParcel.ReferencePointOnly" styleConfig="//@styleConfig.98">
     <title lang="en" text="Cadastral Parcel (ReferencePointOnly)"/>
     <objectType>cp_4.0:CadastralParcel</objectType>
   </layerConfig>
-  <layerConfig name="CP_CadastralZoning" registryId="http://inspire.ec.europa.eu/layer/CP.CadastralZoning" tags="//@tags.2 //@tags.0" layerName="CP.CadastralZoning" styleConfig="//@styleConfig.83">
+  <layerConfig name="CP_CadastralZoning" registryId="http://inspire.ec.europa.eu/layer/CP.CadastralZoning" tags="//@tags.2 //@tags.0" layerName="CP.CadastralZoning" styleConfig="//@styleConfig.99">
     <title lang="en" text="Cadastral Zoning"/>
     <title text="Katasterbezirk"/>
     <objectType>cp_4.0:CadastralZoning</objectType>
   </layerConfig>
-  <layerConfig name="GN_GeographicalNames" registryId="http://inspire.ec.europa.eu/layer/GN.GeographicalNames" tags="//@tags.0 //@tags.2" layerName="GN.GeographicalNames" styleConfig="//@styleConfig.84">
+  <layerConfig name="GN_GeographicalNames" registryId="http://inspire.ec.europa.eu/layer/GN.GeographicalNames" tags="//@tags.0 //@tags.2" layerName="GN.GeographicalNames" styleConfig="//@styleConfig.100">
     <title lang="en" text="Geographical Names"/>
     <title text="Geografische Bezeichnungen"/>
     <objectType>gn_4.0:NamedPlace</objectType>
   </layerConfig>
-  <layerConfig name="HY_Network_WatercourseLink" registryId="" tags="//@tags.0 //@tags.2" layerName="HY.Network.WatercourseLink" styleConfig="//@styleConfig.85">
+  <layerConfig name="HY_Network_WatercourseLink" registryId="" tags="//@tags.0 //@tags.2" layerName="HY.Network.WatercourseLink" styleConfig="//@styleConfig.101">
     <title lang="en" text="Hydrographic network - WatercourseLink"/>
     <title text="Hydrografisches Netzwerk- WatercourseLink"/>
     <objectType>hy-n_4.0:WatercourseLink</objectType>
   </layerConfig>
-  <layerConfig name="HY_Network_HydroNode" registryId="" tags="//@tags.0 //@tags.2" layerName="HY.Network.HydroNode" styleConfig="//@styleConfig.86">
+  <layerConfig name="HY_Network_WatercourseLink_v5" registryId="" tags="//@tags.0 //@tags.2" layerName="HY.Network.WatercourseLink" styleConfig="//@styleConfig.102">
+    <title lang="en" text="Hydrographic network - WatercourseLink"/>
+    <title text="Hydrografisches Netzwerk- WatercourseLink"/>
+    <objectType>hy-n_5.0:WatercourseLink</objectType>
+  </layerConfig>
+  <layerConfig name="HY_Network_HydroNode" registryId="" tags="//@tags.0 //@tags.2" layerName="HY.Network.HydroNode" styleConfig="//@styleConfig.103">
     <title lang="en" text="Hydrographic network - HydroNode"/>
     <title text="Hydrografisches Netzwerk- HydroNode"/>
     <objectType>hy-n_4.0:HydroNode</objectType>
   </layerConfig>
-  <layerConfig name="HY_Physica" registryId="http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.Catchments" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.Catchments" styleConfig="//@styleConfig.87 //@styleConfig.88">
+  <layerConfig name="HY_Network_HydroNode_v5" registryId="" tags="//@tags.0 //@tags.2" layerName="HY.Network.HydroNode" styleConfig="//@styleConfig.104">
+    <title lang="en" text="Hydrographic network - HydroNode"/>
+    <title text="Hydrografisches Netzwerk- HydroNode"/>
+    <objectType>hy-n_5.0:HydroNode</objectType>
+  </layerConfig>
+  <layerConfig name="HY_Physica" registryId="http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.Catchments" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.Catchments" styleConfig="//@styleConfig.105 //@styleConfig.107">
     <title lang="en" text="Catchment"/>
     <title text="Einzugsgebiete"/>
     <objectType>hy-p_4.0:DrainageBasin</objectType>
     <objectType>hy-p_4.0:RiverBasin</objectType>
   </layerConfig>
-  <layerConfig name="HY_Physica_1" registryId="http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.HydroPointOfInterest" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.HydroPointOfInterest" styleConfig="//@styleConfig.89 //@styleConfig.90">
+  <layerConfig name="HY_Physica_v5" registryId="http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.Catchments" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.Catchments" styleConfig="//@styleConfig.106 //@styleConfig.108">
+    <title lang="en" text="Catchment"/>
+    <title text="Einzugsgebiete"/>
+    <objectType>hy-p_5.0:DrainageBasin</objectType>
+    <objectType>hy-p_5.0:RiverBasin</objectType>
+  </layerConfig>
+  <layerConfig name="HY_Physica_1" registryId="http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.HydroPointOfInterest" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.HydroPointOfInterest" styleConfig="//@styleConfig.109 //@styleConfig.111">
     <title lang="en" text="Hydro Point of Interest"/>
     <title text="Interessante hydrologische Punkte"/>
     <objectType>hy-p_4.0:Rapids</objectType>
     <objectType>hy-p_4.0:Falls</objectType>
   </layerConfig>
-  <layerConfig name="HY_Physica_2" registryId="http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.LandWaterBoundary" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.LandWaterBoundary" styleConfig="//@styleConfig.91">
+  <layerConfig name="HY_Physica_1_v5" registryId="http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.HydroPointOfInterest" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.HydroPointOfInterest" styleConfig="//@styleConfig.110 //@styleConfig.112">
+    <title lang="en" text="Hydro Point of Interest"/>
+    <title text="Interessante hydrologische Punkte"/>
+    <objectType>hy-p_5.0:Rapids</objectType>
+    <objectType>hy-p_5.0:Falls</objectType>
+  </layerConfig>
+  <layerConfig name="HY_Physica_2" registryId="http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.LandWaterBoundary" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.LandWaterBoundary" styleConfig="//@styleConfig.113">
     <title lang="en" text="Land water boundary"/>
     <title text="Uferlinien"/>
     <objectType>hy-p_4.0:LandWaterBoundary</objectType>
   </layerConfig>
-  <layerConfig name="HY_Physica_4" registryId="http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.ManMadeObject" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.ManMadeObject" styleConfig="//@styleConfig.92 //@styleConfig.93 //@styleConfig.94 //@styleConfig.95 //@styleConfig.96">
+  <layerConfig name="HY_Physica_2_v5" registryId="http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.LandWaterBoundary" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.LandWaterBoundary" styleConfig="//@styleConfig.114">
+    <title lang="en" text="Land water boundary"/>
+    <title text="Uferlinien"/>
+    <objectType>hy-p_5.0:LandWaterBoundary</objectType>
+  </layerConfig>
+  <layerConfig name="HY_Physica_4" registryId="http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.ManMadeObject" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.ManMadeObject" styleConfig="//@styleConfig.115 //@styleConfig.117 //@styleConfig.119 //@styleConfig.121 //@styleConfig.123">
     <title lang="en" text="Man-made Object"/>
     <title text="Bauwerke an Gewässern"/>
     <objectType>hy-p_4.0:Crossing</objectType>
@@ -126,502 +153,738 @@
     <objectType>hy-p_4.0:Ford</objectType>
     <objectType>hy-p_4.0:Lock</objectType>
   </layerConfig>
-  <layerConfig name="HY_PhysicalWaters_Shore" registryId="http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.Shore" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.Shore" styleConfig="//@styleConfig.97">
+  <layerConfig name="HY_Physica_4_v5" registryId="http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.ManMadeObject" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.ManMadeObject" styleConfig="//@styleConfig.116 //@styleConfig.118 //@styleConfig.120 //@styleConfig.122 //@styleConfig.124">
+    <title lang="en" text="Man-made Object"/>
+    <title text="Bauwerke an Gewässern"/>
+    <objectType>hy-p_4.0:Crossing</objectType>
+    <objectType>hy-p_5.0:DamOrWeir</objectType>
+    <objectType>hy-p_5.0:ShorelineConstruction</objectType>
+    <objectType>hy-p_5.0:Ford</objectType>
+    <objectType>hy-p_5.0:Lock</objectType>
+  </layerConfig>
+  <layerConfig name="HY_PhysicalWaters_Shore" registryId="http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.Shore" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.Shore" styleConfig="//@styleConfig.125">
     <title lang="en" text="Shores"/>
     <title text="Küsten"/>
     <objectType>hy-p_4.0:Shore</objectType>
   </layerConfig>
-  <layerConfig name="HY_Physica_5" registryId="http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.Waterbodies" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.Waterbodies" styleConfig="//@styleConfig.98 //@styleConfig.99">
+  <layerConfig name="HY_PhysicalWaters_Shore_v5" registryId="http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.Shore" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.Shore" styleConfig="//@styleConfig.126">
+    <title lang="en" text="Shores"/>
+    <title text="Küsten"/>
+    <objectType>hy-p_5.0:Shore</objectType>
+  </layerConfig>
+  <layerConfig name="HY_Physica_5" registryId="http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.Waterbodies" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.Waterbodies" styleConfig="//@styleConfig.127 //@styleConfig.129">
     <title lang="en" text="Waterbody"/>
     <title text="Wasserkörper"/>
     <objectType>hy-p_4.0:Watercourse</objectType>
     <objectType>hy-p_4.0:StandingWater</objectType>
   </layerConfig>
-  <layerConfig name="HY_Physica_6" registryId="" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.Waterbodies.Man.Made" styleConfig="//@styleConfig.100 //@styleConfig.101">
+  <layerConfig name="HY_Physica_5_v5" registryId="http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.Waterbodies" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.Waterbodies" styleConfig="//@styleConfig.128 //@styleConfig.130">
+    <title lang="en" text="Waterbody"/>
+    <title text="Wasserkörper"/>
+    <objectType>hy-p_5.0:Watercourse</objectType>
+    <objectType>hy-p_5.0:StandingWater</objectType>
+  </layerConfig>
+  <layerConfig name="HY_Physica_6" registryId="" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.Waterbodies.Man.Made" styleConfig="//@styleConfig.131 //@styleConfig.133">
     <title lang="en" text="Man-made Object (Natural)"/>
     <objectType>hy-p_4.0:Watercourse</objectType>
     <objectType>hy-p_4.0:StandingWater</objectType>
   </layerConfig>
-  <layerConfig name="HY_Physica_7" registryId="" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.Waterbodies.Persistence" styleConfig="//@styleConfig.102 //@styleConfig.103">
+  <layerConfig name="HY_Physica_6_v5" registryId="" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.Waterbodies.Man.Made" styleConfig="//@styleConfig.132 //@styleConfig.134">
+    <title lang="en" text="Man-made Object (Natural)"/>
+    <objectType>hy-p_5.0:Watercourse</objectType>
+    <objectType>hy-p_5.0:StandingWater</objectType>
+  </layerConfig>
+  <layerConfig name="HY_Physica_7" registryId="" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.Waterbodies.Persistence" styleConfig="//@styleConfig.135 //@styleConfig.137">
     <title lang="en" text="Waterbody (Persistence)"/>
     <objectType>hy-p_4.0:Watercourse</objectType>
     <objectType>hy-p_4.0:StandingWater</objectType>
   </layerConfig>
-  <layerConfig name="HY_PhysicalWaters_Wetland" registryId="http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.Wetland" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.Wetland" styleConfig="//@styleConfig.104">
+  <layerConfig name="HY_Physica_7_v5" registryId="" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.Waterbodies.Persistence" styleConfig="//@styleConfig.136 //@styleConfig.138">
+    <title lang="en" text="Waterbody (Persistence)"/>
+    <objectType>hy-p_5.0:Watercourse</objectType>
+    <objectType>hy-p_5.0:StandingWater</objectType>
+  </layerConfig>
+  <layerConfig name="HY_PhysicalWaters_Wetland" registryId="http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.Wetland" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.Wetland" styleConfig="//@styleConfig.139">
     <title lang="en" text="Wetlands"/>
     <title text="Feuchtgebiete"/>
     <objectType>hy-p_4.0:Wetland</objectType>
   </layerConfig>
-  <layerConfig name="PS_ProtectedSite" registryId="http://inspire.ec.europa.eu/layer/PS.ProtectedSite" tags="//@tags.0 //@tags.2" layerName="PS.ProtectedSite" styleConfig="//@styleConfig.105">
+  <layerConfig name="HY_PhysicalWaters_Wetland_v5" registryId="http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.Wetland" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.Wetland" styleConfig="//@styleConfig.140">
+    <title lang="en" text="Wetlands"/>
+    <title text="Feuchtgebiete"/>
+    <objectType>hy-p_5.0:Wetland</objectType>
+  </layerConfig>
+  <layerConfig name="PS_ProtectedSite" registryId="http://inspire.ec.europa.eu/layer/PS.ProtectedSite" tags="//@tags.0 //@tags.2" layerName="PS.ProtectedSite" styleConfig="//@styleConfig.141">
     <title lang="en" text="Protected Sites"/>
     <title text="Schutzgebiete"/>
     <objectType>ps_4.0:ProtectedSite</objectType>
   </layerConfig>
-  <layerConfig name="PS_ProtectedSite_v5" registryId="http://inspire.ec.europa.eu/layer/PS.ProtectedSite" tags="//@tags.0 //@tags.2" layerName="PS.ProtectedSite_v5" styleConfig="//@styleConfig.106">
+  <layerConfig name="PS_ProtectedSite_v5" registryId="http://inspire.ec.europa.eu/layer/PS.ProtectedSite" tags="//@tags.0 //@tags.2" layerName="PS.ProtectedSite" styleConfig="//@styleConfig.142">
     <title lang="en" text="Protected Sites"/>
     <title text="Schutzgebiete"/>
     <objectType>ps_5.0:ProtectedSite</objectType>
   </layerConfig>
-  <layerConfig name="TN_AirTran" registryId="http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.AerodromeArea" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.AerodromeArea" styleConfig="//@styleConfig.107">
+  <layerConfig name="PS_ProtectedSite_v5" registryId="http://inspire.ec.europa.eu/layer/PS.ProtectedSite" tags="//@tags.0 //@tags.2" layerName="PS.ProtectedSite_v5" styleConfig="//@styleConfig.142">
+    <title lang="en" text="Protected Sites"/>
+    <title text="Schutzgebiete"/>
+    <objectType>ps_5.0:ProtectedSite</objectType>
+  </layerConfig>
+  <layerConfig name="TN_AirTran" registryId="http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.AerodromeArea" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.AerodromeArea" styleConfig="//@styleConfig.144">
     <title lang="en" text="Aerodrome Area Default Style"/>
     <title text="Flugplatzgelände"/>
     <objectType>tn-a_4.0:AerodromeArea</objectType>
   </layerConfig>
-  <layerConfig name="TN_AirTran_1" registryId="http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.AirLink" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.AirLink" styleConfig="//@styleConfig.108 //@styleConfig.109">
+  <layerConfig name="TN_AirTran_v5" registryId="http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.AerodromeArea" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.AerodromeArea" styleConfig="//@styleConfig.145">
+    <title lang="en" text="Aerodrome Area Default Style"/>
+    <title text="Flugplatzgelände"/>
+    <objectType>tn-a_5.0:AerodromeArea</objectType>
+  </layerConfig>
+  <layerConfig name="TN_AirTran_1" registryId="http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.AirLink" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.AirLink" styleConfig="//@styleConfig.146 //@styleConfig.148">
     <title lang="en" text="Air Link Default Style"/>
     <title text="Luftverbindung"/>
     <objectType>tn-a_4.0:ProcedureLink</objectType>
     <objectType>tn-a_4.0:AirRouteLink</objectType>
   </layerConfig>
-  <layerConfig name="TN_AirTran_2" registryId="http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.AirspaceArea" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.AirSpaceArea" styleConfig="//@styleConfig.110">
+  <layerConfig name="TN_AirTran_1_v5" registryId="http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.AirLink" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.AirLink" styleConfig="//@styleConfig.147 //@styleConfig.149">
+    <title lang="en" text="Air Link Default Style"/>
+    <title text="Luftverbindung"/>
+    <objectType>tn-a_5.0:ProcedureLink</objectType>
+    <objectType>tn-a_5.0:AirRouteLink</objectType>
+  </layerConfig>
+  <layerConfig name="TN_AirTran_2" registryId="http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.AirspaceArea" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.AirSpaceArea" styleConfig="//@styleConfig.150">
     <title lang="en" text="Air Space Area Default Style"/>
     <title text="Luftraumbereich"/>
     <objectType>tn-a_4.0:AirspaceArea</objectType>
   </layerConfig>
-  <layerConfig name="TN_AirTran_3" registryId="http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.ApronArea" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.ApronArea" styleConfig="//@styleConfig.111">
+  <layerConfig name="TN_AirTran_2_v5" registryId="http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.AirspaceArea" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.AirSpaceArea" styleConfig="//@styleConfig.151">
+    <title lang="en" text="Air Space Area Default Style"/>
+    <title text="Luftraumbereich"/>
+    <objectType>tn-a_5.0:AirspaceArea</objectType>
+  </layerConfig>
+  <layerConfig name="TN_AirTran_3" registryId="http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.ApronArea" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.ApronArea" styleConfig="//@styleConfig.152">
     <title lang="en" text="Apron Area Default Style"/>
     <title text="Vorfeldgelände"/>
     <objectType>tn-a_4.0:ApronArea</objectType>
   </layerConfig>
-  <layerConfig name="TN_AirTran_4" registryId="http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.RunwayArea" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.RunwayArea" styleConfig="//@styleConfig.112">
+  <layerConfig name="TN_AirTran_3_v5" registryId="http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.ApronArea" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.ApronArea" styleConfig="//@styleConfig.153">
+    <title lang="en" text="Apron Area Default Style"/>
+    <title text="Vorfeldgelände"/>
+    <objectType>tn-a_5.0:ApronArea</objectType>
+  </layerConfig>
+  <layerConfig name="TN_AirTran_4" registryId="http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.RunwayArea" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.RunwayArea" styleConfig="//@styleConfig.154">
     <title lang="en" text="Runway Area Default Style"/>
     <title text="Landebahngelände"/>
     <objectType>tn-a_4.0:RunwayArea</objectType>
   </layerConfig>
-  <layerConfig name="TN_AirTran_5" registryId="http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.TaxiwayArea" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.TaxiwayArea" styleConfig="//@styleConfig.113">
+  <layerConfig name="TN_AirTran_4_v5" registryId="http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.RunwayArea" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.RunwayArea" styleConfig="//@styleConfig.155">
+    <title lang="en" text="Runway Area Default Style"/>
+    <title text="Landebahngelände"/>
+    <objectType>tn-a_5.0:RunwayArea</objectType>
+  </layerConfig>
+  <layerConfig name="TN_AirTran_5" registryId="http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.TaxiwayArea" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.TaxiwayArea" styleConfig="//@styleConfig.156">
     <title lang="en" text="Taxiway Area Default Style"/>
     <title text="Rollfeld"/>
     <objectType>tn-a_4.0:TaxiwayArea</objectType>
   </layerConfig>
-  <layerConfig name="TN_AirTran_6" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.DesignatedPoint" styleConfig="//@styleConfig.4">
+  <layerConfig name="TN_AirTran_5_v5" registryId="http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.TaxiwayArea" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.TaxiwayArea" styleConfig="//@styleConfig.157">
+    <title lang="en" text="Taxiway Area Default Style"/>
+    <title text="Rollfeld"/>
+    <objectType>tn-a_5.0:TaxiwayArea</objectType>
+  </layerConfig>
+  <layerConfig name="TN_AirTran_6" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.DesignatedPoint" styleConfig="//@styleConfig.7">
     <title lang="en" text="Designated Point Default Style"/>
     <title text="Designierter Punkt"/>
     <objectType>tn-a_4.0:DesignatedPoint</objectType>
   </layerConfig>
-  <layerConfig name="TN_AirTran_7" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.AerodromeNode" styleConfig="//@styleConfig.7">
+  <layerConfig name="TN_AirTran_6_v5" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.DesignatedPoint" styleConfig="//@styleConfig.8">
+    <title lang="en" text="Designated Point Default Style"/>
+    <title text="Designierter Punkt"/>
+    <objectType>tn-a_5.0:DesignatedPoint</objectType>
+  </layerConfig>
+  <layerConfig name="TN_AirTran_7" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.AerodromeNode" styleConfig="//@styleConfig.13">
     <title lang="en" text="Aerodrome Node Default Style"/>
     <title text="Flugplatzknotenpunkt"/>
     <objectType>tn-a_4.0:AerodromeNode</objectType>
   </layerConfig>
-  <layerConfig name="TN_AirTran_8" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.TouchDownLiftOff" styleConfig="//@styleConfig.8">
+  <layerConfig name="TN_AirTran_7_v5" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.AerodromeNode" styleConfig="//@styleConfig.14">
+    <title lang="en" text="Aerodrome Node Default Style"/>
+    <title text="Flugplatzknotenpunkt"/>
+    <objectType>tn-a_5.0:AerodromeNode</objectType>
+  </layerConfig>
+  <layerConfig name="TN_AirTran_8" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.TouchDownLiftOff" styleConfig="//@styleConfig.15">
     <title lang="en" text="Touch Down Lift Off Area Default Style"/>
     <title text="Start- und Landebereich für Hubschrauber"/>
     <objectType>tn-a_4.0:TouchDownLiftOff</objectType>
   </layerConfig>
-  <layerConfig name="TN_AirTran_9" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.Navaid" styleConfig="//@styleConfig.5">
+  <layerConfig name="TN_AirTran_8_v5" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.TouchDownLiftOff" styleConfig="//@styleConfig.16">
+    <title lang="en" text="Touch Down Lift Off Area Default Style"/>
+    <title text="Start- und Landebereich für Hubschrauber"/>
+    <objectType>tn-a_5.0:TouchDownLiftOff</objectType>
+  </layerConfig>
+  <layerConfig name="TN_AirTran_9" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.Navaid" styleConfig="//@styleConfig.9">
     <title lang="en" text="Navaid Default Style"/>
     <title text="Navigationshilfe"/>
     <objectType>tn-a_4.0:Navaid</objectType>
   </layerConfig>
-  <layerConfig name="TN_AirTran_10" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.RunwayCentrelinePoint" styleConfig="//@styleConfig.6">
+  <layerConfig name="TN_AirTran_9_v5" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.Navaid" styleConfig="//@styleConfig.10">
+    <title lang="en" text="Navaid Default Style"/>
+    <title text="Navigationshilfe"/>
+    <objectType>tn-a_5.0:Navaid</objectType>
+  </layerConfig>
+  <layerConfig name="TN_AirTran_10" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.RunwayCentrelinePoint" styleConfig="//@styleConfig.11">
     <title lang="en" text="Runway Centreline Point Default Style"/>
     <title text="Mittellinienpunkt der Landebahn"/>
     <objectType>tn-a_4.0:RunwayCentrelinePoint</objectType>
   </layerConfig>
-  <layerConfig name="TN_CableTr" registryId="http://inspire.ec.europa.eu/layer/TN.CableTransportNetwork.CablewayLink" tags="//@tags.0 //@tags.2" layerName="TN.CableTransportNetwork.CablewayLink" styleConfig="//@styleConfig.114">
+  <layerConfig name="TN_AirTran_10_v5" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.RunwayCentrelinePoint" styleConfig="//@styleConfig.12">
+    <title lang="en" text="Runway Centreline Point Default Style"/>
+    <title text="Mittellinienpunkt der Landebahn"/>
+    <objectType>tn-a_5.0:RunwayCentrelinePoint</objectType>
+  </layerConfig>
+  <layerConfig name="TN_CableTr" registryId="http://inspire.ec.europa.eu/layer/TN.CableTransportNetwork.CablewayLink" tags="//@tags.0 //@tags.2" layerName="TN.CableTransportNetwork.CablewayLink" styleConfig="//@styleConfig.158">
     <title lang="en" text="Cableway Link Default Style"/>
     <title text="Seilbahnverbindung"/>
     <objectType>tn-c_4.0:CablewayLink</objectType>
   </layerConfig>
-  <layerConfig name="TN_CommonT" registryId="http://inspire.ec.europa.eu/layer/TN.CommonTransportElements.TransportArea" tags="//@tags.0 //@tags.2" layerName="TN.CommonTransportElements.TransportArea" styleConfig="//@styleConfig.115">
+  <layerConfig name="TN_CableTr_v5" registryId="http://inspire.ec.europa.eu/layer/TN.CableTransportNetwork.CablewayLink" tags="//@tags.0 //@tags.2" layerName="TN.CableTransportNetwork.CablewayLink" styleConfig="//@styleConfig.159">
+    <title lang="en" text="Cableway Link Default Style"/>
+    <title text="Seilbahnverbindung"/>
+    <objectType>tn-c_5.0:CablewayLink</objectType>
+  </layerConfig>
+  <layerConfig name="TN_CommonT" registryId="http://inspire.ec.europa.eu/layer/TN.CommonTransportElements.TransportArea" tags="//@tags.0 //@tags.2" layerName="TN.CommonTransportElements.TransportArea" styleConfig="//@styleConfig.160">
     <title lang="en" text="Generic Transport Area Default Style"/>
     <title text="Generischer Verkehrsbereich"/>
     <objectType>tn_4.0:TransportArea</objectType>
   </layerConfig>
-  <layerConfig name="TN_CommonT_1" registryId="http://inspire.ec.europa.eu/layer/TN.CommonTransportElements.TransportLink" tags="//@tags.0 //@tags.2" layerName="TN.CommonTransportElements.TransportLink" styleConfig="//@styleConfig.116">
+  <layerConfig name="TN_CommonT_v5" registryId="http://inspire.ec.europa.eu/layer/TN.CommonTransportElements.TransportArea" tags="//@tags.0 //@tags.2" layerName="TN.CommonTransportElements.TransportArea" styleConfig="//@styleConfig.161">
+    <title lang="en" text="Generic Transport Area Default Style"/>
+    <title text="Generischer Verkehrsbereich"/>
+    <objectType>tn_5.0:TransportArea</objectType>
+  </layerConfig>
+  <layerConfig name="TN_CommonT_1" registryId="http://inspire.ec.europa.eu/layer/TN.CommonTransportElements.TransportLink" tags="//@tags.0 //@tags.2" layerName="TN.CommonTransportElements.TransportLink" styleConfig="//@styleConfig.162">
     <title lang="en" text="Generic Transport Link Default Style"/>
     <title text="Generisches Verkehrssegment"/>
     <objectType>tn_4.0:TransportLink</objectType>
   </layerConfig>
-  <layerConfig name="TN_CommonT_2" registryId="http://inspire.ec.europa.eu/layer/TN.CommonTransportElements.TransportNode" tags="//@tags.0 //@tags.2" layerName="TN.CommonTransportElements.TransportNode" styleConfig="//@styleConfig.117">
+  <layerConfig name="TN_CommonT_1_v5" registryId="http://inspire.ec.europa.eu/layer/TN.CommonTransportElements.TransportLink" tags="//@tags.0 //@tags.2" layerName="TN.CommonTransportElements.TransportLink" styleConfig="//@styleConfig.163">
+    <title lang="en" text="Generic Transport Link Default Style"/>
+    <title text="Generisches Verkehrssegment"/>
+    <objectType>tn_5.0:TransportLink</objectType>
+  </layerConfig>
+  <layerConfig name="TN_CommonT_2" registryId="http://inspire.ec.europa.eu/layer/TN.CommonTransportElements.TransportNode" tags="//@tags.0 //@tags.2" layerName="TN.CommonTransportElements.TransportNode" styleConfig="//@styleConfig.164">
     <title lang="en" text="Generic Transport Node Default Style"/>
     <title text="Generischer Verkehrsknotenpunkt"/>
     <objectType>tn_4.0:TransportNode</objectType>
   </layerConfig>
-  <layerConfig name="TN_RailTra" registryId="http://inspire.ec.europa.eu/layer/TN.RailTransportNetwork.RailwayArea" tags="//@tags.0 //@tags.2" layerName="TN.RailTransportNetwork.RailwayArea" styleConfig="//@styleConfig.118">
+  <layerConfig name="TN_CommonT_2_v5" registryId="http://inspire.ec.europa.eu/layer/TN.CommonTransportElements.TransportNode" tags="//@tags.0 //@tags.2" layerName="TN.CommonTransportElements.TransportNode" styleConfig="//@styleConfig.165">
+    <title lang="en" text="Generic Transport Node Default Style"/>
+    <title text="Generischer Verkehrsknotenpunkt"/>
+    <objectType>tn_5.0:TransportNode</objectType>
+  </layerConfig>
+  <layerConfig name="TN_RailTra" registryId="http://inspire.ec.europa.eu/layer/TN.RailTransportNetwork.RailwayArea" tags="//@tags.0 //@tags.2" layerName="TN.RailTransportNetwork.RailwayArea" styleConfig="//@styleConfig.166">
     <title lang="en" text="Railway Area Default Style"/>
     <title text="Bahngelände"/>
     <objectType>tn-ra_4.0:RailwayArea</objectType>
   </layerConfig>
-  <layerConfig name="TN_RailTra_1" registryId="http://inspire.ec.europa.eu/layer/TN.RailTransportNetwork.RailwayLink" tags="//@tags.0 //@tags.2" layerName="TN.RailTransportNetwork.RailwayLink" styleConfig="//@styleConfig.119">
+  <layerConfig name="TN_RailTra_v5" registryId="http://inspire.ec.europa.eu/layer/TN.RailTransportNetwork.RailwayArea" tags="//@tags.0 //@tags.2" layerName="TN.RailTransportNetwork.RailwayArea" styleConfig="//@styleConfig.167">
+    <title lang="en" text="Railway Area Default Style"/>
+    <title text="Bahngelände"/>
+    <objectType>tn-ra_5.0:RailwayArea</objectType>
+  </layerConfig>
+  <layerConfig name="TN_RailTra_1" registryId="http://inspire.ec.europa.eu/layer/TN.RailTransportNetwork.RailwayLink" tags="//@tags.0 //@tags.2" layerName="TN.RailTransportNetwork.RailwayLink" styleConfig="//@styleConfig.168">
     <title lang="en" text="Railway Link Default Style"/>
     <title text="Eisenbahnverbindung"/>
     <objectType>tn-ra_4.0:RailwayLink</objectType>
   </layerConfig>
-  <layerConfig name="TN_RailTra_2" registryId="http://inspire.ec.europa.eu/layer/TN.RailTransportNetwork.RailwayStationArea" tags="//@tags.0 //@tags.2" layerName="TN.RailTransportNetwork.RailwayStationArea" styleConfig="//@styleConfig.120">
+  <layerConfig name="TN_RailTra_1_v5" registryId="http://inspire.ec.europa.eu/layer/TN.RailTransportNetwork.RailwayLink" tags="//@tags.0 //@tags.2" layerName="TN.RailTransportNetwork.RailwayLink" styleConfig="//@styleConfig.169">
+    <title lang="en" text="Railway Link Default Style"/>
+    <title text="Eisenbahnverbindung"/>
+    <objectType>tn-ra_5.0:RailwayLink</objectType>
+  </layerConfig>
+  <layerConfig name="TN_RailTra_2" registryId="http://inspire.ec.europa.eu/layer/TN.RailTransportNetwork.RailwayStationArea" tags="//@tags.0 //@tags.2" layerName="TN.RailTransportNetwork.RailwayStationArea" styleConfig="//@styleConfig.170">
     <title lang="en" text="Railway Station Area Default Style"/>
     <title text="Bahnhofsgelände"/>
     <objectType>tn-ra_4.0:RailwayStationArea</objectType>
   </layerConfig>
-  <layerConfig name="TN_RailTra_3" registryId="http://inspire.ec.europa.eu/layer/TN.RailTransportNetwork.RailwayYardArea" tags="//@tags.0 //@tags.2" layerName="TN.RailTransportNetwork.RailwayYardArea" styleConfig="//@styleConfig.121">
+  <layerConfig name="TN_RailTra_2_v5" registryId="http://inspire.ec.europa.eu/layer/TN.RailTransportNetwork.RailwayStationArea" tags="//@tags.0 //@tags.2" layerName="TN.RailTransportNetwork.RailwayStationArea" styleConfig="//@styleConfig.171">
+    <title lang="en" text="Railway Station Area Default Style"/>
+    <title text="Bahnhofsgelände"/>
+    <objectType>tn-ra_5.0:RailwayStationArea</objectType>
+  </layerConfig>
+  <layerConfig name="TN_RailTra_3" registryId="http://inspire.ec.europa.eu/layer/TN.RailTransportNetwork.RailwayYardArea" tags="//@tags.0 //@tags.2" layerName="TN.RailTransportNetwork.RailwayYardArea" styleConfig="//@styleConfig.172">
     <title lang="en" text="Railway Yard Area Default Style"/>
     <title text="Rangierbahnhofsgelände"/>
     <objectType>tn-ra_4.0:RailwayYardArea</objectType>
   </layerConfig>
-  <layerConfig name="TN_RoadTra" registryId="http://inspire.ec.europa.eu/layer/TN.RoadTransportNetwork.RoadArea" tags="//@tags.0 //@tags.2" layerName="TN.RoadTransportNetwork.RoadArea" styleConfig="//@styleConfig.122">
+  <layerConfig name="TN_RailTra_3_v5" registryId="http://inspire.ec.europa.eu/layer/TN.RailTransportNetwork.RailwayYardArea" tags="//@tags.0 //@tags.2" layerName="TN.RailTransportNetwork.RailwayYardArea" styleConfig="//@styleConfig.173">
+    <title lang="en" text="Railway Yard Area Default Style"/>
+    <title text="Rangierbahnhofsgelände"/>
+    <objectType>tn-ra_5.0:RailwayYardArea</objectType>
+  </layerConfig>
+  <layerConfig name="TN_RoadTra" registryId="http://inspire.ec.europa.eu/layer/TN.RoadTransportNetwork.RoadArea" tags="//@tags.0 //@tags.2" layerName="TN.RoadTransportNetwork.RoadArea" styleConfig="//@styleConfig.174">
     <title lang="en" text="Road Area Default Style"/>
     <title text="Straßenfläche"/>
     <objectType>tn-ro_4.0:RoadArea</objectType>
   </layerConfig>
-  <layerConfig name="TN_RoadTra_1" registryId="http://inspire.ec.europa.eu/layer/TN.RoadTransportNetwork.RoadLink" tags="//@tags.0 //@tags.2" layerName="TN.RoadTransportNetwork.RoadLink" styleConfig="//@styleConfig.123">
+  <layerConfig name="TN_RoadTra_v5" registryId="http://inspire.ec.europa.eu/layer/TN.RoadTransportNetwork.RoadArea" tags="//@tags.0 //@tags.2" layerName="TN.RoadTransportNetwork.RoadArea" styleConfig="//@styleConfig.175">
+    <title lang="en" text="Road Area Default Style"/>
+    <title text="Straßenfläche"/>
+    <objectType>tn-ro_5.0:RoadArea</objectType>
+  </layerConfig>
+  <layerConfig name="TN_RoadTra_1" registryId="http://inspire.ec.europa.eu/layer/TN.RoadTransportNetwork.RoadLink" tags="//@tags.0 //@tags.2" layerName="TN.RoadTransportNetwork.RoadLink" styleConfig="//@styleConfig.176">
     <title lang="en" text="Road Link Default Style"/>
     <title text="Straßensegment"/>
     <objectType>tn-ro_4.0:RoadLink</objectType>
   </layerConfig>
-  <layerConfig name="TN_RoadTra_2" registryId="http://inspire.ec.europa.eu/layer/TN.RoadTransportNetwork.RoadServiceArea" tags="//@tags.0 //@tags.2" layerName="TN.RoadTransportNetwork.RoadServiceArea" styleConfig="//@styleConfig.124">
+  <layerConfig name="TN_RoadTra_1_v5" registryId="http://inspire.ec.europa.eu/layer/TN.RoadTransportNetwork.RoadLink" tags="//@tags.0 //@tags.2" layerName="TN.RoadTransportNetwork.RoadLink" styleConfig="//@styleConfig.177">
+    <title lang="en" text="Road Link Default Style"/>
+    <title text="Straßensegment"/>
+    <objectType>tn-ro_5.0:RoadLink</objectType>
+  </layerConfig>
+  <layerConfig name="TN_RoadTra_2" registryId="http://inspire.ec.europa.eu/layer/TN.RoadTransportNetwork.RoadServiceArea" tags="//@tags.0 //@tags.2" layerName="TN.RoadTransportNetwork.RoadServiceArea" styleConfig="//@styleConfig.178">
     <title lang="en" text="Road Service Area Default Style"/>
     <title text="Servicebereich"/>
     <objectType>tn-ro_4.0:RoadServiceArea</objectType>
   </layerConfig>
-  <layerConfig name="TN_RoadTra_3" registryId="http://inspire.ec.europa.eu/layer/TN.RoadTransportNetwork.VehicleTrafficArea" tags="//@tags.0 //@tags.2" layerName="TN.RoadTransportNetwork.VehicleTrafficArea" styleConfig="//@styleConfig.125">
+  <layerConfig name="TN_RoadTra_2_v5" registryId="http://inspire.ec.europa.eu/layer/TN.RoadTransportNetwork.RoadServiceArea" tags="//@tags.0 //@tags.2" layerName="TN.RoadTransportNetwork.RoadServiceArea" styleConfig="//@styleConfig.179">
+    <title lang="en" text="Road Service Area Default Style"/>
+    <title text="Servicebereich"/>
+    <objectType>tn-ro_5.0:RoadServiceArea</objectType>
+  </layerConfig>
+  <layerConfig name="TN_RoadTra_3" registryId="http://inspire.ec.europa.eu/layer/TN.RoadTransportNetwork.VehicleTrafficArea" tags="//@tags.0 //@tags.2" layerName="TN.RoadTransportNetwork.VehicleTrafficArea" styleConfig="//@styleConfig.180">
     <title lang="en" text="Vehicle traffic Area Default Style"/>
     <title text="Verkehrsfläche"/>
     <objectType>tn-ro_4.0:VehicleTrafficArea</objectType>
   </layerConfig>
-  <layerConfig name="TN_WaterTr" registryId="http://inspire.ec.europa.eu/layer/TN.WaterTransportNetwork.FairwayArea" tags="//@tags.0 //@tags.2" layerName="TN.WaterTransportNetwork.FairwayArea" styleConfig="//@styleConfig.126">
+  <layerConfig name="TN_RoadTra_3_v5" registryId="http://inspire.ec.europa.eu/layer/TN.RoadTransportNetwork.VehicleTrafficArea" tags="//@tags.0 //@tags.2" layerName="TN.RoadTransportNetwork.VehicleTrafficArea" styleConfig="//@styleConfig.181">
+    <title lang="en" text="Vehicle traffic Area Default Style"/>
+    <title text="Verkehrsfläche"/>
+    <objectType>tn-ro_5.0:VehicleTrafficArea</objectType>
+  </layerConfig>
+  <layerConfig name="TN_WaterTr" registryId="http://inspire.ec.europa.eu/layer/TN.WaterTransportNetwork.FairwayArea" tags="//@tags.0 //@tags.2" layerName="TN.WaterTransportNetwork.FairwayArea" styleConfig="//@styleConfig.182">
     <title lang="en" text="Fairway Area Default Style"/>
     <title text="Fahrrinnenbereich"/>
     <objectType>tn-w_4.0:FairwayArea</objectType>
   </layerConfig>
-  <layerConfig name="TN_WaterTr_1" registryId="http://inspire.ec.europa.eu/layer/TN.WaterTransportNetwork.PortArea" tags="//@tags.0 //@tags.2" layerName="TN.WaterTransportNetwork.PortArea" styleConfig="//@styleConfig.127">
+  <layerConfig name="TN_WaterTr_v5" registryId="http://inspire.ec.europa.eu/layer/TN.WaterTransportNetwork.FairwayArea" tags="//@tags.0 //@tags.2" layerName="TN.WaterTransportNetwork.FairwayArea" styleConfig="//@styleConfig.183">
+    <title lang="en" text="Fairway Area Default Style"/>
+    <title text="Fahrrinnenbereich"/>
+    <objectType>tn-w_5.0:FairwayArea</objectType>
+  </layerConfig>
+  <layerConfig name="TN_WaterTr_1" registryId="http://inspire.ec.europa.eu/layer/TN.WaterTransportNetwork.PortArea" tags="//@tags.0 //@tags.2" layerName="TN.WaterTransportNetwork.PortArea" styleConfig="//@styleConfig.184">
     <title lang="en" text="Port Area Default Style"/>
     <title text="Hafengelände"/>
     <objectType>tn-w_4.0:PortArea</objectType>
   </layerConfig>
-  <layerConfig name="TN_WaterTr_2" registryId="http://inspire.ec.europa.eu/layer/TN.WaterTransportNetwork.WaterwayLink" tags="//@tags.0 //@tags.2" layerName="TN.WaterTransportNetwork.WaterwayLink" styleConfig="//@styleConfig.128">
+  <layerConfig name="TN_WaterTr_1_v5" registryId="http://inspire.ec.europa.eu/layer/TN.WaterTransportNetwork.PortArea" tags="//@tags.0 //@tags.2" layerName="TN.WaterTransportNetwork.PortArea" styleConfig="//@styleConfig.185">
+    <title lang="en" text="Port Area Default Style"/>
+    <title text="Hafengelände"/>
+    <objectType>tn-w_5.0:PortArea</objectType>
+  </layerConfig>
+  <layerConfig name="TN_WaterTr_2" registryId="http://inspire.ec.europa.eu/layer/TN.WaterTransportNetwork.WaterwayLink" tags="//@tags.0 //@tags.2" layerName="TN.WaterTransportNetwork.WaterwayLink" styleConfig="//@styleConfig.186">
     <title lang="en" text="Waterway Link Default Style"/>
     <title text="Wasserstraßenverbindung"/>
     <objectType>tn-w_4.0:WaterwayLink</objectType>
   </layerConfig>
-  <layerConfig name="LC_LandCoverSurfaces" registryId="http://inspire.ec.europa.eu/layer/LC.LandCoverSurfaces" tags="//@tags.2 //@tags.0" layerName="LC.LandCoverSurfaces" styleConfig="//@styleConfig.129">
+  <layerConfig name="TN_WaterTr_2_v5" registryId="http://inspire.ec.europa.eu/layer/TN.WaterTransportNetwork.WaterwayLink" tags="//@tags.0 //@tags.2" layerName="TN.WaterTransportNetwork.WaterwayLink" styleConfig="//@styleConfig.187">
+    <title lang="en" text="Waterway Link Default Style"/>
+    <title text="Wasserstraßenverbindung"/>
+    <objectType>tn-w_5.0:WaterwayLink</objectType>
+  </layerConfig>
+  <layerConfig name="LC_LandCoverSurfaces" registryId="http://inspire.ec.europa.eu/layer/LC.LandCoverSurfaces" tags="//@tags.2 //@tags.0" layerName="LC.LandCoverSurfaces" styleConfig="//@styleConfig.188">
     <title lang="en" text="Land Cover Surfaces"/>
     <title text="Bodenbedeckungsflächen"/>
     <objectType>lcv_4.0:LandCoverUnit</objectType>
   </layerConfig>
-  <layerConfig name="LC_LandCoverPoints" registryId="http://inspire.ec.europa.eu/layer/LC.LandCoverPoints" tags="//@tags.2 //@tags.0" layerName="LC.LandCoverPoints" styleConfig="//@styleConfig.130">
+  <layerConfig name="LC_LandCoverSurfaces_v5" registryId="http://inspire.ec.europa.eu/layer/LC.LandCoverSurfaces" tags="//@tags.2 //@tags.0" layerName="LC.LandCoverSurfaces" styleConfig="//@styleConfig.189">
+    <title lang="en" text="Land Cover Surfaces"/>
+    <title text="Bodenbedeckungsflächen"/>
+    <objectType>lcv_5.0:LandCoverUnit</objectType>
+  </layerConfig>
+  <layerConfig name="LC_LandCoverPoints" registryId="http://inspire.ec.europa.eu/layer/LC.LandCoverPoints" tags="//@tags.2 //@tags.0" layerName="LC.LandCoverPoints" styleConfig="//@styleConfig.190">
     <title lang="en" text="Land Cover Points"/>
     <title text="Bodenbedeckungspunkte"/>
     <objectType>lcv_4.0:LandCoverUnit</objectType>
   </layerConfig>
-  <layerConfig name="BU_Building" registryId="http://inspire.ec.europa.eu/layer/BU.Building" tags="//@tags.0 //@tags.2" layerName="BU.Building" styleConfig="//@styleConfig.131">
+  <layerConfig name="LC_LandCoverPoints_v5" registryId="http://inspire.ec.europa.eu/layer/LC.LandCoverPoints" tags="//@tags.2 //@tags.0" layerName="LC.LandCoverPoints" styleConfig="//@styleConfig.191">
+    <title lang="en" text="Land Cover Points"/>
+    <title text="Bodenbedeckungspunkte"/>
+    <objectType>lcv_5.0:LandCoverUnit</objectType>
+  </layerConfig>
+  <layerConfig name="BU_Building" registryId="http://inspire.ec.europa.eu/layer/BU.Building" tags="//@tags.0 //@tags.2" layerName="BU.Building" styleConfig="//@styleConfig.192">
     <title lang="en" text="Building"/>
     <title text="Gebäude"/>
     <objectType>bu-core2d_4.0:Building</objectType>
   </layerConfig>
-  <layerConfig name="BU_BuildingPart" registryId="http://inspire.ec.europa.eu/layer/BU.BuildingPart" tags="//@tags.0 //@tags.2" layerName="BU.BuildingPart" styleConfig="//@styleConfig.132">
+  <layerConfig name="BU_BuildingPart" registryId="http://inspire.ec.europa.eu/layer/BU.BuildingPart" tags="//@tags.0 //@tags.2" layerName="BU.BuildingPart" styleConfig="//@styleConfig.193">
     <title lang="en" text="BuildingPart"/>
     <title text="Gebäudeteile"/>
     <objectType>bu-core2d_4.0:BuildingPart</objectType>
   </layerConfig>
-  <layerConfig name="LU_ExistingLandUse" registryId="http://inspire.ec.europa.eu/layer/LU.ExistingLandUse" tags="//@tags.2 //@tags.0" layerName="LU.ExistingLandUse" styleConfig="//@styleConfig.66">
+  <layerConfig name="LU_ExistingLandUse" registryId="http://inspire.ec.europa.eu/layer/LU.ExistingLandUse" tags="//@tags.2 //@tags.0" layerName="LU.ExistingLandUse" styleConfig="//@styleConfig.82">
     <title lang="en" text="Existing Land Use"/>
     <title text="Existierende Bodennutzung"/>
     <objectType>elu_4.0:ExistingLandUseObject</objectType>
   </layerConfig>
-  <layerConfig name="LU_SpatialPlan" registryId="http://inspire.ec.europa.eu/layer/LU.SpatialPlan" tags="//@tags.2 //@tags.0" layerName="LU.SpatialPlan" styleConfig="//@styleConfig.65">
+  <layerConfig name="LU_SpatialPlan" registryId="http://inspire.ec.europa.eu/layer/LU.SpatialPlan" tags="//@tags.2 //@tags.0" layerName="LU.SpatialPlan" styleConfig="//@styleConfig.81">
     <title lang="en" text="Spatial Plan"/>
     <title text="Räumlicher Plan"/>
     <objectType>plu_4.0:SpatialPlan</objectType>
   </layerConfig>
-  <layerConfig name="LU_ZoningElement" registryId="http://inspire.ec.europa.eu/layer/LU.ZoningElement" tags="//@tags.2 //@tags.0" layerName="LU.ZoningElement" styleConfig="//@styleConfig.64">
+  <layerConfig name="LU_ZoningElement" registryId="http://inspire.ec.europa.eu/layer/LU.ZoningElement" tags="//@tags.2 //@tags.0" layerName="LU.ZoningElement" styleConfig="//@styleConfig.80">
     <title lang="en" text="Zoning Element"/>
     <title text="Zonierungselement"/>
     <objectType>plu_4.0:ZoningElement</objectType>
   </layerConfig>
-  <layerConfig name="LU_SupplementaryRegulation" registryId="http://inspire.ec.europa.eu/layer/LU.SupplementaryRegulation" tags="//@tags.2 //@tags.0" layerName="LU.SupplementaryRegulation" styleConfig="//@styleConfig.63">
+  <layerConfig name="LU_SupplementaryRegulation" registryId="http://inspire.ec.europa.eu/layer/LU.SupplementaryRegulation" tags="//@tags.2 //@tags.0" layerName="LU.SupplementaryRegulation" styleConfig="//@styleConfig.79">
     <title lang="en" text="Supplementary Regulation"/>
     <title text="Ergänzende Vorschrift"/>
     <objectType>plu_4.0:SupplementaryRegulation</objectType>
   </layerConfig>
-  <layerConfig name="US_GovernmentalService" registryId="" tags="//@tags.0" layerName="US.GovernmentalService" styleConfig="//@styleConfig.62">
+  <layerConfig name="US_GovernmentalService" registryId="" tags="//@tags.0" layerName="US.GovernmentalService" styleConfig="//@styleConfig.77">
     <title lang="en" text="Governmental Service"/>
     <title text="Staatlicher Dienst"/>
     <objectType>us-govserv_4.0:GovernmentalService</objectType>
   </layerConfig>
-  <layerConfig name="AM_AirQualityManagementZone" registryId="http://inspire.ec.europa.eu/layer/AM.AirQualityManagementZone" tags="//@tags.0 //@tags.2" layerName="AM.AirQualityManagementZone" styleConfig="//@styleConfig.60">
+  <layerConfig name="US_GovernmentalService_v5" registryId="" tags="//@tags.0" layerName="US.GovernmentalService" styleConfig="//@styleConfig.78">
+    <title lang="en" text="Governmental Service"/>
+    <title text="Staatlicher Dienst"/>
+    <objectType>us-govserv_5.0:GovernmentalService</objectType>
+  </layerConfig>
+  <layerConfig name="AM_AirQualityManagementZone" registryId="http://inspire.ec.europa.eu/layer/AM.AirQualityManagementZone" tags="//@tags.0 //@tags.2" layerName="AM.AirQualityManagementZone" styleConfig="//@styleConfig.75">
     <title lang="en" text="Air Quality Management Zone"/>
     <title text="Luftqualitäts-Kontrollgebiet"/>
     <objectType>am_4.0:ManagementRestrictionOrRegulationZone</objectType>
   </layerConfig>
-  <layerConfig name="AM_AnimalHealthRestrictionZone" registryId="http://inspire.ec.europa.eu/layer/AM.AnimalHealthRestrictionZone" tags="//@tags.0 //@tags.2" layerName="AM.AnimalHealthRestrictionZone" styleConfig="//@styleConfig.61">
+  <layerConfig name="AM_AnimalHealthRestrictionZone" registryId="http://inspire.ec.europa.eu/layer/AM.AnimalHealthRestrictionZone" tags="//@tags.0 //@tags.2" layerName="AM.AnimalHealthRestrictionZone" styleConfig="//@styleConfig.76">
     <title lang="en" text="Animal Health Restriction Zone"/>
     <title text="Tiergesundheits-Schutzgebiet"/>
     <objectType>am_4.0:ManagementRestrictionOrRegulationZone</objectType>
   </layerConfig>
-  <layerConfig name="AM_AreaForDisposalOfWaste" registryId="http://inspire.ec.europa.eu/layer/AM.AreaForDisposalOfWaste" tags="//@tags.0 //@tags.2" layerName="AM.AreaForDisposalOfWaste" styleConfig="//@styleConfig.59">
+  <layerConfig name="AM_AreaForDisposalOfWaste" registryId="http://inspire.ec.europa.eu/layer/AM.AreaForDisposalOfWaste" tags="//@tags.0 //@tags.2" layerName="AM.AreaForDisposalOfWaste" styleConfig="//@styleConfig.74">
     <title lang="en" text="Area For Disposal Of Waste"/>
     <title text="Abfallentsorgungsgebiet"/>
     <objectType>am_4.0:ManagementRestrictionOrRegulationZone</objectType>
   </layerConfig>
-  <layerConfig name="AM_BathingWaters" registryId="http://inspire.ec.europa.eu/layer/AM.BathingWaters" tags="//@tags.0 //@tags.2" layerName="AM.BathingWaters" styleConfig="//@styleConfig.58">
+  <layerConfig name="AM_BathingWaters" registryId="http://inspire.ec.europa.eu/layer/AM.BathingWaters" tags="//@tags.0 //@tags.2" layerName="AM.BathingWaters" styleConfig="//@styleConfig.73">
     <title lang="en" text="Bathing Waters"/>
     <title text="Badegewässer"/>
     <objectType>am_4.0:ManagementRestrictionOrRegulationZone</objectType>
   </layerConfig>
-  <layerConfig name="AM_CoastalZoneManagementArea" registryId="http://inspire.ec.europa.eu/layer/AM.CoastalZoneManagementArea" tags="//@tags.0 //@tags.2" layerName="AM.CoastalZoneManagementArea" styleConfig="//@styleConfig.57">
+  <layerConfig name="AM_CoastalZoneManagementArea" registryId="http://inspire.ec.europa.eu/layer/AM.CoastalZoneManagementArea" tags="//@tags.0 //@tags.2" layerName="AM.CoastalZoneManagementArea" styleConfig="//@styleConfig.72">
     <title lang="en" text="Coastal Zone Management Area"/>
     <title text="Gebiete des Küstenzonenmanagements"/>
     <objectType>am_4.0:ManagementRestrictionOrRegulationZone</objectType>
   </layerConfig>
-  <layerConfig name="AM_DesignatedWaters" registryId="http://inspire.ec.europa.eu/layer/AM.DesignatedWaters" tags="//@tags.0 //@tags.2" layerName="AM.DesignatedWaters" styleConfig="//@styleConfig.56">
+  <layerConfig name="AM_DesignatedWaters" registryId="http://inspire.ec.europa.eu/layer/AM.DesignatedWaters" tags="//@tags.0 //@tags.2" layerName="AM.DesignatedWaters" styleConfig="//@styleConfig.71">
     <title lang="en" text="Designated Waters"/>
     <title text="Bezeichnetes Gewässer"/>
     <objectType>am_4.0:ManagementRestrictionOrRegulationZone</objectType>
   </layerConfig>
-  <layerConfig name="AM_DrinkingWaterProtectionArea" registryId="http://inspire.ec.europa.eu/layer/AM.DrinkingWaterProtectionArea" tags="//@tags.0 //@tags.2" layerName="AM.DrinkingWaterProtectionArea" styleConfig="//@styleConfig.55">
+  <layerConfig name="AM_DrinkingWaterProtectionArea" registryId="http://inspire.ec.europa.eu/layer/AM.DrinkingWaterProtectionArea" tags="//@tags.0 //@tags.2" layerName="AM.DrinkingWaterProtectionArea" styleConfig="//@styleConfig.70">
     <title lang="en" text="Drinking Water Protection Area"/>
     <title text="Trinkwasserschutzgebiet"/>
     <objectType>am_4.0:ManagementRestrictionOrRegulationZone</objectType>
   </layerConfig>
-  <layerConfig name="AM_FloodUnitOfManagement" registryId="http://inspire.ec.europa.eu/layer/AM.FloodUnitOfManagement" tags="//@tags.0 //@tags.2" layerName="AM.FloodUnitOfManagement" styleConfig="//@styleConfig.54">
+  <layerConfig name="AM_FloodUnitOfManagement" registryId="http://inspire.ec.europa.eu/layer/AM.FloodUnitOfManagement" tags="//@tags.0 //@tags.2" layerName="AM.FloodUnitOfManagement" styleConfig="//@styleConfig.69">
     <title lang="en" text="Flood Unit Of Management"/>
     <title text="Bewirtschaftungseinheit für Hochwasserrisiken"/>
     <objectType>am_4.0:ManagementRestrictionOrRegulationZone</objectType>
   </layerConfig>
-  <layerConfig name="AM_ForestManagementArea" registryId="http://inspire.ec.europa.eu/layer/AM.ForestManagementArea" tags="//@tags.0 //@tags.2" layerName="AM.ForestManagementArea" styleConfig="//@styleConfig.53">
+  <layerConfig name="AM_ForestManagementArea" registryId="http://inspire.ec.europa.eu/layer/AM.ForestManagementArea" tags="//@tags.0 //@tags.2" layerName="AM.ForestManagementArea" styleConfig="//@styleConfig.68">
     <title lang="en" text="Forest Management Area"/>
     <title text="Waldbewirtschaftungsgebiet"/>
     <objectType>am_4.0:ManagementRestrictionOrRegulationZone</objectType>
   </layerConfig>
-  <layerConfig name="AM_MarineRegion" registryId="http://inspire.ec.europa.eu/layer/AM.MarineRegion" tags="//@tags.0 //@tags.2" layerName="AM.MarineRegion" styleConfig="//@styleConfig.52">
+  <layerConfig name="AM_MarineRegion" registryId="http://inspire.ec.europa.eu/layer/AM.MarineRegion" tags="//@tags.0 //@tags.2" layerName="AM.MarineRegion" styleConfig="//@styleConfig.67">
     <title lang="en" text="Marine Region"/>
     <title text="Meeresregion"/>
     <objectType>am_4.0:ManagementRestrictionOrRegulationZone</objectType>
   </layerConfig>
-  <layerConfig name="AM_NitrateVulnerableZone" registryId="http://inspire.ec.europa.eu/layer/AM.NitrateVulnerableZone" tags="//@tags.0 //@tags.2" layerName="AM.NitrateVulnerableZone" styleConfig="//@styleConfig.51">
+  <layerConfig name="AM_NitrateVulnerableZone" registryId="http://inspire.ec.europa.eu/layer/AM.NitrateVulnerableZone" tags="//@tags.0 //@tags.2" layerName="AM.NitrateVulnerableZone" styleConfig="//@styleConfig.66">
     <title lang="en" text="Nitrate Vulnerable Zone"/>
     <title text="Nitratgefährdetes Gebiet"/>
     <objectType>am_4.0:ManagementRestrictionOrRegulationZone</objectType>
   </layerConfig>
-  <layerConfig name="AM_NoiseRestrictionZone" registryId="http://inspire.ec.europa.eu/layer/AM.NoiseRestrictionZone" tags="//@tags.0 //@tags.2" layerName="AM.NoiseRestrictionZone" styleConfig="//@styleConfig.50">
+  <layerConfig name="AM_NoiseRestrictionZone" registryId="http://inspire.ec.europa.eu/layer/AM.NoiseRestrictionZone" tags="//@tags.0 //@tags.2" layerName="AM.NoiseRestrictionZone" styleConfig="//@styleConfig.65">
     <title lang="en" text="Noise Restriction Zone"/>
     <title text="Lärmschutzgebiet"/>
     <objectType>am_4.0:ManagementRestrictionOrRegulationZone</objectType>
   </layerConfig>
-  <layerConfig name="AM_PlantHealthProtectionZone" registryId="http://inspire.ec.europa.eu/layer/AM.PlantHealthProtectionZone" tags="//@tags.0 //@tags.2" layerName="AM.PlantHealthProtectionZone" styleConfig="//@styleConfig.49">
+  <layerConfig name="AM_PlantHealthProtectionZone" registryId="http://inspire.ec.europa.eu/layer/AM.PlantHealthProtectionZone" tags="//@tags.0 //@tags.2" layerName="AM.PlantHealthProtectionZone" styleConfig="//@styleConfig.64">
     <title lang="en" text="Plant Health Protection Zone"/>
     <title text="Pflanzengesundheitliches Schutzgebiet"/>
     <objectType>am_4.0:ManagementRestrictionOrRegulationZone</objectType>
   </layerConfig>
-  <layerConfig name="AM_ProspectingAndMiningPermitArea" registryId="http://inspire.ec.europa.eu/layer/AM.ProspectingAndMiningPermitArea" tags="//@tags.0 //@tags.2" layerName="AM.ProspectingAndMiningPermitArea" styleConfig="//@styleConfig.48">
+  <layerConfig name="AM_ProspectingAndMiningPermitArea" registryId="http://inspire.ec.europa.eu/layer/AM.ProspectingAndMiningPermitArea" tags="//@tags.0 //@tags.2" layerName="AM.ProspectingAndMiningPermitArea" styleConfig="//@styleConfig.63">
     <title lang="en" text="Prospecting And Mining Permit Area"/>
     <title text="Für Prospektion und Bergbau ausgewiesenes Gebiet"/>
     <objectType>am_4.0:ManagementRestrictionOrRegulationZone</objectType>
   </layerConfig>
-  <layerConfig name="AM_RegulatedFairwayAtSeaOrLargeInlandWater" registryId="http://inspire.ec.europa.eu/layer/AM.RegulatedFairwayAtSeaOrLargeInlandWater" tags="//@tags.0 //@tags.2" layerName="AM.RegulatedFairwayAtSeaOrLargeInlandWater" styleConfig="//@styleConfig.47">
+  <layerConfig name="AM_RegulatedFairwayAtSeaOrLargeInlandWater" registryId="http://inspire.ec.europa.eu/layer/AM.RegulatedFairwayAtSeaOrLargeInlandWater" tags="//@tags.0 //@tags.2" layerName="AM.RegulatedFairwayAtSeaOrLargeInlandWater" styleConfig="//@styleConfig.62">
     <title lang="en" text="Regulated Fairway At Sea Or Large Inland Water"/>
     <title text="Geregeltes Fahrwasser auf See oder auf großen Binnengewässern"/>
     <objectType>am_4.0:ManagementRestrictionOrRegulationZone</objectType>
   </layerConfig>
-  <layerConfig name="AM_RestrictedZonesAroundContaminatedSites" registryId="http://inspire.ec.europa.eu/layer/AM.RestrictedZonesAroundContaminatedSites" tags="//@tags.0 //@tags.2" layerName="AM.RestrictedZonesAroundContaminatedSites" styleConfig="//@styleConfig.46">
+  <layerConfig name="AM_RestrictedZonesAroundContaminatedSites" registryId="http://inspire.ec.europa.eu/layer/AM.RestrictedZonesAroundContaminatedSites" tags="//@tags.0 //@tags.2" layerName="AM.RestrictedZonesAroundContaminatedSites" styleConfig="//@styleConfig.61">
     <title lang="en" text="Restricted Zones Around Contaminated Sites"/>
     <title text="Schutzgebiete um kontaminierte Standorte (Altlasten)"/>
     <objectType>am_4.0:ManagementRestrictionOrRegulationZone</objectType>
   </layerConfig>
-  <layerConfig name="AM_RiverBasinDistrict" registryId="http://inspire.ec.europa.eu/layer/AM.RiverBasinDistrict" tags="//@tags.0 //@tags.2" layerName="AM.RiverBasinDistrict" styleConfig="//@styleConfig.45">
+  <layerConfig name="AM_RiverBasinDistrict" registryId="http://inspire.ec.europa.eu/layer/AM.RiverBasinDistrict" tags="//@tags.0 //@tags.2" layerName="AM.RiverBasinDistrict" styleConfig="//@styleConfig.60">
     <title lang="en" text="River Basin District"/>
     <title text="Flussgebietseinheit"/>
     <objectType>am_4.0:ManagementRestrictionOrRegulationZone</objectType>
   </layerConfig>
-  <layerConfig name="AM_SensitiveArea" registryId="http://inspire.ec.europa.eu/layer/AM.SensitiveArea" tags="//@tags.0 //@tags.2" layerName="AM.SensitiveArea" styleConfig="//@styleConfig.44">
+  <layerConfig name="AM_SensitiveArea" registryId="http://inspire.ec.europa.eu/layer/AM.SensitiveArea" tags="//@tags.0 //@tags.2" layerName="AM.SensitiveArea" styleConfig="//@styleConfig.59">
     <title lang="en" text="Sensitive Area"/>
     <title text="Empfindliches Gebiet"/>
     <objectType>am_4.0:ManagementRestrictionOrRegulationZone</objectType>
   </layerConfig>
-  <layerConfig name="AM_WaterBodyForWFD" registryId="http://inspire.ec.europa.eu/layer/AM.WaterBodyForWFD" tags="//@tags.0 //@tags.2" layerName="AM.WaterBodyForWFD" styleConfig="//@styleConfig.43">
+  <layerConfig name="AM_WaterBodyForWFD" registryId="http://inspire.ec.europa.eu/layer/AM.WaterBodyForWFD" tags="//@tags.0 //@tags.2" layerName="AM.WaterBodyForWFD" styleConfig="//@styleConfig.58">
     <title lang="en" text="WaterBodyForWFD"/>
     <title text="Wasserkörper gemäß der Wasserrahmenrichtlinie (2000/60/EG)"/>
     <objectType>am_4.0:ManagementRestrictionOrRegulationZone</objectType>
   </layerConfig>
-  <layerConfig name="US_EnvironmentalManagementFacility" registryId="https://inspire.ec.europa.eu/layer/US.EnvironmentalManagementFacility" tags="//@tags.0 //@tags.2" layerName="US.EnvironmentalManagementFacility" styleConfig="//@styleConfig.3">
+  <layerConfig name="US_EnvironmentalManagementFacility" registryId="https://inspire.ec.europa.eu/layer/US.EnvironmentalManagementFacility" tags="//@tags.0 //@tags.2" layerName="US.EnvironmentalManagementFacility" styleConfig="//@styleConfig.5">
     <title lang="en" text="Environmental Management Facility"/>
     <title text="Umweltmanagementeinrichtungen"/>
     <objectType>us-emf_4.0:EnvironmentalManagementFacility</objectType>
+  </layerConfig>
+  <layerConfig name="US_EnvironmentalManagementFacility_v5" registryId="https://inspire.ec.europa.eu/layer/US.EnvironmentalManagementFacility" tags="//@tags.0 //@tags.2" layerName="US.EnvironmentalManagementFacility" styleConfig="//@styleConfig.6">
+    <title lang="en" text="Environmental Management Facility"/>
+    <title text="Umweltmanagementeinrichtungen"/>
+    <objectType>us-emf_5.0:EnvironmentalManagementFacility</objectType>
   </layerConfig>
   <layerConfig name="US_UtilityNetworkAppurtenance" registryId="" tags="//@tags.0 //@tags.2" layerName="US.UtilityNetworkAppurtenance" styleConfig="//@styleConfig.1">
     <title lang="en" text="Appurtenance"/>
     <title text="Zubehörteil"/>
     <objectType>us-net-common_4.0:Appurtenance</objectType>
   </layerConfig>
-  <layerConfig name="US_UtilityNetworkLink" registryId="" tags="//@tags.0 //@tags.2" layerName="US.UtilityNetworkLink" styleConfig="//@styleConfig.2">
+  <layerConfig name="US_UtilityNetworkAppurtenance_v5" registryId="" tags="//@tags.0 //@tags.2" layerName="US.UtilityNetworkAppurtenance" styleConfig="//@styleConfig.2">
+    <title lang="en" text="Appurtenance"/>
+    <title text="Zubehörteil"/>
+    <objectType>us-net-common_5.0:Appurtenance</objectType>
+  </layerConfig>
+  <layerConfig name="US_UtilityNetworkLink" registryId="" tags="//@tags.0 //@tags.2" layerName="US.UtilityNetworkLink" styleConfig="//@styleConfig.3">
     <title lang="en" text="Utility Link"/>
     <title text="Versorgungsverbindung"/>
     <objectType>us-net-common_4.0:UtilityLink</objectType>
   </layerConfig>
-  <layerConfig name="EF_EnvironmentalMonitoringFacilities" registryId="http://inspire.ec.europa.eu/layer/EF.EnvironmentalMonitoringFacilities" tags="//@tags.0 //@tags.2" layerName="EF.EnvironmentalMonitoringFacilities" styleConfig="//@styleConfig.42">
+  <layerConfig name="US_UtilityNetworkLink_v5" registryId="" tags="//@tags.0 //@tags.2" layerName="US.UtilityNetworkLink" styleConfig="//@styleConfig.4">
+    <title lang="en" text="Utility Link"/>
+    <title text="Versorgungsverbindung"/>
+    <objectType>us-net-common_5.0:UtilityLink</objectType>
+  </layerConfig>
+  <layerConfig name="EF_EnvironmentalMonitoringFacilities" registryId="http://inspire.ec.europa.eu/layer/EF.EnvironmentalMonitoringFacilities" tags="//@tags.0 //@tags.2" layerName="EF.EnvironmentalMonitoringFacilities" styleConfig="//@styleConfig.57">
     <title lang="en" text="Environmental Monitoring Facilities"/>
     <title text="Umweltüberwachungseinrichtungen"/>
     <objectType>ef_4.0:EnvironmentalMonitoringFacility</objectType>
   </layerConfig>
-  <layerConfig name="EF_EnvironmentalMonitoringNetworks" registryId="http://inspire.ec.europa.eu/layer/EF.EnvironmentalMonitoringNetworks" tags="//@tags.0 //@tags.2" layerName="EF.EnvironmentalMonitoringNetworks" styleConfig="//@styleConfig.41">
+  <layerConfig name="EF_EnvironmentalMonitoringNetworks" registryId="http://inspire.ec.europa.eu/layer/EF.EnvironmentalMonitoringNetworks" tags="//@tags.0 //@tags.2" layerName="EF.EnvironmentalMonitoringNetworks" styleConfig="//@styleConfig.56">
     <title lang="en" text="Environmental Monitoring Networks"/>
     <title text="Umweltüberwachungsnetzwerke"/>
     <objectType>ef_4.0:EnvironmentalMonitoringNetwork</objectType>
   </layerConfig>
-  <layerConfig name="EF_EnvironmentalMonitoringProgrammes" registryId="http://inspire.ec.europa.eu/layer/EF.EnvironmentalMonitoringProgrammes" tags="//@tags.0 //@tags.2" layerName="EF.EnvironmentalMonitoringProgrammes" styleConfig="//@styleConfig.40">
+  <layerConfig name="EF_EnvironmentalMonitoringProgrammes" registryId="http://inspire.ec.europa.eu/layer/EF.EnvironmentalMonitoringProgrammes" tags="//@tags.0 //@tags.2" layerName="EF.EnvironmentalMonitoringProgrammes" styleConfig="//@styleConfig.55">
     <title lang="en" text="Environmental Monitoring Programmes"/>
     <title text="Umweltüberwachungsprogramme"/>
     <objectType>ef_4.0:EnvironmentalMonitoringProgramme</objectType>
   </layerConfig>
-  <layerConfig name="NZ_RiskZone" registryId="" tags="//@tags.0 //@tags.2" layerName="NZ.RiskZone" styleConfig="//@styleConfig.39">
+  <layerConfig name="NZ_RiskZone" registryId="" tags="//@tags.0 //@tags.2" layerName="NZ.RiskZone" styleConfig="//@styleConfig.54">
     <title lang="en" text="Risk Zones"/>
     <title text="Risikogebiet"/>
     <objectType>nz-core_4.0:RiskZone</objectType>
   </layerConfig>
-  <layerConfig name="NZ_HazardArea" registryId="" tags="//@tags.0 //@tags.2" layerName="NZ.HazardArea" styleConfig="//@styleConfig.38">
+  <layerConfig name="NZ_HazardArea" registryId="" tags="//@tags.0 //@tags.2" layerName="NZ.HazardArea" styleConfig="//@styleConfig.53">
     <title lang="en" text="Hazard Area"/>
     <title text="Gefahrengebiet"/>
     <objectType>nz-core_4.0:HazardArea</objectType>
   </layerConfig>
-  <layerConfig name="NZ_ExposedElement" registryId="http://inspire.ec.europa.eu/layer/NZ.ExposedElement" tags="//@tags.0 //@tags.2" layerName="NZ.ExposedElement" styleConfig="//@styleConfig.37">
+  <layerConfig name="NZ_ExposedElement" registryId="http://inspire.ec.europa.eu/layer/NZ.ExposedElement" tags="//@tags.0 //@tags.2" layerName="NZ.ExposedElement" styleConfig="//@styleConfig.52">
     <title lang="en" text="Exposed Elements"/>
     <title text="Gefährdetes Element"/>
     <objectType>nz-core_4.0:ExposedElement</objectType>
   </layerConfig>
-  <layerConfig name="NZ_ObservedEvent" registryId="" tags="//@tags.0" layerName="NZ.ObservedEvent" styleConfig="//@styleConfig.36">
+  <layerConfig name="NZ_ObservedEvent" registryId="" tags="//@tags.0" layerName="NZ.ObservedEvent" styleConfig="//@styleConfig.51">
     <title lang="en" text="Observed Event"/>
     <title text="Beobachtetes Ereignis"/>
     <objectType>nz-core_4.0:ObservedEvent</objectType>
   </layerConfig>
-  <layerConfig name="TN_MarkerPost" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.CommonTransportElements.MarkerPost" styleConfig="//@styleConfig.35">
+  <layerConfig name="TN_MarkerPost" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.CommonTransportElements.MarkerPost" styleConfig="//@styleConfig.49">
     <title lang="en" text="Marker Post"/>
     <title text="Stationszeichen"/>
     <objectType>tn_4.0:MarkerPost</objectType>
   </layerConfig>
-  <layerConfig name="TN_W_Beacon" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.WaterTransportNetwork.Beacon" styleConfig="//@styleConfig.34">
+  <layerConfig name="TN_MarkerPost_v5" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.CommonTransportElements.MarkerPost" styleConfig="//@styleConfig.50">
+    <title lang="en" text="Marker Post"/>
+    <title text="Stationszeichen"/>
+    <objectType>tn_5.0:MarkerPost</objectType>
+  </layerConfig>
+  <layerConfig name="TN_W_Beacon" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.WaterTransportNetwork.Beacon" styleConfig="//@styleConfig.47">
     <title lang="en" text="Beacon"/>
     <title text="Leuchtfeuer"/>
     <objectType>tn-w_4.0:Beacon</objectType>
   </layerConfig>
-  <layerConfig name="TN_W_Buoy" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.WaterTransportNetwork.Buoy" styleConfig="//@styleConfig.33">
+  <layerConfig name="TN_W_Beacon_v5" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.WaterTransportNetwork.Beacon" styleConfig="//@styleConfig.48">
+    <title lang="en" text="Beacon"/>
+    <title text="Leuchtfeuer"/>
+    <objectType>tn-w_5.0:Beacon</objectType>
+  </layerConfig>
+  <layerConfig name="TN_W_Buoy" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.WaterTransportNetwork.Buoy" styleConfig="//@styleConfig.45">
     <title lang="en" text="Buoy"/>
     <title text="Tonne"/>
     <objectType>tn-w_4.0:Buoy</objectType>
   </layerConfig>
-  <layerConfig name="TN_W_TrafficSeparationSchemeCrossing" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.WaterTransportNetwork.TrafficSeparationSchemeCrossing" styleConfig="//@styleConfig.32">
+  <layerConfig name="TN_W_Buoy_v5" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.WaterTransportNetwork.Buoy" styleConfig="//@styleConfig.46">
+    <title lang="en" text="Buoy"/>
+    <title text="Tonne"/>
+    <objectType>tn-w_5.0:Buoy</objectType>
+  </layerConfig>
+  <layerConfig name="TN_W_TrafficSeparationSchemeCrossing" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.WaterTransportNetwork.TrafficSeparationSchemeCrossing" styleConfig="//@styleConfig.43">
     <title lang="en" text="Traffic Separation Scheme Crossing"/>
     <title text="Kreuzung eines Verkehrstrennungsgebiets"/>
     <objectType>tn-w_4.0:TrafficSeparationSchemeCrossing</objectType>
   </layerConfig>
-  <layerConfig name="TN_W_TrafficSeparationSchemeSeparator" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.WaterTransportNetwork.TrafficSeparationSchemeSeparator" styleConfig="//@styleConfig.31">
+  <layerConfig name="TN_W_TrafficSeparationSchemeCrossing_v5" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.WaterTransportNetwork.TrafficSeparationSchemeCrossing" styleConfig="//@styleConfig.44">
+    <title lang="en" text="Traffic Separation Scheme Crossing"/>
+    <title text="Kreuzung eines Verkehrstrennungsgebiets"/>
+    <objectType>tn-w_5.0:TrafficSeparationSchemeCrossing</objectType>
+  </layerConfig>
+  <layerConfig name="TN_W_TrafficSeparationSchemeSeparator" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.WaterTransportNetwork.TrafficSeparationSchemeSeparator" styleConfig="//@styleConfig.41">
     <title lang="en" text="Traffic Separation Scheme Separator"/>
     <title text="Übergangszone eines Verkehrstrennungsgebiets"/>
     <objectType>tn-w_4.0:TrafficSeparationSchemeSeparator</objectType>
   </layerConfig>
-  <layerConfig name="PF_ProductionFacility" registryId="" tags="//@tags.0" layerName="PF.ProductionFacility" styleConfig="//@styleConfig.30">
+  <layerConfig name="TN_W_TrafficSeparationSchemeSeparator_v5" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.WaterTransportNetwork.TrafficSeparationSchemeSeparator" styleConfig="//@styleConfig.42">
+    <title lang="en" text="Traffic Separation Scheme Separator"/>
+    <title text="Übergangszone eines Verkehrstrennungsgebiets"/>
+    <objectType>tn-w_5.0:TrafficSeparationSchemeSeparator</objectType>
+  </layerConfig>
+  <layerConfig name="PF_ProductionFacility" registryId="" tags="//@tags.0" layerName="PF.ProductionFacility" styleConfig="//@styleConfig.40">
     <title lang="en" text="Production Facility"/>
     <title text="Produktionsstätte"/>
     <objectType>pf_4.0:ProductionFacility</objectType>
   </layerConfig>
-  <layerConfig name="PF_ProductionBuilding" registryId="http://inspire.ec.europa.eu/layer/PF.ProductionBuilding" tags="//@tags.0 //@tags.2" layerName="PF.ProductionBuilding" styleConfig="//@styleConfig.29">
+  <layerConfig name="PF_ProductionBuilding" registryId="http://inspire.ec.europa.eu/layer/PF.ProductionBuilding" tags="//@tags.0 //@tags.2" layerName="PF.ProductionBuilding" styleConfig="//@styleConfig.39">
     <title lang="en" text="Production And Industrial Building"/>
     <title text="Produktions- und Industriegebäude"/>
     <objectType>pf_4.0:ProductionBuilding</objectType>
   </layerConfig>
-  <layerConfig name="PF_ProductionInstallation" registryId="http://inspire.ec.europa.eu/layer/PF.ProductionInstallation" tags="//@tags.0 //@tags.2" layerName="PF.ProductionInstallation" styleConfig="//@styleConfig.28">
+  <layerConfig name="PF_ProductionInstallation" registryId="http://inspire.ec.europa.eu/layer/PF.ProductionInstallation" tags="//@tags.0 //@tags.2" layerName="PF.ProductionInstallation" styleConfig="//@styleConfig.38">
     <title lang="en" text="Production And Industrial Installation"/>
     <title text="Produktions- und Industrieanlage"/>
     <objectType>pf_4.0:ProductionInstallation</objectType>
   </layerConfig>
-  <layerConfig name="PF_ProductionInstallationPart" registryId="http://inspire.ec.europa.eu/layer/PF.ProductionInstallationPart" tags="//@tags.0 //@tags.2" layerName="PF.ProductionInstallationPart" styleConfig="//@styleConfig.27">
+  <layerConfig name="PF_ProductionInstallationPart" registryId="http://inspire.ec.europa.eu/layer/PF.ProductionInstallationPart" tags="//@tags.0 //@tags.2" layerName="PF.ProductionInstallationPart" styleConfig="//@styleConfig.37">
     <title lang="en" text="Production And Industrial Installation Part"/>
     <title text="Produktions- und Industrieanlagenteil"/>
     <objectType>pf_4.0:ProductionInstallationPart</objectType>
   </layerConfig>
-  <layerConfig name="PF_ProductionPlot" registryId="http://inspire.ec.europa.eu/layer/PF.ProductionPlot" tags="//@tags.0 //@tags.2" layerName="PF.ProductionPlot" styleConfig="//@styleConfig.26">
+  <layerConfig name="PF_ProductionPlot" registryId="http://inspire.ec.europa.eu/layer/PF.ProductionPlot" tags="//@tags.0 //@tags.2" layerName="PF.ProductionPlot" styleConfig="//@styleConfig.36">
     <title lang="en" text="Production And Industrial Plot"/>
     <title text="Produktions- und Industriegelände"/>
     <objectType>pf_4.0:ProductionPlot</objectType>
   </layerConfig>
-  <layerConfig name="PF_ProductionSite" registryId="http://inspire.ec.europa.eu/layer/PF.ProductionSite" tags="//@tags.0 //@tags.2" layerName="PF.ProductionSite" styleConfig="//@styleConfig.25">
+  <layerConfig name="PF_ProductionSite" registryId="http://inspire.ec.europa.eu/layer/PF.ProductionSite" tags="//@tags.0 //@tags.2" layerName="PF.ProductionSite" styleConfig="//@styleConfig.35">
     <title lang="en" text="Production And Industrial Site"/>
     <title text="Produktions- und Industriestandort"/>
     <objectType>pf_4.0:ProductionSite</objectType>
   </layerConfig>
-  <layerConfig name="ER_RenewableAndWasteResource" registryId="http://inspire.ec.europa.eu/layer/ER.RenewableAndWasteResource" tags="//@tags.0" layerName="ER.RenewableAndWasteResource" styleConfig="//@styleConfig.24">
+  <layerConfig name="ER_RenewableAndWasteResource" registryId="http://inspire.ec.europa.eu/layer/ER.RenewableAndWasteResource" tags="//@tags.0" layerName="ER.RenewableAndWasteResource" styleConfig="//@styleConfig.34">
     <title lang="en" text="Renewable And Waste Resource"/>
     <title text="Ressourcen erneuerbarer Energien und Abfallressourcen"/>
     <objectType>er-v_4.0:RenewableAndWasteResource</objectType>
   </layerConfig>
-  <layerConfig name="GE_GeologicUnit_AgeOfRocks" registryId="http://inspire.ec.europa.eu/layer/GE.GeologicUnit" tags="//@tags.0 //@tags.2" layerName="GE.GeologicUnit.AgeOfRocks" styleConfig="//@styleConfig.23">
+  <layerConfig name="GE_GeologicUnit_AgeOfRocks" registryId="http://inspire.ec.europa.eu/layer/GE.GeologicUnit" tags="//@tags.0 //@tags.2" layerName="GE.GeologicUnit.AgeOfRocks" styleConfig="//@styleConfig.33">
     <title lang="en" text="Geologic Units"/>
     <title text="Geologische Einheiten"/>
     <objectType>ge-core_4.0:MappedFeature</objectType>
   </layerConfig>
-  <layerConfig name="GE_Borehole" registryId="http://inspire.ec.europa.eu/layer/GE.Borehole" tags="//@tags.0 //@tags.2" layerName="GE.Borehole" styleConfig="//@styleConfig.133">
+  <layerConfig name="GE_Borehole" registryId="http://inspire.ec.europa.eu/layer/GE.Borehole" tags="//@tags.0 //@tags.2" layerName="GE.Borehole" styleConfig="//@styleConfig.194">
     <title lang="en" text="Boreholes"/>
     <title text="Bohrlöcher"/>
     <objectType>ge-core_4.0:Borehole</objectType>
   </layerConfig>
-  <layerConfig name="BR_BiogeographicalRegion" registryId="http://inspire.ec.europa.eu/layer/BR.Bio-geographicalRegion" tags="//@tags.0 //@tags.2" layerName="BR.Bio-geographicalRegion" styleConfig="//@styleConfig.22">
+  <layerConfig name="BR_BiogeographicalRegion" registryId="http://inspire.ec.europa.eu/layer/BR.Bio-geographicalRegion" tags="//@tags.0 //@tags.2" layerName="BR.Bio-geographicalRegion" styleConfig="//@styleConfig.32">
     <title lang="en" text="Bio-geographical regions"/>
     <title text="Biogeografische Regionen"/>
     <objectType>br_4.0:Bio-geographicalRegion</objectType>
   </layerConfig>
-  <layerConfig name="BR_Natura2000andEmeraldBiogeographicalRegion" registryId="" tags="//@tags.0 //@tags.2" layerName="BR.Natura2000andEmeraldBio-geographicalRegion" styleConfig="//@styleConfig.21">
+  <layerConfig name="BR_Natura2000andEmeraldBiogeographicalRegion" registryId="" tags="//@tags.0 //@tags.2" layerName="BR.Natura2000andEmeraldBio-geographicalRegion" styleConfig="//@styleConfig.31">
     <title lang="en" text="Bio-geographical regions"/>
     <title text="Biogeografische Regionen"/>
     <objectType>br_4.0:Bio-geographicalRegion</objectType>
   </layerConfig>
-  <layerConfig name="SU_VectorStatisticalUnit" registryId="http://inspire.ec.europa.eu/layer/SU.VectorStatisticalUnit" tags="//@tags.0 //@tags.2" layerName="SU.VectorStatisticalUnit" styleConfig="//@styleConfig.19">
+  <layerConfig name="SU_VectorStatisticalUnit" registryId="http://inspire.ec.europa.eu/layer/SU.VectorStatisticalUnit" tags="//@tags.0 //@tags.2" layerName="SU.VectorStatisticalUnit" styleConfig="//@styleConfig.29">
     <title lang="en" text="Vector statistical units"/>
     <title text="Statistische Vektoreinheiten"/>
     <objectType>su-vector_4.0:VectorStatisticalUnit</objectType>
   </layerConfig>
-  <layerConfig name="SU_StatisticalGridCell" registryId="http://inspire.ec.europa.eu/layer/SU.StatisticalGridCell" tags="//@tags.0" layerName="SU.StatisticalGridCell" styleConfig="//@styleConfig.20">
+  <layerConfig name="SU_StatisticalGridCell" registryId="http://inspire.ec.europa.eu/layer/SU.StatisticalGridCell" tags="//@tags.0" layerName="SU.StatisticalGridCell" styleConfig="//@styleConfig.30">
     <title lang="en" text="Statistical grid cells"/>
     <title text="Statistische Vektoreinheiten"/>
     <objectType>su-grid_4.0:StatisticalGridCell</objectType>
   </layerConfig>
-  <layerConfig name="HH_HealthDeterminantMeasure" registryId="http://inspire.ec.europa.eu/layer/HH.HealthDeterminantMeasure" tags="//@tags.0 //@tags.2" layerName="HH.HealthDeterminantMeasure" styleConfig="//@styleConfig.18">
+  <layerConfig name="HH_HealthDeterminantMeasure" registryId="http://inspire.ec.europa.eu/layer/HH.HealthDeterminantMeasure" tags="//@tags.0 //@tags.2" layerName="HH.HealthDeterminantMeasure" styleConfig="//@styleConfig.27">
     <title lang="en" text="Health determinant measure"/>
     <title text="Messwerte für Gesundheitsfaktoren"/>
     <objectType>hh_4.0:EnvHealthDeterminantMeasure</objectType>
   </layerConfig>
-  <layerConfig name="EL_BreakLine" registryId="http://inspire.ec.europa.eu/layer/EL.BreakLine" tags="//@tags.0 //@tags.2" layerName="EL.BreakLine" styleConfig="//@styleConfig.17">
+  <layerConfig name="HH_HealthDeterminantMeasure_v5" registryId="http://inspire.ec.europa.eu/layer/HH.HealthDeterminantMeasure" tags="//@tags.0 //@tags.2" layerName="HH.HealthDeterminantMeasure" styleConfig="//@styleConfig.28">
+    <title lang="en" text="Health determinant measure"/>
+    <title text="Messwerte für Gesundheitsfaktoren"/>
+    <objectType>hh_5.0:EnvHealthDeterminantMeasure</objectType>
+  </layerConfig>
+  <layerConfig name="EL_BreakLine" registryId="http://inspire.ec.europa.eu/layer/EL.BreakLine" tags="//@tags.0 //@tags.2" layerName="EL.BreakLine" styleConfig="//@styleConfig.26">
     <title lang="en" text="Break Line"/>
     <title text="Bruchkante"/>
     <objectType>el-vec_4.0:BreakLine</objectType>
   </layerConfig>
-  <layerConfig name="EL_ContourLine" registryId="http://inspire.ec.europa.eu/layer/EL.ContourLine" tags="//@tags.0 //@tags.2" layerName="EL.ContourLine" styleConfig="//@styleConfig.16">
+  <layerConfig name="EL_ContourLine" registryId="http://inspire.ec.europa.eu/layer/EL.ContourLine" tags="//@tags.0 //@tags.2" layerName="EL.ContourLine" styleConfig="//@styleConfig.25">
     <title lang="en" text="Contour Line"/>
     <title text="Höhenlinie"/>
     <objectType>el-vec_4.0:ContourLine</objectType>
   </layerConfig>
-  <layerConfig name="EL_IsolatedArea" registryId="http://inspire.ec.europa.eu/layer/EL.IsolatedArea" tags="//@tags.0 //@tags.2" layerName="EL.IsolatedArea" styleConfig="//@styleConfig.15">
+  <layerConfig name="EL_IsolatedArea" registryId="http://inspire.ec.europa.eu/layer/EL.IsolatedArea" tags="//@tags.0 //@tags.2" layerName="EL.IsolatedArea" styleConfig="//@styleConfig.24">
     <title lang="en" text="Isolated Area"/>
     <title text="Abgesondertes Gebiet"/>
     <objectType>el-vec_4.0:IsolatedArea</objectType>
   </layerConfig>
-  <layerConfig name="EL_SpotElevation" registryId="http://inspire.ec.europa.eu/layer/EL.SpotElevation" tags="//@tags.0 //@tags.2" layerName="EL.SpotElevation" styleConfig="//@styleConfig.14">
+  <layerConfig name="EL_SpotElevation" registryId="http://inspire.ec.europa.eu/layer/EL.SpotElevation" tags="//@tags.0 //@tags.2" layerName="EL.SpotElevation" styleConfig="//@styleConfig.23">
     <title lang="en" text="Spot Elevation"/>
     <title text="Höhenlagenpunkt"/>
     <objectType>el-vec_4.0:SpotElevation</objectType>
   </layerConfig>
-  <layerConfig name="EL_VoidArea" registryId="http://inspire.ec.europa.eu/layer/EL.VoidArea" tags="//@tags.0 //@tags.2" layerName="EL.VoidArea" styleConfig="//@styleConfig.13">
+  <layerConfig name="EL_VoidArea" registryId="http://inspire.ec.europa.eu/layer/EL.VoidArea" tags="//@tags.0 //@tags.2" layerName="EL.VoidArea" styleConfig="//@styleConfig.22">
     <title lang="en" text="Void Area"/>
     <title text="Leeres Gebiet"/>
     <objectType>el-vec_4.0:VoidArea</objectType>
   </layerConfig>
-  <layerConfig name="EL_ContourLineType" registryId="" tags="//@tags.0 //@tags.2" layerName="EL.ContourLineType" styleConfig="//@styleConfig.12">
+  <layerConfig name="EL_ContourLineType" registryId="" tags="//@tags.0 //@tags.2" layerName="EL.ContourLineType" styleConfig="//@styleConfig.21">
     <title lang="en" text="Contour Line Type"/>
     <title text="Höhenlinie"/>
     <objectType>el-vec_4.0:ContourLine</objectType>
   </layerConfig>
-  <layerConfig name="EL_TIN" registryId="http://inspire.ec.europa.eu/layer/EL.ElevationTIN" tags="//@tags.0" layerName="EL.ElevationTIN" styleConfig="//@styleConfig.11">
+  <layerConfig name="EL_TIN" registryId="http://inspire.ec.europa.eu/layer/EL.ElevationTIN" tags="//@tags.0" layerName="EL.ElevationTIN" styleConfig="//@styleConfig.20">
     <title lang="en" text="Elevation TIN"/>
     <title text="Höhenlagenstruktur-TIN"/>
     <objectType>el-tin_4.0:ElevationTIN</objectType>
   </layerConfig>
-  <layerConfig name="SD_SpeciesDistribution" registryId="" tags="//@tags.0 //@tags.2" layerName="SD.SpeciesDistribution" styleConfig="//@styleConfig.10">
+  <layerConfig name="SD_SpeciesDistribution" registryId="" tags="//@tags.0 //@tags.2" layerName="SD.SpeciesDistribution" styleConfig="//@styleConfig.19">
     <title lang="en" text="Species Distribution"/>
     <title text="Verteilung der Arten"/>
     <objectType>sd_4.0:SpeciesDistributionUnit</objectType>
   </layerConfig>
-  <layerConfig name="TN_RO_RoadNode" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.RoadNode" styleConfig="//@styleConfig.9">
+  <layerConfig name="TN_RO_RoadNode" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.RoadNode" styleConfig="//@styleConfig.17">
     <title lang="en" text="Road Node"/>
     <title text="Strassenknotenpunkt"/>
     <objectType>tn-ro_4.0:RoadNode</objectType>
+  </layerConfig>
+  <layerConfig name="TN_RO_RoadNode_v5" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.RoadNode" styleConfig="//@styleConfig.18">
+    <title lang="en" text="Road Node"/>
+    <title text="Strassenknotenpunkt"/>
+    <objectType>tn-ro_5.0:RoadNode</objectType>
   </layerConfig>
   <layerConfig name="SF_SpatialSamplingFeature" registryId="" tags="//@tags.0 //@tags.2" layerName="SF.SpatialSamplingFeature" styleConfig="//@styleConfig.0">
     <title lang="en" text="Spatial Sampling Feature"/>
@@ -634,29 +897,56 @@
   <styleConfig name="US_UtilityNetworkAppurtenance">
     <remoteStyle featureTypeName="us-net-common_4.0:Appurtenance" url="feature-styles/US_UtilityNetworkAppurtenance.se"/>
   </styleConfig>
+  <styleConfig name="US_UtilityNetworkAppurtenance_v5">
+    <remoteStyle featureTypeName="us-net-common_5.0:Appurtenance" url="feature-styles/US_UtilityNetworkAppurtenance_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="US_UtilityNetworkLink">
     <remoteStyle featureTypeName="us-net-common_4.0:UtilityLink" url="feature-styles/US_UtilityNetworkLink.se"/>
+  </styleConfig>
+  <styleConfig name="US_UtilityNetworkLink_v5">
+    <remoteStyle featureTypeName="us-net-common_5.0:UtilityLink" url="feature-styles/US_UtilityNetworkLink_v5_0.se"/>
   </styleConfig>
   <styleConfig name="US_EnvironmentalManagementFacility">
     <remoteStyle featureTypeName="us-emf_4.0:EnvironmentalManagementFacility" url="feature-styles/US_EnvironmentalManagementFacility.se"/>
   </styleConfig>
+  <styleConfig name="US_EnvironmentalManagementFacility_v5">
+    <remoteStyle featureTypeName="us-emf_5.0:EnvironmentalManagementFacility" url="feature-styles/US_EnvironmentalManagementFacility_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="TN_A_DesignatedPoint">
     <remoteStyle featureTypeName="tn-a_4.0:DesignatedPoint" url="feature-styles/TN_A_DesignatedPoint.se"/>
+  </styleConfig>
+  <styleConfig name="TN_A_DesignatedPoint_v5">
+    <remoteStyle featureTypeName="tn-a_5.0:DesignatedPoint" url="feature-styles/TN_A_DesignatedPoint_v5_0.se"/>
   </styleConfig>
   <styleConfig name="TN_A_Navaid">
     <remoteStyle featureTypeName="tn-a_4.0:Navaid" url="feature-styles/TN_A_Navaid.se"/>
   </styleConfig>
+  <styleConfig name="TN_A_Navaid_v5">
+    <remoteStyle featureTypeName="tn-a_5.0:Navaid" url="feature-styles/TN_A_Navaid_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="TN_A_RunwayCentrelinePoint">
     <remoteStyle featureTypeName="tn-a_4.0:RunwayCentrelinePoint" url="feature-styles/TN_A_RunwayCentrelinePoint.se"/>
+  </styleConfig>
+  <styleConfig name="TN_A_RunwayCentrelinePoint_v5">
+    <remoteStyle featureTypeName="tn-a_5.0:RunwayCentrelinePoint" url="feature-styles/TN_A_RunwayCentrelinePoint_v5_0.se"/>
   </styleConfig>
   <styleConfig name="TN_A_AerodromeNode">
     <remoteStyle featureTypeName="tn-a_4.0:AerodromeNode" url="feature-styles/TN_A_AerodromeNode.se"/>
   </styleConfig>
+  <styleConfig name="TN_A_AerodromeNode_v5">
+    <remoteStyle featureTypeName="tn-a_5.0:AerodromeNode" url="feature-styles/TN_A_AerodromeNode_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="TN_A_TouchDownLiftOff">
     <remoteStyle featureTypeName="tn-a_4.0:TouchDownLiftOff" url="feature-styles/TN_A_TouchDownLiftOff.se"/>
   </styleConfig>
+  <styleConfig name="TN_A_TouchDownLiftOff_v5">
+    <remoteStyle featureTypeName="tn-a_5.0:TouchDownLiftOff" url="feature-styles/TN_A_TouchDownLiftOff_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="TN_RO_RoadNode">
     <remoteStyle featureTypeName="tn-ro_4.0:RoadNode" url="feature-styles/TN_RO_RoadNode.se"/>
+  </styleConfig>
+  <styleConfig name="TN_RO_RoadNode_v5">
+    <remoteStyle featureTypeName="tn-ro_5.0:RoadNode" url="feature-styles/TN_RO_RoadNode_v5_0.se"/>
   </styleConfig>
   <styleConfig name="SD_SpeciesDistribution">
     <remoteStyle featureTypeName="sd_4.0:SpeciesDistributionUnit" url="feature-styles/SD_SpeciesDistribution.se"/>
@@ -684,6 +974,9 @@
   </styleConfig>
   <styleConfig name="HH_HealthDeterminantMeasure">
     <remoteStyle featureTypeName="hh_4.0:EnvHealthDeterminantMeasure" url="feature-styles/HH_HealthDeterminantMeasure.se"/>
+  </styleConfig>
+  <styleConfig name="HH_HealthDeterminantMeasure_v5">
+    <remoteStyle featureTypeName="hh_5.0:EnvHealthDeterminantMeasure" url="feature-styles/HH_HealthDeterminantMeasure_v5_0.se"/>
   </styleConfig>
   <styleConfig name="SU_VectorStatisticalUnit">
     <remoteStyle featureTypeName="su-vector_4.0:VectorStatisticalUnit" url="feature-styles/SU_VectorStatisticalUnit.se"/>
@@ -724,17 +1017,32 @@
   <styleConfig name="TN_W_TrafficSeparationSchemeSeparator">
     <remoteStyle featureTypeName="tn-w_4.0:TrafficSeparationSchemeSeparator" url="feature-styles/TN_W_TrafficSeparationSchemeSeparator.se"/>
   </styleConfig>
+  <styleConfig name="TN_W_TrafficSeparationSchemeSeparator_v5">
+    <remoteStyle featureTypeName="tn-w_5.0:TrafficSeparationSchemeSeparator" url="feature-styles/TN_W_TrafficSeparationSchemeSeparator_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="TN_W_TrafficSeparationSchemeCrossing">
     <remoteStyle featureTypeName="tn-w_4.0:TrafficSeparationSchemeCrossing" url="feature-styles/TN_W_TrafficSeparationSchemeCrossing.se"/>
+  </styleConfig>
+  <styleConfig name="TN_W_TrafficSeparationSchemeCrossing_v5">
+    <remoteStyle featureTypeName="tn-w_5.0:TrafficSeparationSchemeCrossing" url="feature-styles/TN_W_TrafficSeparationSchemeCrossing_v5_0.se"/>
   </styleConfig>
   <styleConfig name="TN_W_Buoy">
     <remoteStyle featureTypeName="tn-w_4.0:Buoy" url="feature-styles/TN_W_Buoy.se"/>
   </styleConfig>
+  <styleConfig name="TN_W_Buoy_v5">
+    <remoteStyle featureTypeName="tn-w_5.0:Buoy" url="feature-styles/TN_W_Buoy_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="TN_W_Beacon">
     <remoteStyle featureTypeName="tn-w_4.0:Beacon" url="feature-styles/TN_W_Beacon.se"/>
   </styleConfig>
+  <styleConfig name="TN_W_Beacon_v5">
+    <remoteStyle featureTypeName="tn-w_5.0:Beacon" url="feature-styles/TN_W_Beacon_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="TN_MarkerPost">
     <remoteStyle featureTypeName="tn_4.0:MarkerPost" url="feature-styles/TN_MarkerPost.se"/>
+  </styleConfig>
+  <styleConfig name="TN_MarkerPost_v5">
+    <remoteStyle featureTypeName="tn_5.0:MarkerPost" url="feature-styles/TN_MarkerPost_v5_0.se"/>
   </styleConfig>
   <styleConfig name="NZ_ObservedEvent">
     <remoteStyle featureTypeName="nz-core_4.0:ObservedEvent" url="feature-styles/NZ_ObservedEvent.se"/>
@@ -817,6 +1125,9 @@
   <styleConfig name="US_GovernmentalService">
     <remoteStyle featureTypeName="us-govserv_4.0:GovernmentalService" url="feature-styles/US_GovernmentalService.se"/>
   </styleConfig>
+  <styleConfig name="US_GovernmentalService_v5">
+    <remoteStyle featureTypeName="us-govserv_5.0:GovernmentalService" url="feature-styles/US_GovernmentalService_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="LU_SupplementaryRegulation">
     <remoteStyle featureTypeName="plu_4.0:SupplementaryRegulation" url="feature-styles/LU_SupplementaryRegulation.se"/>
   </styleConfig>
@@ -886,65 +1197,128 @@
   <styleConfig name="HY_N_WatercourseLink">
     <remoteStyle featureTypeName="hy-n_4.0:WatercourseLink" url="feature-styles/HY_N_WatercourseLink.se"/>
   </styleConfig>
+  <styleConfig name="HY_N_WatercourseLink_v5">
+    <remoteStyle featureTypeName="hy-n_5.0:WatercourseLink" url="feature-styles/HY_N_WatercourseLink_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="HY_N_HydroNode">
     <remoteStyle featureTypeName="hy-n_4.0:HydroNode" url="feature-styles/HY_N_HydroNode.se"/>
+  </styleConfig>
+  <styleConfig name="HY_N_HydroNode_v5">
+    <remoteStyle featureTypeName="hy-n_5.0:HydroNode" url="feature-styles/HY_N_HydroNode_v5_0.se"/>
   </styleConfig>
   <styleConfig name="HY_P_DrainageBasin">
     <remoteStyle featureTypeName="hy-p_4.0:DrainageBasin" url="feature-styles/HY_P_DrainageBasin.se"/>
   </styleConfig>
+  <styleConfig name="HY_P_DrainageBasin_v5">
+    <remoteStyle featureTypeName="hy-p_5.0:DrainageBasin" url="feature-styles/HY_P_DrainageBasin_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="HY_P_RiverBasin">
     <remoteStyle featureTypeName="hy-p_4.0:RiverBasin" url="feature-styles/HY_P_RiverBasin.se"/>
+  </styleConfig>
+  <styleConfig name="HY_P_RiverBasin_v5">
+    <remoteStyle featureTypeName="hy-p_5.0:RiverBasin" url="feature-styles/HY_P_RiverBasin_v5_0.se"/>
   </styleConfig>
   <styleConfig name="HY_P_Rapids">
     <remoteStyle featureTypeName="hy-p_4.0:Rapids" url="feature-styles/HY_P_Rapids.se"/>
   </styleConfig>
+  <styleConfig name="HY_P_Rapids_v5">
+    <remoteStyle featureTypeName="hy-p_5.0:Rapids" url="feature-styles/HY_P_Rapids_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="HY_P_Falls">
     <remoteStyle featureTypeName="hy-p_4.0:Falls" url="feature-styles/HY_P_Falls.se"/>
+  </styleConfig>
+  <styleConfig name="HY_P_Falls_v5">
+    <remoteStyle featureTypeName="hy-p_5.0:Falls" url="feature-styles/HY_P_Falls_v5_0.se"/>
   </styleConfig>
   <styleConfig name="HY_P_LandWaterBoundary">
     <remoteStyle featureTypeName="hy-p_4.0:LandWaterBoundary" url="feature-styles/HY_P_LandWaterBoundary.se"/>
   </styleConfig>
+  <styleConfig name="HY_P_LandWaterBoundary_v5">
+    <remoteStyle featureTypeName="hy-p_5.0:LandWaterBoundary" url="feature-styles/HY_P_LandWaterBoundary_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="HY_P_Crossing">
     <remoteStyle featureTypeName="hy-p_4.0:Crossing" url="feature-styles/HY_P_Crossing.se"/>
+  </styleConfig>
+  <styleConfig name="HY_P_Crossing_v5">
+    <remoteStyle featureTypeName="hy-p_5.0:Crossing" url="feature-styles/HY_P_Crossing_v5_0.se"/>
   </styleConfig>
   <styleConfig name="HY_P_DamOrWeir">
     <remoteStyle featureTypeName="hy-p_4.0:DamOrWeir" url="feature-styles/HY_P_DamOrWeir.se"/>
   </styleConfig>
+  <styleConfig name="HY_P_DamOrWeir_v5">
+    <remoteStyle featureTypeName="hy-p_5.0:DamOrWeir" url="feature-styles/HY_P_DamOrWeir_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="HY_P_ShoreLineConstruction">
     <remoteStyle featureTypeName="hy-p_4.0:ShorelineConstruction" url="feature-styles/HY_P_ShoreLineConstruction.se"/>
+  </styleConfig>
+  <styleConfig name="HY_P_ShoreLineConstruction_v5">
+    <remoteStyle featureTypeName="hy-p_5.0:ShorelineConstruction" url="feature-styles/HY_P_ShoreLineConstruction_v5_0.se"/>
   </styleConfig>
   <styleConfig name="HY_P_Ford">
     <remoteStyle featureTypeName="hy-p_4.0:Ford" url="feature-styles/HY_P_Ford.se"/>
   </styleConfig>
+  <styleConfig name="HY_P_Ford_v5">
+    <remoteStyle featureTypeName="hy-p_5.0:Ford" url="feature-styles/HY_P_Ford_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="HY_P_Lock">
     <remoteStyle featureTypeName="hy-p_4.0:Lock" url="feature-styles/HY_P_Lock.se"/>
+  </styleConfig>
+  <styleConfig name="HY_P_Lock_v5">
+    <remoteStyle featureTypeName="hy-p_5.0:Lock" url="feature-styles/HY_P_Lock_v5_0.se"/>
   </styleConfig>
   <styleConfig name="HY_P_Shore">
     <remoteStyle featureTypeName="hy-p_4.0:Shore" url="feature-styles/HY_P_Shore.se"/>
   </styleConfig>
+  <styleConfig name="HY_P_Shore_v5">
+    <remoteStyle featureTypeName="hy-p_5.0:Shore" url="feature-styles/HY_P_Shore_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="HY_P_Watercourse">
     <remoteStyle featureTypeName="hy-p_4.0:Watercourse" url="feature-styles/HY_P_Watercourse.se"/>
+  </styleConfig>
+  <styleConfig name="HY_P_Watercourse_v5">
+    <remoteStyle featureTypeName="hy-p_5.0:Watercourse" url="feature-styles/HY_P_Watercourse_v5_0.se"/>
   </styleConfig>
   <styleConfig name="HY_P_StandingWater">
     <remoteStyle featureTypeName="hy-p_4.0:StandingWater" url="feature-styles/HY_P_StandingWater.se"/>
   </styleConfig>
+  <styleConfig name="HY_P_StandingWater_v5">
+    <remoteStyle featureTypeName="hy-p_5.0:StandingWater" url="feature-styles/HY_P_StandingWater_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="HY_P_Watercourse_ManMade">
     <remoteStyle featureTypeName="hy-p_4.0:Watercourse" url="feature-styles/HY_P_Watercourse_ManMade.se"/>
+  </styleConfig>
+  <styleConfig name="HY_P_Watercourse_ManMade_v5">
+    <remoteStyle featureTypeName="hy-p_5.0:Watercourse" url="feature-styles/HY_P_Watercourse_ManMade_v5_0.se"/>
   </styleConfig>
   <styleConfig name="HY_P_StandingWater_ManMade">
     <remoteStyle featureTypeName="hy-p_4.0:StandingWater" url="feature-styles/HY_P_StandingWater_ManMade.se"/>
   </styleConfig>
+  <styleConfig name="HY_P_StandingWater_ManMade_v5">
+    <remoteStyle featureTypeName="hy-p_5.0:StandingWater" url="feature-styles/HY_P_StandingWater_ManMade_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="HY_P_WatercoursePersistence">
     <remoteStyle featureTypeName="hy-p_4.0:Watercourse" url="feature-styles/HY_P_WatercoursePersistence.se"/>
+  </styleConfig>
+  <styleConfig name="HY_P_WatercoursePersistence_v5">
+    <remoteStyle featureTypeName="hy-p_5.0:Watercourse" url="feature-styles/HY_P_WatercoursePersistence_v5_0.se"/>
   </styleConfig>
   <styleConfig name="HY_P_WaterbodiesPersistence">
     <remoteStyle featureTypeName="hy-p_4.0:StandingWater" url="feature-styles/HY_P_WaterbodiesPersistence.se"/>
   </styleConfig>
+  <styleConfig name="HY_P_WaterbodiesPersistence_v5">
+    <remoteStyle featureTypeName="hy-p_5.0:StandingWater" url="feature-styles/HY_P_WaterbodiesPersistence_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="HY_P_Wetland">
     <remoteStyle featureTypeName="hy-p_4.0:Wetland" url="feature-styles/HY_P_Wetland.se"/>
   </styleConfig>
+  <styleConfig name="HY_P_Wetland_v5">
+    <remoteStyle featureTypeName="hy-p_5.0:Wetland" url="feature-styles/HY_P_Wetland_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="PS_ProtectedSite">
     <remoteStyle featureTypeName="ps_4.0:ProtectedSite" url="feature-styles/PS_ProtectedSites.se"/>
+  </styleConfig>
+  <styleConfig name="PS_ProtectedSite_v5">
+    <remoteStyle featureTypeName="ps_5.0:ProtectedSite" url="feature-styles/PS_ProtectedSites_v5_0.se"/>
   </styleConfig>
   <styleConfig name="PS_ProtectedSite_v5">
     <remoteStyle featureTypeName="ps_5.0:ProtectedSite" url="feature-styles/PS_ProtectedSites_v5.se"/>
@@ -952,74 +1326,146 @@
   <styleConfig name="TN_A_AerodromeArea">
     <remoteStyle featureTypeName="tn-a_4.0:AerodromeArea" url="feature-styles/TN_A_AerodromeArea.se"/>
   </styleConfig>
+  <styleConfig name="TN_A_AerodromeArea_v5">
+    <remoteStyle featureTypeName="tn-a_5.0:AerodromeArea" url="feature-styles/TN_A_AerodromeArea_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="TN_A_ProcedureLink">
     <remoteStyle featureTypeName="tn-a_4.0:ProcedureLink" url="feature-styles/TN_A_ProcedureLink.se"/>
+  </styleConfig>
+  <styleConfig name="TN_A_ProcedureLink_v5">
+    <remoteStyle featureTypeName="tn-a_5.0:ProcedureLink" url="feature-styles/TN_A_ProcedureLink_v5_0.se"/>
   </styleConfig>
   <styleConfig name="TN_A_AirRouteLink">
     <remoteStyle featureTypeName="tn-a_4.0:AirRouteLink" url="feature-styles/TN_A_AirRouteLink.se"/>
   </styleConfig>
+  <styleConfig name="TN_A_AirRouteLink_v5">
+    <remoteStyle featureTypeName="tn-a_5.0:AirRouteLink" url="feature-styles/TN_A_AirRouteLink_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="TN_A_AirspaceArea">
     <remoteStyle featureTypeName="tn-a_4.0:AirspaceArea" url="feature-styles/TN_A_AirspaceArea.se"/>
+  </styleConfig>
+  <styleConfig name="TN_A_AirspaceArea_v5">
+    <remoteStyle featureTypeName="tn-a_5.0:AirspaceArea" url="feature-styles/TN_A_AirspaceArea_v5_0.se"/>
   </styleConfig>
   <styleConfig name="TN_A_ApronArea">
     <remoteStyle featureTypeName="tn-a_4.0:ApronArea" url="feature-styles/TN_A_ApronArea.se"/>
   </styleConfig>
+  <styleConfig name="TN_A_ApronArea_v5">
+    <remoteStyle featureTypeName="tn-a_5.0:ApronArea" url="feature-styles/TN_A_ApronArea_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="TN_A_RunwayArea">
     <remoteStyle featureTypeName="tn-a_4.0:RunwayArea" url="feature-styles/TN_A_RunwayArea.se"/>
+  </styleConfig>
+  <styleConfig name="TN_A_RunwayArea_v5">
+    <remoteStyle featureTypeName="tn-a_5.0:RunwayArea" url="feature-styles/TN_A_RunwayArea_v5_0.se"/>
   </styleConfig>
   <styleConfig name="TN_A_TaxiwayArea">
     <remoteStyle featureTypeName="tn-a_4.0:TaxiwayArea" url="feature-styles/TN_A_TaxiwayArea.se"/>
   </styleConfig>
+  <styleConfig name="TN_A_TaxiwayArea_v5">
+    <remoteStyle featureTypeName="tn-a_5.0:TaxiwayArea" url="feature-styles/TN_A_TaxiwayArea_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="TN_C_CablewayLink">
     <remoteStyle featureTypeName="tn-c_4.0:CablewayLink" url="feature-styles/TN_C_CablewayLink.se"/>
+  </styleConfig>
+  <styleConfig name="TN_C_CablewayLink_v5">
+    <remoteStyle featureTypeName="tn-c_5.0:CablewayLink" url="feature-styles/TN_C_CablewayLink_v5_0.se"/>
   </styleConfig>
   <styleConfig name="TN_TransportArea">
     <remoteStyle featureTypeName="tn_4.0:TransportArea" url="feature-styles/TN_TransportArea.se"/>
   </styleConfig>
+  <styleConfig name="TN_TransportArea_v5">
+    <remoteStyle featureTypeName="tn_5.0:TransportArea" url="feature-styles/TN_TransportArea_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="TN_TransportLink">
     <remoteStyle featureTypeName="tn_4.0:TransportLink" url="feature-styles/TN_TransportLink.se"/>
+  </styleConfig>
+  <styleConfig name="TN_TransportLink_v5">
+    <remoteStyle featureTypeName="tn_5.0:TransportLink" url="feature-styles/TN_TransportLink_v5_0.se"/>
   </styleConfig>
   <styleConfig name="TN_TransportNode">
     <remoteStyle featureTypeName="tn_4.0:TransportNode" url="feature-styles/TN_TransportNode.se"/>
   </styleConfig>
+  <styleConfig name="TN_TransportNode_v5">
+    <remoteStyle featureTypeName="tn_5.0:TransportNode" url="feature-styles/TN_TransportNode_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="TN_RA_RailwayArea">
     <remoteStyle featureTypeName="tn-ra_4.0:RailwayArea" url="feature-styles/TN_RA_RailwayArea.se"/>
+  </styleConfig>
+  <styleConfig name="TN_RA_RailwayArea_v5">
+    <remoteStyle featureTypeName="tn-ra_5.0:RailwayArea" url="feature-styles/TN_RA_RailwayArea_v5_0.se"/>
   </styleConfig>
   <styleConfig name="TN_RA_RailwayLink">
     <remoteStyle featureTypeName="tn-ra_4.0:RailwayLink" url="feature-styles/TN_RA_RailwayLink.se"/>
   </styleConfig>
+  <styleConfig name="TN_RA_RailwayLink_v5">
+    <remoteStyle featureTypeName="tn-ra_5.0:RailwayLink" url="feature-styles/TN_RA_RailwayLink_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="TN_RA_RailwayStationArea">
     <remoteStyle featureTypeName="tn-ra_4.0:RailwayStationArea" url="feature-styles/TN_RA_RailwayStationArea.se"/>
+  </styleConfig>
+  <styleConfig name="TN_RA_RailwayStationArea_v5">
+    <remoteStyle featureTypeName="tn-ra_5.0:RailwayStationArea" url="feature-styles/TN_RA_RailwayStationArea_v5_0.se"/>
   </styleConfig>
   <styleConfig name="TN_RA_RailwayYardArea">
     <remoteStyle featureTypeName="tn-ra_4.0:RailwayYardArea" url="feature-styles/TN_RA_RailwayYardArea.se"/>
   </styleConfig>
+  <styleConfig name="TN_RA_RailwayYardArea_v5">
+    <remoteStyle featureTypeName="tn-ra_5.0:RailwayYardArea" url="feature-styles/TN_RA_RailwayYardArea_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="TN_RO_RoadArea">
     <remoteStyle featureTypeName="tn-ro_4.0:RoadArea" url="feature-styles/TN_RO_RoadArea.se"/>
+  </styleConfig>
+  <styleConfig name="TN_RO_RoadArea_v5">
+    <remoteStyle featureTypeName="tn-ro_5.0:RoadArea" url="feature-styles/TN_RO_RoadArea_v5_0.se"/>
   </styleConfig>
   <styleConfig name="TN_RO_RoadLink">
     <remoteStyle featureTypeName="tn-ro_4.0:RoadLink" url="feature-styles/TN_RO_RoadLink.se"/>
   </styleConfig>
+  <styleConfig name="TN_RO_RoadLink_v5">
+    <remoteStyle featureTypeName="tn-ro_5.0:RoadLink" url="feature-styles/TN_RO_RoadLink_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="TN_RO_RoadServiceArea">
     <remoteStyle featureTypeName="tn-ro_4.0:RoadServiceArea" url="feature-styles/TN_RO_RoadServiceArea.se"/>
+  </styleConfig>
+  <styleConfig name="TN_RO_RoadServiceArea_v5">
+    <remoteStyle featureTypeName="tn-ro_5.0:RoadServiceArea" url="feature-styles/TN_RO_RoadServiceArea_v5_0.se"/>
   </styleConfig>
   <styleConfig name="TN_RO_VehicleTrafficArea">
     <remoteStyle featureTypeName="tn-ro_4.0:VehicleTrafficArea" url="feature-styles/TN_RO_VehicleTrafficArea.se"/>
   </styleConfig>
+  <styleConfig name="TN_RO_VehicleTrafficArea_v5">
+    <remoteStyle featureTypeName="tn-ro_5.0:VehicleTrafficArea" url="feature-styles/TN_RO_VehicleTrafficArea_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="TN_W_FairwayArea">
     <remoteStyle featureTypeName="tn-w_4.0:FairwayArea" url="feature-styles/TN_W_FairwayArea.se"/>
+  </styleConfig>
+  <styleConfig name="TN_W_FairwayArea_v5">
+    <remoteStyle featureTypeName="tn-w_5.0:FairwayArea" url="feature-styles/TN_W_FairwayArea_v5_0.se"/>
   </styleConfig>
   <styleConfig name="TN_W_PortArea">
     <remoteStyle featureTypeName="tn-w_4.0:PortArea" url="feature-styles/TN_W_PortArea.se"/>
   </styleConfig>
+  <styleConfig name="TN_W_PortArea_v5">
+    <remoteStyle featureTypeName="tn-w_5.0:PortArea" url="feature-styles/TN_W_PortArea_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="TN_W_WaterwayLink">
     <remoteStyle featureTypeName="tn-w_4.0:WaterwayLink" url="feature-styles/TN_W_WaterwayLink.se"/>
+  </styleConfig>
+  <styleConfig name="TN_W_WaterwayLink_v5">
+    <remoteStyle featureTypeName="tn-w_5.0:WaterwayLink" url="feature-styles/TN_W_WaterwayLink_v5_0.se"/>
   </styleConfig>
   <styleConfig name="LC_LandCoverSurfaces">
     <remoteStyle featureTypeName="lcv_4.0:LandCoverUnit" url="feature-styles/LC_LandCoverSurfaces.se"/>
   </styleConfig>
+  <styleConfig name="LC_LandCoverSurfaces_v5">
+    <remoteStyle featureTypeName="lcv_5.0:LandCoverUnit" url="feature-styles/LC_LandCoverSurfaces_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="LC_LandCoverPoints">
     <remoteStyle featureTypeName="lcv_4.0:LandCoverUnit" url="feature-styles/LC_LandCoverPoints.se"/>
+  </styleConfig>
+  <styleConfig name="LC_LandCoverPoints_v5">
+    <remoteStyle featureTypeName="lcv_5.0:LandCoverUnit" url="feature-styles/LC_LandCoverPoints_v5_0.se"/>
   </styleConfig>
   <styleConfig name="BU_Building">
     <remoteStyle featureTypeName="bu-core2d_4.0:Building" url="feature-styles/BU_Building.se"/>

--- a/generated/config.xml
+++ b/generated/config.xml
@@ -1,123 +1,150 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<styleconfig:StyleModel xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:ad_4.0="http://inspire.ec.europa.eu/schemas/ad/4.0" xmlns:am_4.0="http://inspire.ec.europa.eu/schemas/am/4.0" xmlns:au_4.0="http://inspire.ec.europa.eu/schemas/au/4.0" xmlns:br_4.0="http://inspire.ec.europa.eu/schemas/br/4.0" xmlns:bu-core2d_4.0="http://inspire.ec.europa.eu/schemas/bu-core2d/4.0" xmlns:cp_4.0="http://inspire.ec.europa.eu/schemas/cp/4.0" xmlns:ef_4.0="http://inspire.ec.europa.eu/schemas/ef/4.0" xmlns:el-tin_4.0="http://inspire.ec.europa.eu/schemas/el-tin/4.0" xmlns:el-vec_4.0="http://inspire.ec.europa.eu/schemas/el-vec/4.0" xmlns:elu_4.0="http://inspire.ec.europa.eu/schemas/elu/4.0" xmlns:er-v_4.0="http://inspire.ec.europa.eu/schemas/er-v/4.0" xmlns:ge-core_4.0="http://inspire.ec.europa.eu/schemas/ge-core/4.0" xmlns:gn_4.0="http://inspire.ec.europa.eu/schemas/gn/4.0" xmlns:hh_4.0="http://inspire.ec.europa.eu/schemas/hh/4.0" xmlns:hy-n_4.0="http://inspire.ec.europa.eu/schemas/hy-n/4.0" xmlns:hy-p_4.0="http://inspire.ec.europa.eu/schemas/hy-p/4.0" xmlns:lcv_4.0="http://inspire.ec.europa.eu/schemas/lcv/4.0" xmlns:mu_3.0="http://inspire.ec.europa.eu/schemas/mu/3.0" xmlns:nz-core_4.0="http://inspire.ec.europa.eu/schemas/nz-core/4.0" xmlns:pf_4.0="http://inspire.ec.europa.eu/schemas/pf/4.0" xmlns:plu_4.0="http://inspire.ec.europa.eu/schemas/plu/4.0" xmlns:ps_4.0="http://inspire.ec.europa.eu/schemas/ps/4.0" xmlns:ps_5.0="http://inspire.ec.europa.eu/schemas/ps/5.0" xmlns:samplingSpatial_2.0="http://www.opengis.net/samplingSpatial/2.0" xmlns:sd_4.0="http://inspire.ec.europa.eu/schemas/sd/4.0" xmlns:styleconfig="http://to.wetf.styling.models/model/styles" xmlns:su-grid_4.0="https://inspire.ec.europa.eu/schemas/su-grid/4.0" xmlns:su-vector_4.0="http://inspire.ec.europa.eu/schemas/su-vector/4.0" xmlns:tn-a_4.0="http://inspire.ec.europa.eu/schemas/tn-a/4.0" xmlns:tn-c_4.0="http://inspire.ec.europa.eu/schemas/tn-c/4.0" xmlns:tn-ra_4.0="http://inspire.ec.europa.eu/schemas/tn-ra/4.0" xmlns:tn-ro_4.0="http://inspire.ec.europa.eu/schemas/tn-ro/4.0" xmlns:tn-w_4.0="http://inspire.ec.europa.eu/schemas/tn-w/4.0" xmlns:tn_4.0="http://inspire.ec.europa.eu/schemas/tn/4.0" xmlns:us-emf_4.0="http://inspire.ec.europa.eu/schemas/us-emf/4.0" xmlns:us-govserv_4.0="http://inspire.ec.europa.eu/schemas/us-govserv/4.0" xmlns:us-net-common_4.0="http://inspire.ec.europa.eu/schemas/us-net-common/4.0">
+<styleconfig:StyleModel xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:ad_4.0="http://inspire.ec.europa.eu/schemas/ad/4.0" xmlns:am_4.0="http://inspire.ec.europa.eu/schemas/am/4.0" xmlns:au_4.0="http://inspire.ec.europa.eu/schemas/au/4.0" xmlns:br_4.0="http://inspire.ec.europa.eu/schemas/br/4.0" xmlns:bu-core2d_4.0="http://inspire.ec.europa.eu/schemas/bu-core2d/4.0" xmlns:cp_4.0="http://inspire.ec.europa.eu/schemas/cp/4.0" xmlns:ef_4.0="http://inspire.ec.europa.eu/schemas/ef/4.0" xmlns:el-tin_4.0="http://inspire.ec.europa.eu/schemas/el-tin/4.0" xmlns:el-vec_4.0="http://inspire.ec.europa.eu/schemas/el-vec/4.0" xmlns:elu_4.0="http://inspire.ec.europa.eu/schemas/elu/4.0" xmlns:er-v_4.0="http://inspire.ec.europa.eu/schemas/er-v/4.0" xmlns:ge-core_4.0="http://inspire.ec.europa.eu/schemas/ge-core/4.0" xmlns:gn_4.0="http://inspire.ec.europa.eu/schemas/gn/4.0" xmlns:hh_4.0="http://inspire.ec.europa.eu/schemas/hh/4.0" xmlns:hh_5.0="http://inspire.ec.europa.eu/schemas/hh/5.0" xmlns:hy-n_4.0="http://inspire.ec.europa.eu/schemas/hy-n/4.0" xmlns:hy-n_5.0="http://inspire.ec.europa.eu/schemas/hy-n/5.0" xmlns:hy-p_4.0="http://inspire.ec.europa.eu/schemas/hy-p/4.0" xmlns:hy-p_5.0="http://inspire.ec.europa.eu/schemas/hy-p/5.0" xmlns:lcv_4.0="http://inspire.ec.europa.eu/schemas/lcv/4.0" xmlns:lcv_5.0="http://inspire.ec.europa.eu/schemas/lcv/5.0" xmlns:mu_3.0="http://inspire.ec.europa.eu/schemas/mu/3.0" xmlns:nz-core_4.0="http://inspire.ec.europa.eu/schemas/nz-core/4.0" xmlns:pf_4.0="http://inspire.ec.europa.eu/schemas/pf/4.0" xmlns:plu_4.0="http://inspire.ec.europa.eu/schemas/plu/4.0" xmlns:ps_4.0="http://inspire.ec.europa.eu/schemas/ps/4.0" xmlns:ps_5.0="http://inspire.ec.europa.eu/schemas/ps/5.0" xmlns:samplingSpatial_2.0="http://www.opengis.net/samplingSpatial/2.0" xmlns:sd_4.0="http://inspire.ec.europa.eu/schemas/sd/4.0" xmlns:styleconfig="http://to.wetf.styling.models/model/styles" xmlns:su-grid_4.0="https://inspire.ec.europa.eu/schemas/su-grid/4.0" xmlns:su-vector_4.0="http://inspire.ec.europa.eu/schemas/su-vector/4.0" xmlns:tn-a_4.0="http://inspire.ec.europa.eu/schemas/tn-a/4.0" xmlns:tn-a_5.0="http://inspire.ec.europa.eu/schemas/tn-a/5.0" xmlns:tn-c_4.0="http://inspire.ec.europa.eu/schemas/tn-c/4.0" xmlns:tn-c_5.0="http://inspire.ec.europa.eu/schemas/tn-c/5.0" xmlns:tn-ra_4.0="http://inspire.ec.europa.eu/schemas/tn-ra/4.0" xmlns:tn-ra_5.0="http://inspire.ec.europa.eu/schemas/tn-ra/5.0" xmlns:tn-ro_4.0="http://inspire.ec.europa.eu/schemas/tn-ro/4.0" xmlns:tn-ro_5.0="http://inspire.ec.europa.eu/schemas/tn-ro/5.0" xmlns:tn-w_4.0="http://inspire.ec.europa.eu/schemas/tn-w/4.0" xmlns:tn-w_5.0="http://inspire.ec.europa.eu/schemas/tn-w/5.0" xmlns:tn_4.0="http://inspire.ec.europa.eu/schemas/tn/4.0" xmlns:tn_5.0="http://inspire.ec.europa.eu/schemas/tn/5.0" xmlns:us-emf_4.0="http://inspire.ec.europa.eu/schemas/us-emf/4.0" xmlns:us-emf_5.0="http://inspire.ec.europa.eu/schemas/us-emf/5.0" xmlns:us-govserv_4.0="http://inspire.ec.europa.eu/schemas/us-govserv/4.0" xmlns:us-govserv_5.0="http://inspire.ec.europa.eu/schemas/us-govserv/5.0" xmlns:us-net-common_4.0="http://inspire.ec.europa.eu/schemas/us-net-common/4.0" xmlns:us-net-common_5.0="http://inspire.ec.europa.eu/schemas/us-net-common/5.0">
   <tags name="inspire"/>
   <tags name="inspire_wetransform"/>
   <tags name="production"/>
-  <layerConfig name="AD_Address" registryId="http://inspire.ec.europa.eu/layer/AD.Address" tags="//@tags.0 //@tags.2" layerName="AD.Address" styleConfig="//@styleConfig.67">
+  <layerConfig name="AD_Address" registryId="http://inspire.ec.europa.eu/layer/AD.Address" tags="//@tags.0 //@tags.2" layerName="AD.Address" styleConfig="//@styleConfig.83">
     <title lang="en" text="Addresses"/>
     <title text="Addressen"/>
     <objectType>ad_4.0:Address</objectType>
   </layerConfig>
-  <layerConfig name="AU_AdministrativeBoundary" registryId="http://inspire.ec.europa.eu/layer/AU.AdministrativeBoundary" tags="//@tags.2 //@tags.0" layerName="AU.AdministrativeBoundary" styleConfig="//@styleConfig.68">
+  <layerConfig name="AU_AdministrativeBoundary" registryId="http://inspire.ec.europa.eu/layer/AU.AdministrativeBoundary" tags="//@tags.2 //@tags.0" layerName="AU.AdministrativeBoundary" styleConfig="//@styleConfig.84">
     <title lang="en" text="Administrative boundary"/>
     <title text="Verwaltungsgrenze"/>
     <objectType>au_4.0:AdministrativeBoundary</objectType>
   </layerConfig>
-  <layerConfig name="AU_AdministrativeUnit" registryId="http://inspire.ec.europa.eu/layer/AU.AdministrativeUnit" tags="//@tags.2 //@tags.0" layerName="AU.AdministrativeUnit" styleConfig="//@styleConfig.69">
+  <layerConfig name="AU_AdministrativeUnit" registryId="http://inspire.ec.europa.eu/layer/AU.AdministrativeUnit" tags="//@tags.2 //@tags.0" layerName="AU.AdministrativeUnit" styleConfig="//@styleConfig.85">
     <title lang="en" text="Administrative unit"/>
     <title text="Verwaltungseinheit"/>
     <objectType>au_4.0:AdministrativeUnit</objectType>
   </layerConfig>
-  <layerConfig name="AU_Baseline" registryId="http://inspire.ec.europa.eu/layer/AU.Baseline" layerName="AU.Baseline" styleConfig="//@styleConfig.70">
+  <layerConfig name="AU_Baseline" registryId="http://inspire.ec.europa.eu/layer/AU.Baseline" layerName="AU.Baseline" styleConfig="//@styleConfig.86">
     <title lang="en" text="Baseline"/>
     <title text="Basislinie"/>
     <objectType>mu_3.0:Baseline</objectType>
   </layerConfig>
-  <layerConfig name="AU_Condominium" registryId="http://inspire.ec.europa.eu/layer/AU.Condominium" layerName="AU.Condominium" styleConfig="//@styleConfig.71">
+  <layerConfig name="AU_Condominium" registryId="http://inspire.ec.europa.eu/layer/AU.Condominium" layerName="AU.Condominium" styleConfig="//@styleConfig.87">
     <title lang="en" text="Condominium"/>
     <title text="Kondominium"/>
     <objectType>au_4.0:Condominium</objectType>
   </layerConfig>
-  <layerConfig name="AU_ContiguousZone" registryId="http://inspire.ec.europa.eu/layer/AU.ContiguousZone" layerName="AU.ContiguousZone" styleConfig="//@styleConfig.72">
+  <layerConfig name="AU_ContiguousZone" registryId="http://inspire.ec.europa.eu/layer/AU.ContiguousZone" layerName="AU.ContiguousZone" styleConfig="//@styleConfig.88">
     <title lang="en" text="Contiguous zone"/>
     <title text="Anschlusszone"/>
     <objectType>mu_3.0:ContiguousZone</objectType>
   </layerConfig>
-  <layerConfig name="AU_ContinentalShelf" registryId="http://inspire.ec.europa.eu/layer/AU.ContinentalShelf" layerName="AU.ContinentalShelf" styleConfig="//@styleConfig.73">
+  <layerConfig name="AU_ContinentalShelf" registryId="http://inspire.ec.europa.eu/layer/AU.ContinentalShelf" layerName="AU.ContinentalShelf" styleConfig="//@styleConfig.89">
     <title lang="en" text="Continental shelf"/>
     <title text="Festlandsockel"/>
     <objectType>mu_3.0:ContinentalShelf</objectType>
   </layerConfig>
-  <layerConfig name="AU_ExclusiveEconomicZone" registryId="http://inspire.ec.europa.eu/layer/AU.ExclusiveEconomicZone" layerName="AU.ExclusiveEconomicZone" styleConfig="//@styleConfig.74">
+  <layerConfig name="AU_ExclusiveEconomicZone" registryId="http://inspire.ec.europa.eu/layer/AU.ExclusiveEconomicZone" layerName="AU.ExclusiveEconomicZone" styleConfig="//@styleConfig.90">
     <title lang="en" text="Exclusive economic zone"/>
     <title text="Ausschließliche Wirtschaftszone"/>
     <objectType>mu_3.0:ExclusiveEconomicZone</objectType>
   </layerConfig>
-  <layerConfig name="AU_InternalWaters" registryId="http://inspire.ec.europa.eu/layer/AU.InternalWaters" layerName="AU.InternalWaters" styleConfig="//@styleConfig.75">
+  <layerConfig name="AU_InternalWaters" registryId="http://inspire.ec.europa.eu/layer/AU.InternalWaters" layerName="AU.InternalWaters" styleConfig="//@styleConfig.91">
     <title lang="en" text="Internal waters"/>
     <title text="Innere Gewässer"/>
     <objectType>mu_3.0:InternalWaters</objectType>
   </layerConfig>
-  <layerConfig name="AU_MaritimeBoundary" registryId="http://inspire.ec.europa.eu/layer/AU.MaritimeBoundary" layerName="AU.MaritimeBoundary" styleConfig="//@styleConfig.76">
+  <layerConfig name="AU_MaritimeBoundary" registryId="http://inspire.ec.europa.eu/layer/AU.MaritimeBoundary" layerName="AU.MaritimeBoundary" styleConfig="//@styleConfig.92">
     <title lang="en" text="Maritime boundary"/>
     <title text="Seegrenze"/>
     <objectType>mu_3.0:MaritimeBoundary</objectType>
   </layerConfig>
-  <layerConfig name="AU_TerritorialSea" registryId="http://inspire.ec.europa.eu/layer/AU.TerritorialSea" layerName="AU.TerritorialSea" styleConfig="//@styleConfig.77">
+  <layerConfig name="AU_TerritorialSea" registryId="http://inspire.ec.europa.eu/layer/AU.TerritorialSea" layerName="AU.TerritorialSea" styleConfig="//@styleConfig.93">
     <title lang="en" text="Territorial sea"/>
     <title text="Küstenmeer"/>
     <objectType>mu_3.0:TerritorialSea</objectType>
   </layerConfig>
-  <layerConfig name="CP_CadastralBoundary" registryId="http://inspire.ec.europa.eu/layer/CP.CadastralBoundary" tags="//@tags.2 //@tags.0" layerName="CP.CadastralBoundary" styleConfig="//@styleConfig.78">
+  <layerConfig name="CP_CadastralBoundary" registryId="http://inspire.ec.europa.eu/layer/CP.CadastralBoundary" tags="//@tags.2 //@tags.0" layerName="CP.CadastralBoundary" styleConfig="//@styleConfig.94">
     <title lang="en" text="Cadastral Boundary"/>
     <title text="Flurstücksgrenze"/>
     <objectType>cp_4.0:CadastralBoundary</objectType>
   </layerConfig>
-  <layerConfig name="CP_Cadastr" registryId="http://inspire.ec.europa.eu/layer/CP.CadastralParcel" tags="//@tags.2 //@tags.0" layerName="CP.CadastralParcel.BoundariesOnly" styleConfig="//@styleConfig.79">
+  <layerConfig name="CP_Cadastr" registryId="http://inspire.ec.europa.eu/layer/CP.CadastralParcel" tags="//@tags.2 //@tags.0" layerName="CP.CadastralParcel.BoundariesOnly" styleConfig="//@styleConfig.95">
     <title lang="en" text="Cadastral Parcel (Boundary only)"/>
     <objectType>cp_4.0:CadastralParcel</objectType>
   </layerConfig>
-  <layerConfig name="CP_CadastralParcel" registryId="http://inspire.ec.europa.eu/layer/CP.CadastralParcel" tags="//@tags.2 //@tags.0" layerName="CP.CadastralParcel" styleConfig="//@styleConfig.80">
+  <layerConfig name="CP_CadastralParcel" registryId="http://inspire.ec.europa.eu/layer/CP.CadastralParcel" tags="//@tags.2 //@tags.0" layerName="CP.CadastralParcel" styleConfig="//@styleConfig.96">
     <title lang="en" text="Cadastral Parcel"/>
     <title text="Flurstück"/>
     <objectType>cp_4.0:CadastralParcel</objectType>
   </layerConfig>
-  <layerConfig name="CP_Cadastr_1" registryId="http://inspire.ec.europa.eu/layer/CP.CadastralParcel" tags="//@tags.2 //@tags.0" layerName="CP.CadastralParcel.LabelOnReferencePoint" styleConfig="//@styleConfig.81">
+  <layerConfig name="CP_Cadastr_1" registryId="http://inspire.ec.europa.eu/layer/CP.CadastralParcel" tags="//@tags.2 //@tags.0" layerName="CP.CadastralParcel.LabelOnReferencePoint" styleConfig="//@styleConfig.97">
     <title lang="en" text="Cadastral Parcel (LabelOnReferencePoint)"/>
     <objectType>cp_4.0:CadastralParcel</objectType>
   </layerConfig>
-  <layerConfig name="CP_Cadastr_2" registryId="http://inspire.ec.europa.eu/layer/CP.CadastralParcel" tags="//@tags.2 //@tags.0" layerName="CP.CadastralParcel.ReferencePointOnly" styleConfig="//@styleConfig.82">
+  <layerConfig name="CP_Cadastr_2" registryId="http://inspire.ec.europa.eu/layer/CP.CadastralParcel" tags="//@tags.2 //@tags.0" layerName="CP.CadastralParcel.ReferencePointOnly" styleConfig="//@styleConfig.98">
     <title lang="en" text="Cadastral Parcel (ReferencePointOnly)"/>
     <objectType>cp_4.0:CadastralParcel</objectType>
   </layerConfig>
-  <layerConfig name="CP_CadastralZoning" registryId="http://inspire.ec.europa.eu/layer/CP.CadastralZoning" tags="//@tags.2 //@tags.0" layerName="CP.CadastralZoning" styleConfig="//@styleConfig.83">
+  <layerConfig name="CP_CadastralZoning" registryId="http://inspire.ec.europa.eu/layer/CP.CadastralZoning" tags="//@tags.2 //@tags.0" layerName="CP.CadastralZoning" styleConfig="//@styleConfig.99">
     <title lang="en" text="Cadastral Zoning"/>
     <title text="Katasterbezirk"/>
     <objectType>cp_4.0:CadastralZoning</objectType>
   </layerConfig>
-  <layerConfig name="GN_GeographicalNames" registryId="http://inspire.ec.europa.eu/layer/GN.GeographicalNames" tags="//@tags.0 //@tags.2" layerName="GN.GeographicalNames" styleConfig="//@styleConfig.84">
+  <layerConfig name="GN_GeographicalNames" registryId="http://inspire.ec.europa.eu/layer/GN.GeographicalNames" tags="//@tags.0 //@tags.2" layerName="GN.GeographicalNames" styleConfig="//@styleConfig.100">
     <title lang="en" text="Geographical Names"/>
     <title text="Geografische Bezeichnungen"/>
     <objectType>gn_4.0:NamedPlace</objectType>
   </layerConfig>
-  <layerConfig name="HY_Network_WatercourseLink" registryId="" tags="//@tags.0 //@tags.2" layerName="HY.Network.WatercourseLink" styleConfig="//@styleConfig.85">
+  <layerConfig name="HY_Network_WatercourseLink" registryId="" tags="//@tags.0 //@tags.2" layerName="HY.Network.WatercourseLink" styleConfig="//@styleConfig.101">
     <title lang="en" text="Hydrographic network - WatercourseLink"/>
     <title text="Hydrografisches Netzwerk- WatercourseLink"/>
     <objectType>hy-n_4.0:WatercourseLink</objectType>
   </layerConfig>
-  <layerConfig name="HY_Network_HydroNode" registryId="" tags="//@tags.0 //@tags.2" layerName="HY.Network.HydroNode" styleConfig="//@styleConfig.86">
+  <layerConfig name="HY_Network_WatercourseLink_v5" registryId="" tags="//@tags.0 //@tags.2" layerName="HY.Network.WatercourseLink" styleConfig="//@styleConfig.102">
+    <title lang="en" text="Hydrographic network - WatercourseLink"/>
+    <title text="Hydrografisches Netzwerk- WatercourseLink"/>
+    <objectType>hy-n_5.0:WatercourseLink</objectType>
+  </layerConfig>
+  <layerConfig name="HY_Network_HydroNode" registryId="" tags="//@tags.0 //@tags.2" layerName="HY.Network.HydroNode" styleConfig="//@styleConfig.103">
     <title lang="en" text="Hydrographic network - HydroNode"/>
     <title text="Hydrografisches Netzwerk- HydroNode"/>
     <objectType>hy-n_4.0:HydroNode</objectType>
   </layerConfig>
-  <layerConfig name="HY_Physica" registryId="http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.Catchments" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.Catchments" styleConfig="//@styleConfig.87 //@styleConfig.88">
+  <layerConfig name="HY_Network_HydroNode_v5" registryId="" tags="//@tags.0 //@tags.2" layerName="HY.Network.HydroNode" styleConfig="//@styleConfig.104">
+    <title lang="en" text="Hydrographic network - HydroNode"/>
+    <title text="Hydrografisches Netzwerk- HydroNode"/>
+    <objectType>hy-n_5.0:HydroNode</objectType>
+  </layerConfig>
+  <layerConfig name="HY_Physica" registryId="http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.Catchments" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.Catchments" styleConfig="//@styleConfig.105 //@styleConfig.107">
     <title lang="en" text="Catchment"/>
     <title text="Einzugsgebiete"/>
     <objectType>hy-p_4.0:DrainageBasin</objectType>
     <objectType>hy-p_4.0:RiverBasin</objectType>
   </layerConfig>
-  <layerConfig name="HY_Physica_1" registryId="http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.HydroPointOfInterest" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.HydroPointOfInterest" styleConfig="//@styleConfig.89 //@styleConfig.90">
+  <layerConfig name="HY_Physica_v5" registryId="http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.Catchments" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.Catchments" styleConfig="//@styleConfig.106 //@styleConfig.108">
+    <title lang="en" text="Catchment"/>
+    <title text="Einzugsgebiete"/>
+    <objectType>hy-p_5.0:DrainageBasin</objectType>
+    <objectType>hy-p_5.0:RiverBasin</objectType>
+  </layerConfig>
+  <layerConfig name="HY_Physica_1" registryId="http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.HydroPointOfInterest" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.HydroPointOfInterest" styleConfig="//@styleConfig.109 //@styleConfig.111">
     <title lang="en" text="Hydro Point of Interest"/>
     <title text="Interessante hydrologische Punkte"/>
     <objectType>hy-p_4.0:Rapids</objectType>
     <objectType>hy-p_4.0:Falls</objectType>
   </layerConfig>
-  <layerConfig name="HY_Physica_2" registryId="http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.LandWaterBoundary" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.LandWaterBoundary" styleConfig="//@styleConfig.91">
+  <layerConfig name="HY_Physica_1_v5" registryId="http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.HydroPointOfInterest" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.HydroPointOfInterest" styleConfig="//@styleConfig.110 //@styleConfig.112">
+    <title lang="en" text="Hydro Point of Interest"/>
+    <title text="Interessante hydrologische Punkte"/>
+    <objectType>hy-p_5.0:Rapids</objectType>
+    <objectType>hy-p_5.0:Falls</objectType>
+  </layerConfig>
+  <layerConfig name="HY_Physica_2" registryId="http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.LandWaterBoundary" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.LandWaterBoundary" styleConfig="//@styleConfig.113">
     <title lang="en" text="Land water boundary"/>
     <title text="Uferlinien"/>
     <objectType>hy-p_4.0:LandWaterBoundary</objectType>
   </layerConfig>
-  <layerConfig name="HY_Physica_4" registryId="http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.ManMadeObject" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.ManMadeObject" styleConfig="//@styleConfig.92 //@styleConfig.93 //@styleConfig.94 //@styleConfig.95 //@styleConfig.96">
+  <layerConfig name="HY_Physica_2_v5" registryId="http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.LandWaterBoundary" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.LandWaterBoundary" styleConfig="//@styleConfig.114">
+    <title lang="en" text="Land water boundary"/>
+    <title text="Uferlinien"/>
+    <objectType>hy-p_5.0:LandWaterBoundary</objectType>
+  </layerConfig>
+  <layerConfig name="HY_Physica_4" registryId="http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.ManMadeObject" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.ManMadeObject" styleConfig="//@styleConfig.115 //@styleConfig.117 //@styleConfig.119 //@styleConfig.121 //@styleConfig.123">
     <title lang="en" text="Man-made Object"/>
     <title text="Bauwerke an Gewässern"/>
     <objectType>hy-p_4.0:Crossing</objectType>
@@ -126,502 +153,738 @@
     <objectType>hy-p_4.0:Ford</objectType>
     <objectType>hy-p_4.0:Lock</objectType>
   </layerConfig>
-  <layerConfig name="HY_PhysicalWaters_Shore" registryId="http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.Shore" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.Shore" styleConfig="//@styleConfig.97">
+  <layerConfig name="HY_Physica_4_v5" registryId="http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.ManMadeObject" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.ManMadeObject" styleConfig="//@styleConfig.116 //@styleConfig.118 //@styleConfig.120 //@styleConfig.122 //@styleConfig.124">
+    <title lang="en" text="Man-made Object"/>
+    <title text="Bauwerke an Gewässern"/>
+    <objectType>hy-p_4.0:Crossing</objectType>
+    <objectType>hy-p_5.0:DamOrWeir</objectType>
+    <objectType>hy-p_5.0:ShorelineConstruction</objectType>
+    <objectType>hy-p_5.0:Ford</objectType>
+    <objectType>hy-p_5.0:Lock</objectType>
+  </layerConfig>
+  <layerConfig name="HY_PhysicalWaters_Shore" registryId="http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.Shore" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.Shore" styleConfig="//@styleConfig.125">
     <title lang="en" text="Shores"/>
     <title text="Küsten"/>
     <objectType>hy-p_4.0:Shore</objectType>
   </layerConfig>
-  <layerConfig name="HY_Physica_5" registryId="http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.Waterbodies" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.Waterbodies" styleConfig="//@styleConfig.98 //@styleConfig.99">
+  <layerConfig name="HY_PhysicalWaters_Shore_v5" registryId="http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.Shore" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.Shore" styleConfig="//@styleConfig.126">
+    <title lang="en" text="Shores"/>
+    <title text="Küsten"/>
+    <objectType>hy-p_5.0:Shore</objectType>
+  </layerConfig>
+  <layerConfig name="HY_Physica_5" registryId="http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.Waterbodies" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.Waterbodies" styleConfig="//@styleConfig.127 //@styleConfig.129">
     <title lang="en" text="Waterbody"/>
     <title text="Wasserkörper"/>
     <objectType>hy-p_4.0:Watercourse</objectType>
     <objectType>hy-p_4.0:StandingWater</objectType>
   </layerConfig>
-  <layerConfig name="HY_Physica_6" registryId="" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.Waterbodies.Man.Made" styleConfig="//@styleConfig.100 //@styleConfig.101">
+  <layerConfig name="HY_Physica_5_v5" registryId="http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.Waterbodies" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.Waterbodies" styleConfig="//@styleConfig.128 //@styleConfig.130">
+    <title lang="en" text="Waterbody"/>
+    <title text="Wasserkörper"/>
+    <objectType>hy-p_5.0:Watercourse</objectType>
+    <objectType>hy-p_5.0:StandingWater</objectType>
+  </layerConfig>
+  <layerConfig name="HY_Physica_6" registryId="" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.Waterbodies.Man.Made" styleConfig="//@styleConfig.131 //@styleConfig.133">
     <title lang="en" text="Man-made Object (Natural)"/>
     <objectType>hy-p_4.0:Watercourse</objectType>
     <objectType>hy-p_4.0:StandingWater</objectType>
   </layerConfig>
-  <layerConfig name="HY_Physica_7" registryId="" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.Waterbodies.Persistence" styleConfig="//@styleConfig.102 //@styleConfig.103">
+  <layerConfig name="HY_Physica_6_v5" registryId="" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.Waterbodies.Man.Made" styleConfig="//@styleConfig.132 //@styleConfig.134">
+    <title lang="en" text="Man-made Object (Natural)"/>
+    <objectType>hy-p_5.0:Watercourse</objectType>
+    <objectType>hy-p_5.0:StandingWater</objectType>
+  </layerConfig>
+  <layerConfig name="HY_Physica_7" registryId="" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.Waterbodies.Persistence" styleConfig="//@styleConfig.135 //@styleConfig.137">
     <title lang="en" text="Waterbody (Persistence)"/>
     <objectType>hy-p_4.0:Watercourse</objectType>
     <objectType>hy-p_4.0:StandingWater</objectType>
   </layerConfig>
-  <layerConfig name="HY_PhysicalWaters_Wetland" registryId="http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.Wetland" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.Wetland" styleConfig="//@styleConfig.104">
+  <layerConfig name="HY_Physica_7_v5" registryId="" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.Waterbodies.Persistence" styleConfig="//@styleConfig.136 //@styleConfig.138">
+    <title lang="en" text="Waterbody (Persistence)"/>
+    <objectType>hy-p_5.0:Watercourse</objectType>
+    <objectType>hy-p_5.0:StandingWater</objectType>
+  </layerConfig>
+  <layerConfig name="HY_PhysicalWaters_Wetland" registryId="http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.Wetland" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.Wetland" styleConfig="//@styleConfig.139">
     <title lang="en" text="Wetlands"/>
     <title text="Feuchtgebiete"/>
     <objectType>hy-p_4.0:Wetland</objectType>
   </layerConfig>
-  <layerConfig name="PS_ProtectedSite" registryId="http://inspire.ec.europa.eu/layer/PS.ProtectedSite" tags="//@tags.0 //@tags.2" layerName="PS.ProtectedSite" styleConfig="//@styleConfig.105">
+  <layerConfig name="HY_PhysicalWaters_Wetland_v5" registryId="http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.Wetland" tags="//@tags.0 //@tags.2" layerName="HY.PhysicalWaters.Wetland" styleConfig="//@styleConfig.140">
+    <title lang="en" text="Wetlands"/>
+    <title text="Feuchtgebiete"/>
+    <objectType>hy-p_5.0:Wetland</objectType>
+  </layerConfig>
+  <layerConfig name="PS_ProtectedSite" registryId="http://inspire.ec.europa.eu/layer/PS.ProtectedSite" tags="//@tags.0 //@tags.2" layerName="PS.ProtectedSite" styleConfig="//@styleConfig.141">
     <title lang="en" text="Protected Sites"/>
     <title text="Schutzgebiete"/>
     <objectType>ps_4.0:ProtectedSite</objectType>
   </layerConfig>
-  <layerConfig name="PS_ProtectedSite_v5" registryId="http://inspire.ec.europa.eu/layer/PS.ProtectedSite" tags="//@tags.0 //@tags.2" layerName="PS.ProtectedSite_v5" styleConfig="//@styleConfig.106">
+  <layerConfig name="PS_ProtectedSite_v5" registryId="http://inspire.ec.europa.eu/layer/PS.ProtectedSite" tags="//@tags.0 //@tags.2" layerName="PS.ProtectedSite" styleConfig="//@styleConfig.142">
     <title lang="en" text="Protected Sites"/>
     <title text="Schutzgebiete"/>
     <objectType>ps_5.0:ProtectedSite</objectType>
   </layerConfig>
-  <layerConfig name="TN_AirTran" registryId="http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.AerodromeArea" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.AerodromeArea" styleConfig="//@styleConfig.107">
+  <layerConfig name="PS_ProtectedSite_v5" registryId="http://inspire.ec.europa.eu/layer/PS.ProtectedSite" tags="//@tags.0 //@tags.2" layerName="PS.ProtectedSite_v5" styleConfig="//@styleConfig.142">
+    <title lang="en" text="Protected Sites"/>
+    <title text="Schutzgebiete"/>
+    <objectType>ps_5.0:ProtectedSite</objectType>
+  </layerConfig>
+  <layerConfig name="TN_AirTran" registryId="http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.AerodromeArea" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.AerodromeArea" styleConfig="//@styleConfig.144">
     <title lang="en" text="Aerodrome Area Default Style"/>
     <title text="Flugplatzgelände"/>
     <objectType>tn-a_4.0:AerodromeArea</objectType>
   </layerConfig>
-  <layerConfig name="TN_AirTran_1" registryId="http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.AirLink" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.AirLink" styleConfig="//@styleConfig.108 //@styleConfig.109">
+  <layerConfig name="TN_AirTran_v5" registryId="http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.AerodromeArea" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.AerodromeArea" styleConfig="//@styleConfig.145">
+    <title lang="en" text="Aerodrome Area Default Style"/>
+    <title text="Flugplatzgelände"/>
+    <objectType>tn-a_5.0:AerodromeArea</objectType>
+  </layerConfig>
+  <layerConfig name="TN_AirTran_1" registryId="http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.AirLink" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.AirLink" styleConfig="//@styleConfig.146 //@styleConfig.148">
     <title lang="en" text="Air Link Default Style"/>
     <title text="Luftverbindung"/>
     <objectType>tn-a_4.0:ProcedureLink</objectType>
     <objectType>tn-a_4.0:AirRouteLink</objectType>
   </layerConfig>
-  <layerConfig name="TN_AirTran_2" registryId="http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.AirspaceArea" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.AirSpaceArea" styleConfig="//@styleConfig.110">
+  <layerConfig name="TN_AirTran_1_v5" registryId="http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.AirLink" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.AirLink" styleConfig="//@styleConfig.147 //@styleConfig.149">
+    <title lang="en" text="Air Link Default Style"/>
+    <title text="Luftverbindung"/>
+    <objectType>tn-a_5.0:ProcedureLink</objectType>
+    <objectType>tn-a_5.0:AirRouteLink</objectType>
+  </layerConfig>
+  <layerConfig name="TN_AirTran_2" registryId="http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.AirspaceArea" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.AirSpaceArea" styleConfig="//@styleConfig.150">
     <title lang="en" text="Air Space Area Default Style"/>
     <title text="Luftraumbereich"/>
     <objectType>tn-a_4.0:AirspaceArea</objectType>
   </layerConfig>
-  <layerConfig name="TN_AirTran_3" registryId="http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.ApronArea" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.ApronArea" styleConfig="//@styleConfig.111">
+  <layerConfig name="TN_AirTran_2_v5" registryId="http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.AirspaceArea" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.AirSpaceArea" styleConfig="//@styleConfig.151">
+    <title lang="en" text="Air Space Area Default Style"/>
+    <title text="Luftraumbereich"/>
+    <objectType>tn-a_5.0:AirspaceArea</objectType>
+  </layerConfig>
+  <layerConfig name="TN_AirTran_3" registryId="http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.ApronArea" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.ApronArea" styleConfig="//@styleConfig.152">
     <title lang="en" text="Apron Area Default Style"/>
     <title text="Vorfeldgelände"/>
     <objectType>tn-a_4.0:ApronArea</objectType>
   </layerConfig>
-  <layerConfig name="TN_AirTran_4" registryId="http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.RunwayArea" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.RunwayArea" styleConfig="//@styleConfig.112">
+  <layerConfig name="TN_AirTran_3_v5" registryId="http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.ApronArea" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.ApronArea" styleConfig="//@styleConfig.153">
+    <title lang="en" text="Apron Area Default Style"/>
+    <title text="Vorfeldgelände"/>
+    <objectType>tn-a_5.0:ApronArea</objectType>
+  </layerConfig>
+  <layerConfig name="TN_AirTran_4" registryId="http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.RunwayArea" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.RunwayArea" styleConfig="//@styleConfig.154">
     <title lang="en" text="Runway Area Default Style"/>
     <title text="Landebahngelände"/>
     <objectType>tn-a_4.0:RunwayArea</objectType>
   </layerConfig>
-  <layerConfig name="TN_AirTran_5" registryId="http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.TaxiwayArea" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.TaxiwayArea" styleConfig="//@styleConfig.113">
+  <layerConfig name="TN_AirTran_4_v5" registryId="http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.RunwayArea" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.RunwayArea" styleConfig="//@styleConfig.155">
+    <title lang="en" text="Runway Area Default Style"/>
+    <title text="Landebahngelände"/>
+    <objectType>tn-a_5.0:RunwayArea</objectType>
+  </layerConfig>
+  <layerConfig name="TN_AirTran_5" registryId="http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.TaxiwayArea" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.TaxiwayArea" styleConfig="//@styleConfig.156">
     <title lang="en" text="Taxiway Area Default Style"/>
     <title text="Rollfeld"/>
     <objectType>tn-a_4.0:TaxiwayArea</objectType>
   </layerConfig>
-  <layerConfig name="TN_AirTran_6" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.DesignatedPoint" styleConfig="//@styleConfig.4">
+  <layerConfig name="TN_AirTran_5_v5" registryId="http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.TaxiwayArea" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.TaxiwayArea" styleConfig="//@styleConfig.157">
+    <title lang="en" text="Taxiway Area Default Style"/>
+    <title text="Rollfeld"/>
+    <objectType>tn-a_5.0:TaxiwayArea</objectType>
+  </layerConfig>
+  <layerConfig name="TN_AirTran_6" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.DesignatedPoint" styleConfig="//@styleConfig.7">
     <title lang="en" text="Designated Point Default Style"/>
     <title text="Designierter Punkt"/>
     <objectType>tn-a_4.0:DesignatedPoint</objectType>
   </layerConfig>
-  <layerConfig name="TN_AirTran_7" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.AerodromeNode" styleConfig="//@styleConfig.7">
+  <layerConfig name="TN_AirTran_6_v5" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.DesignatedPoint" styleConfig="//@styleConfig.8">
+    <title lang="en" text="Designated Point Default Style"/>
+    <title text="Designierter Punkt"/>
+    <objectType>tn-a_5.0:DesignatedPoint</objectType>
+  </layerConfig>
+  <layerConfig name="TN_AirTran_7" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.AerodromeNode" styleConfig="//@styleConfig.13">
     <title lang="en" text="Aerodrome Node Default Style"/>
     <title text="Flugplatzknotenpunkt"/>
     <objectType>tn-a_4.0:AerodromeNode</objectType>
   </layerConfig>
-  <layerConfig name="TN_AirTran_8" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.TouchDownLiftOff" styleConfig="//@styleConfig.8">
+  <layerConfig name="TN_AirTran_7_v5" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.AerodromeNode" styleConfig="//@styleConfig.14">
+    <title lang="en" text="Aerodrome Node Default Style"/>
+    <title text="Flugplatzknotenpunkt"/>
+    <objectType>tn-a_5.0:AerodromeNode</objectType>
+  </layerConfig>
+  <layerConfig name="TN_AirTran_8" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.TouchDownLiftOff" styleConfig="//@styleConfig.15">
     <title lang="en" text="Touch Down Lift Off Area Default Style"/>
     <title text="Start- und Landebereich für Hubschrauber"/>
     <objectType>tn-a_4.0:TouchDownLiftOff</objectType>
   </layerConfig>
-  <layerConfig name="TN_AirTran_9" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.Navaid" styleConfig="//@styleConfig.5">
+  <layerConfig name="TN_AirTran_8_v5" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.TouchDownLiftOff" styleConfig="//@styleConfig.16">
+    <title lang="en" text="Touch Down Lift Off Area Default Style"/>
+    <title text="Start- und Landebereich für Hubschrauber"/>
+    <objectType>tn-a_5.0:TouchDownLiftOff</objectType>
+  </layerConfig>
+  <layerConfig name="TN_AirTran_9" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.Navaid" styleConfig="//@styleConfig.9">
     <title lang="en" text="Navaid Default Style"/>
     <title text="Navigationshilfe"/>
     <objectType>tn-a_4.0:Navaid</objectType>
   </layerConfig>
-  <layerConfig name="TN_AirTran_10" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.RunwayCentrelinePoint" styleConfig="//@styleConfig.6">
+  <layerConfig name="TN_AirTran_9_v5" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.Navaid" styleConfig="//@styleConfig.10">
+    <title lang="en" text="Navaid Default Style"/>
+    <title text="Navigationshilfe"/>
+    <objectType>tn-a_5.0:Navaid</objectType>
+  </layerConfig>
+  <layerConfig name="TN_AirTran_10" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.RunwayCentrelinePoint" styleConfig="//@styleConfig.11">
     <title lang="en" text="Runway Centreline Point Default Style"/>
     <title text="Mittellinienpunkt der Landebahn"/>
     <objectType>tn-a_4.0:RunwayCentrelinePoint</objectType>
   </layerConfig>
-  <layerConfig name="TN_CableTr" registryId="http://inspire.ec.europa.eu/layer/TN.CableTransportNetwork.CablewayLink" tags="//@tags.0 //@tags.2" layerName="TN.CableTransportNetwork.CablewayLink" styleConfig="//@styleConfig.114">
+  <layerConfig name="TN_AirTran_10_v5" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.AirTransportNetwork.RunwayCentrelinePoint" styleConfig="//@styleConfig.12">
+    <title lang="en" text="Runway Centreline Point Default Style"/>
+    <title text="Mittellinienpunkt der Landebahn"/>
+    <objectType>tn-a_5.0:RunwayCentrelinePoint</objectType>
+  </layerConfig>
+  <layerConfig name="TN_CableTr" registryId="http://inspire.ec.europa.eu/layer/TN.CableTransportNetwork.CablewayLink" tags="//@tags.0 //@tags.2" layerName="TN.CableTransportNetwork.CablewayLink" styleConfig="//@styleConfig.158">
     <title lang="en" text="Cableway Link Default Style"/>
     <title text="Seilbahnverbindung"/>
     <objectType>tn-c_4.0:CablewayLink</objectType>
   </layerConfig>
-  <layerConfig name="TN_CommonT" registryId="http://inspire.ec.europa.eu/layer/TN.CommonTransportElements.TransportArea" tags="//@tags.0 //@tags.2" layerName="TN.CommonTransportElements.TransportArea" styleConfig="//@styleConfig.115">
+  <layerConfig name="TN_CableTr_v5" registryId="http://inspire.ec.europa.eu/layer/TN.CableTransportNetwork.CablewayLink" tags="//@tags.0 //@tags.2" layerName="TN.CableTransportNetwork.CablewayLink" styleConfig="//@styleConfig.159">
+    <title lang="en" text="Cableway Link Default Style"/>
+    <title text="Seilbahnverbindung"/>
+    <objectType>tn-c_5.0:CablewayLink</objectType>
+  </layerConfig>
+  <layerConfig name="TN_CommonT" registryId="http://inspire.ec.europa.eu/layer/TN.CommonTransportElements.TransportArea" tags="//@tags.0 //@tags.2" layerName="TN.CommonTransportElements.TransportArea" styleConfig="//@styleConfig.160">
     <title lang="en" text="Generic Transport Area Default Style"/>
     <title text="Generischer Verkehrsbereich"/>
     <objectType>tn_4.0:TransportArea</objectType>
   </layerConfig>
-  <layerConfig name="TN_CommonT_1" registryId="http://inspire.ec.europa.eu/layer/TN.CommonTransportElements.TransportLink" tags="//@tags.0 //@tags.2" layerName="TN.CommonTransportElements.TransportLink" styleConfig="//@styleConfig.116">
+  <layerConfig name="TN_CommonT_v5" registryId="http://inspire.ec.europa.eu/layer/TN.CommonTransportElements.TransportArea" tags="//@tags.0 //@tags.2" layerName="TN.CommonTransportElements.TransportArea" styleConfig="//@styleConfig.161">
+    <title lang="en" text="Generic Transport Area Default Style"/>
+    <title text="Generischer Verkehrsbereich"/>
+    <objectType>tn_5.0:TransportArea</objectType>
+  </layerConfig>
+  <layerConfig name="TN_CommonT_1" registryId="http://inspire.ec.europa.eu/layer/TN.CommonTransportElements.TransportLink" tags="//@tags.0 //@tags.2" layerName="TN.CommonTransportElements.TransportLink" styleConfig="//@styleConfig.162">
     <title lang="en" text="Generic Transport Link Default Style"/>
     <title text="Generisches Verkehrssegment"/>
     <objectType>tn_4.0:TransportLink</objectType>
   </layerConfig>
-  <layerConfig name="TN_CommonT_2" registryId="http://inspire.ec.europa.eu/layer/TN.CommonTransportElements.TransportNode" tags="//@tags.0 //@tags.2" layerName="TN.CommonTransportElements.TransportNode" styleConfig="//@styleConfig.117">
+  <layerConfig name="TN_CommonT_1_v5" registryId="http://inspire.ec.europa.eu/layer/TN.CommonTransportElements.TransportLink" tags="//@tags.0 //@tags.2" layerName="TN.CommonTransportElements.TransportLink" styleConfig="//@styleConfig.163">
+    <title lang="en" text="Generic Transport Link Default Style"/>
+    <title text="Generisches Verkehrssegment"/>
+    <objectType>tn_5.0:TransportLink</objectType>
+  </layerConfig>
+  <layerConfig name="TN_CommonT_2" registryId="http://inspire.ec.europa.eu/layer/TN.CommonTransportElements.TransportNode" tags="//@tags.0 //@tags.2" layerName="TN.CommonTransportElements.TransportNode" styleConfig="//@styleConfig.164">
     <title lang="en" text="Generic Transport Node Default Style"/>
     <title text="Generischer Verkehrsknotenpunkt"/>
     <objectType>tn_4.0:TransportNode</objectType>
   </layerConfig>
-  <layerConfig name="TN_RailTra" registryId="http://inspire.ec.europa.eu/layer/TN.RailTransportNetwork.RailwayArea" tags="//@tags.0 //@tags.2" layerName="TN.RailTransportNetwork.RailwayArea" styleConfig="//@styleConfig.118">
+  <layerConfig name="TN_CommonT_2_v5" registryId="http://inspire.ec.europa.eu/layer/TN.CommonTransportElements.TransportNode" tags="//@tags.0 //@tags.2" layerName="TN.CommonTransportElements.TransportNode" styleConfig="//@styleConfig.165">
+    <title lang="en" text="Generic Transport Node Default Style"/>
+    <title text="Generischer Verkehrsknotenpunkt"/>
+    <objectType>tn_5.0:TransportNode</objectType>
+  </layerConfig>
+  <layerConfig name="TN_RailTra" registryId="http://inspire.ec.europa.eu/layer/TN.RailTransportNetwork.RailwayArea" tags="//@tags.0 //@tags.2" layerName="TN.RailTransportNetwork.RailwayArea" styleConfig="//@styleConfig.166">
     <title lang="en" text="Railway Area Default Style"/>
     <title text="Bahngelände"/>
     <objectType>tn-ra_4.0:RailwayArea</objectType>
   </layerConfig>
-  <layerConfig name="TN_RailTra_1" registryId="http://inspire.ec.europa.eu/layer/TN.RailTransportNetwork.RailwayLink" tags="//@tags.0 //@tags.2" layerName="TN.RailTransportNetwork.RailwayLink" styleConfig="//@styleConfig.119">
+  <layerConfig name="TN_RailTra_v5" registryId="http://inspire.ec.europa.eu/layer/TN.RailTransportNetwork.RailwayArea" tags="//@tags.0 //@tags.2" layerName="TN.RailTransportNetwork.RailwayArea" styleConfig="//@styleConfig.167">
+    <title lang="en" text="Railway Area Default Style"/>
+    <title text="Bahngelände"/>
+    <objectType>tn-ra_5.0:RailwayArea</objectType>
+  </layerConfig>
+  <layerConfig name="TN_RailTra_1" registryId="http://inspire.ec.europa.eu/layer/TN.RailTransportNetwork.RailwayLink" tags="//@tags.0 //@tags.2" layerName="TN.RailTransportNetwork.RailwayLink" styleConfig="//@styleConfig.168">
     <title lang="en" text="Railway Link Default Style"/>
     <title text="Eisenbahnverbindung"/>
     <objectType>tn-ra_4.0:RailwayLink</objectType>
   </layerConfig>
-  <layerConfig name="TN_RailTra_2" registryId="http://inspire.ec.europa.eu/layer/TN.RailTransportNetwork.RailwayStationArea" tags="//@tags.0 //@tags.2" layerName="TN.RailTransportNetwork.RailwayStationArea" styleConfig="//@styleConfig.120">
+  <layerConfig name="TN_RailTra_1_v5" registryId="http://inspire.ec.europa.eu/layer/TN.RailTransportNetwork.RailwayLink" tags="//@tags.0 //@tags.2" layerName="TN.RailTransportNetwork.RailwayLink" styleConfig="//@styleConfig.169">
+    <title lang="en" text="Railway Link Default Style"/>
+    <title text="Eisenbahnverbindung"/>
+    <objectType>tn-ra_5.0:RailwayLink</objectType>
+  </layerConfig>
+  <layerConfig name="TN_RailTra_2" registryId="http://inspire.ec.europa.eu/layer/TN.RailTransportNetwork.RailwayStationArea" tags="//@tags.0 //@tags.2" layerName="TN.RailTransportNetwork.RailwayStationArea" styleConfig="//@styleConfig.170">
     <title lang="en" text="Railway Station Area Default Style"/>
     <title text="Bahnhofsgelände"/>
     <objectType>tn-ra_4.0:RailwayStationArea</objectType>
   </layerConfig>
-  <layerConfig name="TN_RailTra_3" registryId="http://inspire.ec.europa.eu/layer/TN.RailTransportNetwork.RailwayYardArea" tags="//@tags.0 //@tags.2" layerName="TN.RailTransportNetwork.RailwayYardArea" styleConfig="//@styleConfig.121">
+  <layerConfig name="TN_RailTra_2_v5" registryId="http://inspire.ec.europa.eu/layer/TN.RailTransportNetwork.RailwayStationArea" tags="//@tags.0 //@tags.2" layerName="TN.RailTransportNetwork.RailwayStationArea" styleConfig="//@styleConfig.171">
+    <title lang="en" text="Railway Station Area Default Style"/>
+    <title text="Bahnhofsgelände"/>
+    <objectType>tn-ra_5.0:RailwayStationArea</objectType>
+  </layerConfig>
+  <layerConfig name="TN_RailTra_3" registryId="http://inspire.ec.europa.eu/layer/TN.RailTransportNetwork.RailwayYardArea" tags="//@tags.0 //@tags.2" layerName="TN.RailTransportNetwork.RailwayYardArea" styleConfig="//@styleConfig.172">
     <title lang="en" text="Railway Yard Area Default Style"/>
     <title text="Rangierbahnhofsgelände"/>
     <objectType>tn-ra_4.0:RailwayYardArea</objectType>
   </layerConfig>
-  <layerConfig name="TN_RoadTra" registryId="http://inspire.ec.europa.eu/layer/TN.RoadTransportNetwork.RoadArea" tags="//@tags.0 //@tags.2" layerName="TN.RoadTransportNetwork.RoadArea" styleConfig="//@styleConfig.122">
+  <layerConfig name="TN_RailTra_3_v5" registryId="http://inspire.ec.europa.eu/layer/TN.RailTransportNetwork.RailwayYardArea" tags="//@tags.0 //@tags.2" layerName="TN.RailTransportNetwork.RailwayYardArea" styleConfig="//@styleConfig.173">
+    <title lang="en" text="Railway Yard Area Default Style"/>
+    <title text="Rangierbahnhofsgelände"/>
+    <objectType>tn-ra_5.0:RailwayYardArea</objectType>
+  </layerConfig>
+  <layerConfig name="TN_RoadTra" registryId="http://inspire.ec.europa.eu/layer/TN.RoadTransportNetwork.RoadArea" tags="//@tags.0 //@tags.2" layerName="TN.RoadTransportNetwork.RoadArea" styleConfig="//@styleConfig.174">
     <title lang="en" text="Road Area Default Style"/>
     <title text="Straßenfläche"/>
     <objectType>tn-ro_4.0:RoadArea</objectType>
   </layerConfig>
-  <layerConfig name="TN_RoadTra_1" registryId="http://inspire.ec.europa.eu/layer/TN.RoadTransportNetwork.RoadLink" tags="//@tags.0 //@tags.2" layerName="TN.RoadTransportNetwork.RoadLink" styleConfig="//@styleConfig.123">
+  <layerConfig name="TN_RoadTra_v5" registryId="http://inspire.ec.europa.eu/layer/TN.RoadTransportNetwork.RoadArea" tags="//@tags.0 //@tags.2" layerName="TN.RoadTransportNetwork.RoadArea" styleConfig="//@styleConfig.175">
+    <title lang="en" text="Road Area Default Style"/>
+    <title text="Straßenfläche"/>
+    <objectType>tn-ro_5.0:RoadArea</objectType>
+  </layerConfig>
+  <layerConfig name="TN_RoadTra_1" registryId="http://inspire.ec.europa.eu/layer/TN.RoadTransportNetwork.RoadLink" tags="//@tags.0 //@tags.2" layerName="TN.RoadTransportNetwork.RoadLink" styleConfig="//@styleConfig.176">
     <title lang="en" text="Road Link Default Style"/>
     <title text="Straßensegment"/>
     <objectType>tn-ro_4.0:RoadLink</objectType>
   </layerConfig>
-  <layerConfig name="TN_RoadTra_2" registryId="http://inspire.ec.europa.eu/layer/TN.RoadTransportNetwork.RoadServiceArea" tags="//@tags.0 //@tags.2" layerName="TN.RoadTransportNetwork.RoadServiceArea" styleConfig="//@styleConfig.124">
+  <layerConfig name="TN_RoadTra_1_v5" registryId="http://inspire.ec.europa.eu/layer/TN.RoadTransportNetwork.RoadLink" tags="//@tags.0 //@tags.2" layerName="TN.RoadTransportNetwork.RoadLink" styleConfig="//@styleConfig.177">
+    <title lang="en" text="Road Link Default Style"/>
+    <title text="Straßensegment"/>
+    <objectType>tn-ro_5.0:RoadLink</objectType>
+  </layerConfig>
+  <layerConfig name="TN_RoadTra_2" registryId="http://inspire.ec.europa.eu/layer/TN.RoadTransportNetwork.RoadServiceArea" tags="//@tags.0 //@tags.2" layerName="TN.RoadTransportNetwork.RoadServiceArea" styleConfig="//@styleConfig.178">
     <title lang="en" text="Road Service Area Default Style"/>
     <title text="Servicebereich"/>
     <objectType>tn-ro_4.0:RoadServiceArea</objectType>
   </layerConfig>
-  <layerConfig name="TN_RoadTra_3" registryId="http://inspire.ec.europa.eu/layer/TN.RoadTransportNetwork.VehicleTrafficArea" tags="//@tags.0 //@tags.2" layerName="TN.RoadTransportNetwork.VehicleTrafficArea" styleConfig="//@styleConfig.125">
+  <layerConfig name="TN_RoadTra_2_v5" registryId="http://inspire.ec.europa.eu/layer/TN.RoadTransportNetwork.RoadServiceArea" tags="//@tags.0 //@tags.2" layerName="TN.RoadTransportNetwork.RoadServiceArea" styleConfig="//@styleConfig.179">
+    <title lang="en" text="Road Service Area Default Style"/>
+    <title text="Servicebereich"/>
+    <objectType>tn-ro_5.0:RoadServiceArea</objectType>
+  </layerConfig>
+  <layerConfig name="TN_RoadTra_3" registryId="http://inspire.ec.europa.eu/layer/TN.RoadTransportNetwork.VehicleTrafficArea" tags="//@tags.0 //@tags.2" layerName="TN.RoadTransportNetwork.VehicleTrafficArea" styleConfig="//@styleConfig.180">
     <title lang="en" text="Vehicle traffic Area Default Style"/>
     <title text="Verkehrsfläche"/>
     <objectType>tn-ro_4.0:VehicleTrafficArea</objectType>
   </layerConfig>
-  <layerConfig name="TN_WaterTr" registryId="http://inspire.ec.europa.eu/layer/TN.WaterTransportNetwork.FairwayArea" tags="//@tags.0 //@tags.2" layerName="TN.WaterTransportNetwork.FairwayArea" styleConfig="//@styleConfig.126">
+  <layerConfig name="TN_RoadTra_3_v5" registryId="http://inspire.ec.europa.eu/layer/TN.RoadTransportNetwork.VehicleTrafficArea" tags="//@tags.0 //@tags.2" layerName="TN.RoadTransportNetwork.VehicleTrafficArea" styleConfig="//@styleConfig.181">
+    <title lang="en" text="Vehicle traffic Area Default Style"/>
+    <title text="Verkehrsfläche"/>
+    <objectType>tn-ro_5.0:VehicleTrafficArea</objectType>
+  </layerConfig>
+  <layerConfig name="TN_WaterTr" registryId="http://inspire.ec.europa.eu/layer/TN.WaterTransportNetwork.FairwayArea" tags="//@tags.0 //@tags.2" layerName="TN.WaterTransportNetwork.FairwayArea" styleConfig="//@styleConfig.182">
     <title lang="en" text="Fairway Area Default Style"/>
     <title text="Fahrrinnenbereich"/>
     <objectType>tn-w_4.0:FairwayArea</objectType>
   </layerConfig>
-  <layerConfig name="TN_WaterTr_1" registryId="http://inspire.ec.europa.eu/layer/TN.WaterTransportNetwork.PortArea" tags="//@tags.0 //@tags.2" layerName="TN.WaterTransportNetwork.PortArea" styleConfig="//@styleConfig.127">
+  <layerConfig name="TN_WaterTr_v5" registryId="http://inspire.ec.europa.eu/layer/TN.WaterTransportNetwork.FairwayArea" tags="//@tags.0 //@tags.2" layerName="TN.WaterTransportNetwork.FairwayArea" styleConfig="//@styleConfig.183">
+    <title lang="en" text="Fairway Area Default Style"/>
+    <title text="Fahrrinnenbereich"/>
+    <objectType>tn-w_5.0:FairwayArea</objectType>
+  </layerConfig>
+  <layerConfig name="TN_WaterTr_1" registryId="http://inspire.ec.europa.eu/layer/TN.WaterTransportNetwork.PortArea" tags="//@tags.0 //@tags.2" layerName="TN.WaterTransportNetwork.PortArea" styleConfig="//@styleConfig.184">
     <title lang="en" text="Port Area Default Style"/>
     <title text="Hafengelände"/>
     <objectType>tn-w_4.0:PortArea</objectType>
   </layerConfig>
-  <layerConfig name="TN_WaterTr_2" registryId="http://inspire.ec.europa.eu/layer/TN.WaterTransportNetwork.WaterwayLink" tags="//@tags.0 //@tags.2" layerName="TN.WaterTransportNetwork.WaterwayLink" styleConfig="//@styleConfig.128">
+  <layerConfig name="TN_WaterTr_1_v5" registryId="http://inspire.ec.europa.eu/layer/TN.WaterTransportNetwork.PortArea" tags="//@tags.0 //@tags.2" layerName="TN.WaterTransportNetwork.PortArea" styleConfig="//@styleConfig.185">
+    <title lang="en" text="Port Area Default Style"/>
+    <title text="Hafengelände"/>
+    <objectType>tn-w_5.0:PortArea</objectType>
+  </layerConfig>
+  <layerConfig name="TN_WaterTr_2" registryId="http://inspire.ec.europa.eu/layer/TN.WaterTransportNetwork.WaterwayLink" tags="//@tags.0 //@tags.2" layerName="TN.WaterTransportNetwork.WaterwayLink" styleConfig="//@styleConfig.186">
     <title lang="en" text="Waterway Link Default Style"/>
     <title text="Wasserstraßenverbindung"/>
     <objectType>tn-w_4.0:WaterwayLink</objectType>
   </layerConfig>
-  <layerConfig name="LC_LandCoverSurfaces" registryId="http://inspire.ec.europa.eu/layer/LC.LandCoverSurfaces" tags="//@tags.2 //@tags.0" layerName="LC.LandCoverSurfaces" styleConfig="//@styleConfig.129">
+  <layerConfig name="TN_WaterTr_2_v5" registryId="http://inspire.ec.europa.eu/layer/TN.WaterTransportNetwork.WaterwayLink" tags="//@tags.0 //@tags.2" layerName="TN.WaterTransportNetwork.WaterwayLink" styleConfig="//@styleConfig.187">
+    <title lang="en" text="Waterway Link Default Style"/>
+    <title text="Wasserstraßenverbindung"/>
+    <objectType>tn-w_5.0:WaterwayLink</objectType>
+  </layerConfig>
+  <layerConfig name="LC_LandCoverSurfaces" registryId="http://inspire.ec.europa.eu/layer/LC.LandCoverSurfaces" tags="//@tags.2 //@tags.0" layerName="LC.LandCoverSurfaces" styleConfig="//@styleConfig.188">
     <title lang="en" text="Land Cover Surfaces"/>
     <title text="Bodenbedeckungsflächen"/>
     <objectType>lcv_4.0:LandCoverUnit</objectType>
   </layerConfig>
-  <layerConfig name="LC_LandCoverPoints" registryId="http://inspire.ec.europa.eu/layer/LC.LandCoverPoints" tags="//@tags.2 //@tags.0" layerName="LC.LandCoverPoints" styleConfig="//@styleConfig.130">
+  <layerConfig name="LC_LandCoverSurfaces_v5" registryId="http://inspire.ec.europa.eu/layer/LC.LandCoverSurfaces" tags="//@tags.2 //@tags.0" layerName="LC.LandCoverSurfaces" styleConfig="//@styleConfig.189">
+    <title lang="en" text="Land Cover Surfaces"/>
+    <title text="Bodenbedeckungsflächen"/>
+    <objectType>lcv_5.0:LandCoverUnit</objectType>
+  </layerConfig>
+  <layerConfig name="LC_LandCoverPoints" registryId="http://inspire.ec.europa.eu/layer/LC.LandCoverPoints" tags="//@tags.2 //@tags.0" layerName="LC.LandCoverPoints" styleConfig="//@styleConfig.190">
     <title lang="en" text="Land Cover Points"/>
     <title text="Bodenbedeckungspunkte"/>
     <objectType>lcv_4.0:LandCoverUnit</objectType>
   </layerConfig>
-  <layerConfig name="BU_Building" registryId="http://inspire.ec.europa.eu/layer/BU.Building" tags="//@tags.0 //@tags.2" layerName="BU.Building" styleConfig="//@styleConfig.131">
+  <layerConfig name="LC_LandCoverPoints_v5" registryId="http://inspire.ec.europa.eu/layer/LC.LandCoverPoints" tags="//@tags.2 //@tags.0" layerName="LC.LandCoverPoints" styleConfig="//@styleConfig.191">
+    <title lang="en" text="Land Cover Points"/>
+    <title text="Bodenbedeckungspunkte"/>
+    <objectType>lcv_5.0:LandCoverUnit</objectType>
+  </layerConfig>
+  <layerConfig name="BU_Building" registryId="http://inspire.ec.europa.eu/layer/BU.Building" tags="//@tags.0 //@tags.2" layerName="BU.Building" styleConfig="//@styleConfig.192">
     <title lang="en" text="Building"/>
     <title text="Gebäude"/>
     <objectType>bu-core2d_4.0:Building</objectType>
   </layerConfig>
-  <layerConfig name="BU_BuildingPart" registryId="http://inspire.ec.europa.eu/layer/BU.BuildingPart" tags="//@tags.0 //@tags.2" layerName="BU.BuildingPart" styleConfig="//@styleConfig.132">
+  <layerConfig name="BU_BuildingPart" registryId="http://inspire.ec.europa.eu/layer/BU.BuildingPart" tags="//@tags.0 //@tags.2" layerName="BU.BuildingPart" styleConfig="//@styleConfig.193">
     <title lang="en" text="BuildingPart"/>
     <title text="Gebäudeteile"/>
     <objectType>bu-core2d_4.0:BuildingPart</objectType>
   </layerConfig>
-  <layerConfig name="LU_ExistingLandUse" registryId="http://inspire.ec.europa.eu/layer/LU.ExistingLandUse" tags="//@tags.2 //@tags.0" layerName="LU.ExistingLandUse" styleConfig="//@styleConfig.66">
+  <layerConfig name="LU_ExistingLandUse" registryId="http://inspire.ec.europa.eu/layer/LU.ExistingLandUse" tags="//@tags.2 //@tags.0" layerName="LU.ExistingLandUse" styleConfig="//@styleConfig.82">
     <title lang="en" text="Existing Land Use"/>
     <title text="Existierende Bodennutzung"/>
     <objectType>elu_4.0:ExistingLandUseObject</objectType>
   </layerConfig>
-  <layerConfig name="LU_SpatialPlan" registryId="http://inspire.ec.europa.eu/layer/LU.SpatialPlan" tags="//@tags.2 //@tags.0" layerName="LU.SpatialPlan" styleConfig="//@styleConfig.65">
+  <layerConfig name="LU_SpatialPlan" registryId="http://inspire.ec.europa.eu/layer/LU.SpatialPlan" tags="//@tags.2 //@tags.0" layerName="LU.SpatialPlan" styleConfig="//@styleConfig.81">
     <title lang="en" text="Spatial Plan"/>
     <title text="Räumlicher Plan"/>
     <objectType>plu_4.0:SpatialPlan</objectType>
   </layerConfig>
-  <layerConfig name="LU_ZoningElement" registryId="http://inspire.ec.europa.eu/layer/LU.ZoningElement" tags="//@tags.2 //@tags.0" layerName="LU.ZoningElement" styleConfig="//@styleConfig.64">
+  <layerConfig name="LU_ZoningElement" registryId="http://inspire.ec.europa.eu/layer/LU.ZoningElement" tags="//@tags.2 //@tags.0" layerName="LU.ZoningElement" styleConfig="//@styleConfig.80">
     <title lang="en" text="Zoning Element"/>
     <title text="Zonierungselement"/>
     <objectType>plu_4.0:ZoningElement</objectType>
   </layerConfig>
-  <layerConfig name="LU_SupplementaryRegulation" registryId="http://inspire.ec.europa.eu/layer/LU.SupplementaryRegulation" tags="//@tags.2 //@tags.0" layerName="LU.SupplementaryRegulation" styleConfig="//@styleConfig.63">
+  <layerConfig name="LU_SupplementaryRegulation" registryId="http://inspire.ec.europa.eu/layer/LU.SupplementaryRegulation" tags="//@tags.2 //@tags.0" layerName="LU.SupplementaryRegulation" styleConfig="//@styleConfig.79">
     <title lang="en" text="Supplementary Regulation"/>
     <title text="Ergänzende Vorschrift"/>
     <objectType>plu_4.0:SupplementaryRegulation</objectType>
   </layerConfig>
-  <layerConfig name="US_GovernmentalService" registryId="" tags="//@tags.0" layerName="US.GovernmentalService" styleConfig="//@styleConfig.62">
+  <layerConfig name="US_GovernmentalService" registryId="" tags="//@tags.0" layerName="US.GovernmentalService" styleConfig="//@styleConfig.77">
     <title lang="en" text="Governmental Service"/>
     <title text="Staatlicher Dienst"/>
     <objectType>us-govserv_4.0:GovernmentalService</objectType>
   </layerConfig>
-  <layerConfig name="AM_AirQualityManagementZone" registryId="http://inspire.ec.europa.eu/layer/AM.AirQualityManagementZone" tags="//@tags.0 //@tags.2" layerName="AM.AirQualityManagementZone" styleConfig="//@styleConfig.60">
+  <layerConfig name="US_GovernmentalService_v5" registryId="" tags="//@tags.0" layerName="US.GovernmentalService" styleConfig="//@styleConfig.78">
+    <title lang="en" text="Governmental Service"/>
+    <title text="Staatlicher Dienst"/>
+    <objectType>us-govserv_5.0:GovernmentalService</objectType>
+  </layerConfig>
+  <layerConfig name="AM_AirQualityManagementZone" registryId="http://inspire.ec.europa.eu/layer/AM.AirQualityManagementZone" tags="//@tags.0 //@tags.2" layerName="AM.AirQualityManagementZone" styleConfig="//@styleConfig.75">
     <title lang="en" text="Air Quality Management Zone"/>
     <title text="Luftqualitäts-Kontrollgebiet"/>
     <objectType>am_4.0:ManagementRestrictionOrRegulationZone</objectType>
   </layerConfig>
-  <layerConfig name="AM_AnimalHealthRestrictionZone" registryId="http://inspire.ec.europa.eu/layer/AM.AnimalHealthRestrictionZone" tags="//@tags.0 //@tags.2" layerName="AM.AnimalHealthRestrictionZone" styleConfig="//@styleConfig.61">
+  <layerConfig name="AM_AnimalHealthRestrictionZone" registryId="http://inspire.ec.europa.eu/layer/AM.AnimalHealthRestrictionZone" tags="//@tags.0 //@tags.2" layerName="AM.AnimalHealthRestrictionZone" styleConfig="//@styleConfig.76">
     <title lang="en" text="Animal Health Restriction Zone"/>
     <title text="Tiergesundheits-Schutzgebiet"/>
     <objectType>am_4.0:ManagementRestrictionOrRegulationZone</objectType>
   </layerConfig>
-  <layerConfig name="AM_AreaForDisposalOfWaste" registryId="http://inspire.ec.europa.eu/layer/AM.AreaForDisposalOfWaste" tags="//@tags.0 //@tags.2" layerName="AM.AreaForDisposalOfWaste" styleConfig="//@styleConfig.59">
+  <layerConfig name="AM_AreaForDisposalOfWaste" registryId="http://inspire.ec.europa.eu/layer/AM.AreaForDisposalOfWaste" tags="//@tags.0 //@tags.2" layerName="AM.AreaForDisposalOfWaste" styleConfig="//@styleConfig.74">
     <title lang="en" text="Area For Disposal Of Waste"/>
     <title text="Abfallentsorgungsgebiet"/>
     <objectType>am_4.0:ManagementRestrictionOrRegulationZone</objectType>
   </layerConfig>
-  <layerConfig name="AM_BathingWaters" registryId="http://inspire.ec.europa.eu/layer/AM.BathingWaters" tags="//@tags.0 //@tags.2" layerName="AM.BathingWaters" styleConfig="//@styleConfig.58">
+  <layerConfig name="AM_BathingWaters" registryId="http://inspire.ec.europa.eu/layer/AM.BathingWaters" tags="//@tags.0 //@tags.2" layerName="AM.BathingWaters" styleConfig="//@styleConfig.73">
     <title lang="en" text="Bathing Waters"/>
     <title text="Badegewässer"/>
     <objectType>am_4.0:ManagementRestrictionOrRegulationZone</objectType>
   </layerConfig>
-  <layerConfig name="AM_CoastalZoneManagementArea" registryId="http://inspire.ec.europa.eu/layer/AM.CoastalZoneManagementArea" tags="//@tags.0 //@tags.2" layerName="AM.CoastalZoneManagementArea" styleConfig="//@styleConfig.57">
+  <layerConfig name="AM_CoastalZoneManagementArea" registryId="http://inspire.ec.europa.eu/layer/AM.CoastalZoneManagementArea" tags="//@tags.0 //@tags.2" layerName="AM.CoastalZoneManagementArea" styleConfig="//@styleConfig.72">
     <title lang="en" text="Coastal Zone Management Area"/>
     <title text="Gebiete des Küstenzonenmanagements"/>
     <objectType>am_4.0:ManagementRestrictionOrRegulationZone</objectType>
   </layerConfig>
-  <layerConfig name="AM_DesignatedWaters" registryId="http://inspire.ec.europa.eu/layer/AM.DesignatedWaters" tags="//@tags.0 //@tags.2" layerName="AM.DesignatedWaters" styleConfig="//@styleConfig.56">
+  <layerConfig name="AM_DesignatedWaters" registryId="http://inspire.ec.europa.eu/layer/AM.DesignatedWaters" tags="//@tags.0 //@tags.2" layerName="AM.DesignatedWaters" styleConfig="//@styleConfig.71">
     <title lang="en" text="Designated Waters"/>
     <title text="Bezeichnetes Gewässer"/>
     <objectType>am_4.0:ManagementRestrictionOrRegulationZone</objectType>
   </layerConfig>
-  <layerConfig name="AM_DrinkingWaterProtectionArea" registryId="http://inspire.ec.europa.eu/layer/AM.DrinkingWaterProtectionArea" tags="//@tags.0 //@tags.2" layerName="AM.DrinkingWaterProtectionArea" styleConfig="//@styleConfig.55">
+  <layerConfig name="AM_DrinkingWaterProtectionArea" registryId="http://inspire.ec.europa.eu/layer/AM.DrinkingWaterProtectionArea" tags="//@tags.0 //@tags.2" layerName="AM.DrinkingWaterProtectionArea" styleConfig="//@styleConfig.70">
     <title lang="en" text="Drinking Water Protection Area"/>
     <title text="Trinkwasserschutzgebiet"/>
     <objectType>am_4.0:ManagementRestrictionOrRegulationZone</objectType>
   </layerConfig>
-  <layerConfig name="AM_FloodUnitOfManagement" registryId="http://inspire.ec.europa.eu/layer/AM.FloodUnitOfManagement" tags="//@tags.0 //@tags.2" layerName="AM.FloodUnitOfManagement" styleConfig="//@styleConfig.54">
+  <layerConfig name="AM_FloodUnitOfManagement" registryId="http://inspire.ec.europa.eu/layer/AM.FloodUnitOfManagement" tags="//@tags.0 //@tags.2" layerName="AM.FloodUnitOfManagement" styleConfig="//@styleConfig.69">
     <title lang="en" text="Flood Unit Of Management"/>
     <title text="Bewirtschaftungseinheit für Hochwasserrisiken"/>
     <objectType>am_4.0:ManagementRestrictionOrRegulationZone</objectType>
   </layerConfig>
-  <layerConfig name="AM_ForestManagementArea" registryId="http://inspire.ec.europa.eu/layer/AM.ForestManagementArea" tags="//@tags.0 //@tags.2" layerName="AM.ForestManagementArea" styleConfig="//@styleConfig.53">
+  <layerConfig name="AM_ForestManagementArea" registryId="http://inspire.ec.europa.eu/layer/AM.ForestManagementArea" tags="//@tags.0 //@tags.2" layerName="AM.ForestManagementArea" styleConfig="//@styleConfig.68">
     <title lang="en" text="Forest Management Area"/>
     <title text="Waldbewirtschaftungsgebiet"/>
     <objectType>am_4.0:ManagementRestrictionOrRegulationZone</objectType>
   </layerConfig>
-  <layerConfig name="AM_MarineRegion" registryId="http://inspire.ec.europa.eu/layer/AM.MarineRegion" tags="//@tags.0 //@tags.2" layerName="AM.MarineRegion" styleConfig="//@styleConfig.52">
+  <layerConfig name="AM_MarineRegion" registryId="http://inspire.ec.europa.eu/layer/AM.MarineRegion" tags="//@tags.0 //@tags.2" layerName="AM.MarineRegion" styleConfig="//@styleConfig.67">
     <title lang="en" text="Marine Region"/>
     <title text="Meeresregion"/>
     <objectType>am_4.0:ManagementRestrictionOrRegulationZone</objectType>
   </layerConfig>
-  <layerConfig name="AM_NitrateVulnerableZone" registryId="http://inspire.ec.europa.eu/layer/AM.NitrateVulnerableZone" tags="//@tags.0 //@tags.2" layerName="AM.NitrateVulnerableZone" styleConfig="//@styleConfig.51">
+  <layerConfig name="AM_NitrateVulnerableZone" registryId="http://inspire.ec.europa.eu/layer/AM.NitrateVulnerableZone" tags="//@tags.0 //@tags.2" layerName="AM.NitrateVulnerableZone" styleConfig="//@styleConfig.66">
     <title lang="en" text="Nitrate Vulnerable Zone"/>
     <title text="Nitratgefährdetes Gebiet"/>
     <objectType>am_4.0:ManagementRestrictionOrRegulationZone</objectType>
   </layerConfig>
-  <layerConfig name="AM_NoiseRestrictionZone" registryId="http://inspire.ec.europa.eu/layer/AM.NoiseRestrictionZone" tags="//@tags.0 //@tags.2" layerName="AM.NoiseRestrictionZone" styleConfig="//@styleConfig.50">
+  <layerConfig name="AM_NoiseRestrictionZone" registryId="http://inspire.ec.europa.eu/layer/AM.NoiseRestrictionZone" tags="//@tags.0 //@tags.2" layerName="AM.NoiseRestrictionZone" styleConfig="//@styleConfig.65">
     <title lang="en" text="Noise Restriction Zone"/>
     <title text="Lärmschutzgebiet"/>
     <objectType>am_4.0:ManagementRestrictionOrRegulationZone</objectType>
   </layerConfig>
-  <layerConfig name="AM_PlantHealthProtectionZone" registryId="http://inspire.ec.europa.eu/layer/AM.PlantHealthProtectionZone" tags="//@tags.0 //@tags.2" layerName="AM.PlantHealthProtectionZone" styleConfig="//@styleConfig.49">
+  <layerConfig name="AM_PlantHealthProtectionZone" registryId="http://inspire.ec.europa.eu/layer/AM.PlantHealthProtectionZone" tags="//@tags.0 //@tags.2" layerName="AM.PlantHealthProtectionZone" styleConfig="//@styleConfig.64">
     <title lang="en" text="Plant Health Protection Zone"/>
     <title text="Pflanzengesundheitliches Schutzgebiet"/>
     <objectType>am_4.0:ManagementRestrictionOrRegulationZone</objectType>
   </layerConfig>
-  <layerConfig name="AM_ProspectingAndMiningPermitArea" registryId="http://inspire.ec.europa.eu/layer/AM.ProspectingAndMiningPermitArea" tags="//@tags.0 //@tags.2" layerName="AM.ProspectingAndMiningPermitArea" styleConfig="//@styleConfig.48">
+  <layerConfig name="AM_ProspectingAndMiningPermitArea" registryId="http://inspire.ec.europa.eu/layer/AM.ProspectingAndMiningPermitArea" tags="//@tags.0 //@tags.2" layerName="AM.ProspectingAndMiningPermitArea" styleConfig="//@styleConfig.63">
     <title lang="en" text="Prospecting And Mining Permit Area"/>
     <title text="Für Prospektion und Bergbau ausgewiesenes Gebiet"/>
     <objectType>am_4.0:ManagementRestrictionOrRegulationZone</objectType>
   </layerConfig>
-  <layerConfig name="AM_RegulatedFairwayAtSeaOrLargeInlandWater" registryId="http://inspire.ec.europa.eu/layer/AM.RegulatedFairwayAtSeaOrLargeInlandWater" tags="//@tags.0 //@tags.2" layerName="AM.RegulatedFairwayAtSeaOrLargeInlandWater" styleConfig="//@styleConfig.47">
+  <layerConfig name="AM_RegulatedFairwayAtSeaOrLargeInlandWater" registryId="http://inspire.ec.europa.eu/layer/AM.RegulatedFairwayAtSeaOrLargeInlandWater" tags="//@tags.0 //@tags.2" layerName="AM.RegulatedFairwayAtSeaOrLargeInlandWater" styleConfig="//@styleConfig.62">
     <title lang="en" text="Regulated Fairway At Sea Or Large Inland Water"/>
     <title text="Geregeltes Fahrwasser auf See oder auf großen Binnengewässern"/>
     <objectType>am_4.0:ManagementRestrictionOrRegulationZone</objectType>
   </layerConfig>
-  <layerConfig name="AM_RestrictedZonesAroundContaminatedSites" registryId="http://inspire.ec.europa.eu/layer/AM.RestrictedZonesAroundContaminatedSites" tags="//@tags.0 //@tags.2" layerName="AM.RestrictedZonesAroundContaminatedSites" styleConfig="//@styleConfig.46">
+  <layerConfig name="AM_RestrictedZonesAroundContaminatedSites" registryId="http://inspire.ec.europa.eu/layer/AM.RestrictedZonesAroundContaminatedSites" tags="//@tags.0 //@tags.2" layerName="AM.RestrictedZonesAroundContaminatedSites" styleConfig="//@styleConfig.61">
     <title lang="en" text="Restricted Zones Around Contaminated Sites"/>
     <title text="Schutzgebiete um kontaminierte Standorte (Altlasten)"/>
     <objectType>am_4.0:ManagementRestrictionOrRegulationZone</objectType>
   </layerConfig>
-  <layerConfig name="AM_RiverBasinDistrict" registryId="http://inspire.ec.europa.eu/layer/AM.RiverBasinDistrict" tags="//@tags.0 //@tags.2" layerName="AM.RiverBasinDistrict" styleConfig="//@styleConfig.45">
+  <layerConfig name="AM_RiverBasinDistrict" registryId="http://inspire.ec.europa.eu/layer/AM.RiverBasinDistrict" tags="//@tags.0 //@tags.2" layerName="AM.RiverBasinDistrict" styleConfig="//@styleConfig.60">
     <title lang="en" text="River Basin District"/>
     <title text="Flussgebietseinheit"/>
     <objectType>am_4.0:ManagementRestrictionOrRegulationZone</objectType>
   </layerConfig>
-  <layerConfig name="AM_SensitiveArea" registryId="http://inspire.ec.europa.eu/layer/AM.SensitiveArea" tags="//@tags.0 //@tags.2" layerName="AM.SensitiveArea" styleConfig="//@styleConfig.44">
+  <layerConfig name="AM_SensitiveArea" registryId="http://inspire.ec.europa.eu/layer/AM.SensitiveArea" tags="//@tags.0 //@tags.2" layerName="AM.SensitiveArea" styleConfig="//@styleConfig.59">
     <title lang="en" text="Sensitive Area"/>
     <title text="Empfindliches Gebiet"/>
     <objectType>am_4.0:ManagementRestrictionOrRegulationZone</objectType>
   </layerConfig>
-  <layerConfig name="AM_WaterBodyForWFD" registryId="http://inspire.ec.europa.eu/layer/AM.WaterBodyForWFD" tags="//@tags.0 //@tags.2" layerName="AM.WaterBodyForWFD" styleConfig="//@styleConfig.43">
+  <layerConfig name="AM_WaterBodyForWFD" registryId="http://inspire.ec.europa.eu/layer/AM.WaterBodyForWFD" tags="//@tags.0 //@tags.2" layerName="AM.WaterBodyForWFD" styleConfig="//@styleConfig.58">
     <title lang="en" text="WaterBodyForWFD"/>
     <title text="Wasserkörper gemäß der Wasserrahmenrichtlinie (2000/60/EG)"/>
     <objectType>am_4.0:ManagementRestrictionOrRegulationZone</objectType>
   </layerConfig>
-  <layerConfig name="US_EnvironmentalManagementFacility" registryId="https://inspire.ec.europa.eu/layer/US.EnvironmentalManagementFacility" tags="//@tags.0 //@tags.2" layerName="US.EnvironmentalManagementFacility" styleConfig="//@styleConfig.3">
+  <layerConfig name="US_EnvironmentalManagementFacility" registryId="https://inspire.ec.europa.eu/layer/US.EnvironmentalManagementFacility" tags="//@tags.0 //@tags.2" layerName="US.EnvironmentalManagementFacility" styleConfig="//@styleConfig.5">
     <title lang="en" text="Environmental Management Facility"/>
     <title text="Umweltmanagementeinrichtungen"/>
     <objectType>us-emf_4.0:EnvironmentalManagementFacility</objectType>
+  </layerConfig>
+  <layerConfig name="US_EnvironmentalManagementFacility_v5" registryId="https://inspire.ec.europa.eu/layer/US.EnvironmentalManagementFacility" tags="//@tags.0 //@tags.2" layerName="US.EnvironmentalManagementFacility" styleConfig="//@styleConfig.6">
+    <title lang="en" text="Environmental Management Facility"/>
+    <title text="Umweltmanagementeinrichtungen"/>
+    <objectType>us-emf_5.0:EnvironmentalManagementFacility</objectType>
   </layerConfig>
   <layerConfig name="US_UtilityNetworkAppurtenance" registryId="" tags="//@tags.0 //@tags.2" layerName="US.UtilityNetworkAppurtenance" styleConfig="//@styleConfig.1">
     <title lang="en" text="Appurtenance"/>
     <title text="Zubehörteil"/>
     <objectType>us-net-common_4.0:Appurtenance</objectType>
   </layerConfig>
-  <layerConfig name="US_UtilityNetworkLink" registryId="" tags="//@tags.0 //@tags.2" layerName="US.UtilityNetworkLink" styleConfig="//@styleConfig.2">
+  <layerConfig name="US_UtilityNetworkAppurtenance_v5" registryId="" tags="//@tags.0 //@tags.2" layerName="US.UtilityNetworkAppurtenance" styleConfig="//@styleConfig.2">
+    <title lang="en" text="Appurtenance"/>
+    <title text="Zubehörteil"/>
+    <objectType>us-net-common_5.0:Appurtenance</objectType>
+  </layerConfig>
+  <layerConfig name="US_UtilityNetworkLink" registryId="" tags="//@tags.0 //@tags.2" layerName="US.UtilityNetworkLink" styleConfig="//@styleConfig.3">
     <title lang="en" text="Utility Link"/>
     <title text="Versorgungsverbindung"/>
     <objectType>us-net-common_4.0:UtilityLink</objectType>
   </layerConfig>
-  <layerConfig name="EF_EnvironmentalMonitoringFacilities" registryId="http://inspire.ec.europa.eu/layer/EF.EnvironmentalMonitoringFacilities" tags="//@tags.0 //@tags.2" layerName="EF.EnvironmentalMonitoringFacilities" styleConfig="//@styleConfig.42">
+  <layerConfig name="US_UtilityNetworkLink_v5" registryId="" tags="//@tags.0 //@tags.2" layerName="US.UtilityNetworkLink" styleConfig="//@styleConfig.4">
+    <title lang="en" text="Utility Link"/>
+    <title text="Versorgungsverbindung"/>
+    <objectType>us-net-common_5.0:UtilityLink</objectType>
+  </layerConfig>
+  <layerConfig name="EF_EnvironmentalMonitoringFacilities" registryId="http://inspire.ec.europa.eu/layer/EF.EnvironmentalMonitoringFacilities" tags="//@tags.0 //@tags.2" layerName="EF.EnvironmentalMonitoringFacilities" styleConfig="//@styleConfig.57">
     <title lang="en" text="Environmental Monitoring Facilities"/>
     <title text="Umweltüberwachungseinrichtungen"/>
     <objectType>ef_4.0:EnvironmentalMonitoringFacility</objectType>
   </layerConfig>
-  <layerConfig name="EF_EnvironmentalMonitoringNetworks" registryId="http://inspire.ec.europa.eu/layer/EF.EnvironmentalMonitoringNetworks" tags="//@tags.0 //@tags.2" layerName="EF.EnvironmentalMonitoringNetworks" styleConfig="//@styleConfig.41">
+  <layerConfig name="EF_EnvironmentalMonitoringNetworks" registryId="http://inspire.ec.europa.eu/layer/EF.EnvironmentalMonitoringNetworks" tags="//@tags.0 //@tags.2" layerName="EF.EnvironmentalMonitoringNetworks" styleConfig="//@styleConfig.56">
     <title lang="en" text="Environmental Monitoring Networks"/>
     <title text="Umweltüberwachungsnetzwerke"/>
     <objectType>ef_4.0:EnvironmentalMonitoringNetwork</objectType>
   </layerConfig>
-  <layerConfig name="EF_EnvironmentalMonitoringProgrammes" registryId="http://inspire.ec.europa.eu/layer/EF.EnvironmentalMonitoringProgrammes" tags="//@tags.0 //@tags.2" layerName="EF.EnvironmentalMonitoringProgrammes" styleConfig="//@styleConfig.40">
+  <layerConfig name="EF_EnvironmentalMonitoringProgrammes" registryId="http://inspire.ec.europa.eu/layer/EF.EnvironmentalMonitoringProgrammes" tags="//@tags.0 //@tags.2" layerName="EF.EnvironmentalMonitoringProgrammes" styleConfig="//@styleConfig.55">
     <title lang="en" text="Environmental Monitoring Programmes"/>
     <title text="Umweltüberwachungsprogramme"/>
     <objectType>ef_4.0:EnvironmentalMonitoringProgramme</objectType>
   </layerConfig>
-  <layerConfig name="NZ_RiskZone" registryId="" tags="//@tags.0 //@tags.2" layerName="NZ.RiskZone" styleConfig="//@styleConfig.39">
+  <layerConfig name="NZ_RiskZone" registryId="" tags="//@tags.0 //@tags.2" layerName="NZ.RiskZone" styleConfig="//@styleConfig.54">
     <title lang="en" text="Risk Zones"/>
     <title text="Risikogebiet"/>
     <objectType>nz-core_4.0:RiskZone</objectType>
   </layerConfig>
-  <layerConfig name="NZ_HazardArea" registryId="" tags="//@tags.0 //@tags.2" layerName="NZ.HazardArea" styleConfig="//@styleConfig.38">
+  <layerConfig name="NZ_HazardArea" registryId="" tags="//@tags.0 //@tags.2" layerName="NZ.HazardArea" styleConfig="//@styleConfig.53">
     <title lang="en" text="Hazard Area"/>
     <title text="Gefahrengebiet"/>
     <objectType>nz-core_4.0:HazardArea</objectType>
   </layerConfig>
-  <layerConfig name="NZ_ExposedElement" registryId="http://inspire.ec.europa.eu/layer/NZ.ExposedElement" tags="//@tags.0 //@tags.2" layerName="NZ.ExposedElement" styleConfig="//@styleConfig.37">
+  <layerConfig name="NZ_ExposedElement" registryId="http://inspire.ec.europa.eu/layer/NZ.ExposedElement" tags="//@tags.0 //@tags.2" layerName="NZ.ExposedElement" styleConfig="//@styleConfig.52">
     <title lang="en" text="Exposed Elements"/>
     <title text="Gefährdetes Element"/>
     <objectType>nz-core_4.0:ExposedElement</objectType>
   </layerConfig>
-  <layerConfig name="NZ_ObservedEvent" registryId="" tags="//@tags.0" layerName="NZ.ObservedEvent" styleConfig="//@styleConfig.36">
+  <layerConfig name="NZ_ObservedEvent" registryId="" tags="//@tags.0" layerName="NZ.ObservedEvent" styleConfig="//@styleConfig.51">
     <title lang="en" text="Observed Event"/>
     <title text="Beobachtetes Ereignis"/>
     <objectType>nz-core_4.0:ObservedEvent</objectType>
   </layerConfig>
-  <layerConfig name="TN_MarkerPost" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.CommonTransportElements.MarkerPost" styleConfig="//@styleConfig.35">
+  <layerConfig name="TN_MarkerPost" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.CommonTransportElements.MarkerPost" styleConfig="//@styleConfig.49">
     <title lang="en" text="Marker Post"/>
     <title text="Stationszeichen"/>
     <objectType>tn_4.0:MarkerPost</objectType>
   </layerConfig>
-  <layerConfig name="TN_W_Beacon" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.WaterTransportNetwork.Beacon" styleConfig="//@styleConfig.34">
+  <layerConfig name="TN_MarkerPost_v5" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.CommonTransportElements.MarkerPost" styleConfig="//@styleConfig.50">
+    <title lang="en" text="Marker Post"/>
+    <title text="Stationszeichen"/>
+    <objectType>tn_5.0:MarkerPost</objectType>
+  </layerConfig>
+  <layerConfig name="TN_W_Beacon" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.WaterTransportNetwork.Beacon" styleConfig="//@styleConfig.47">
     <title lang="en" text="Beacon"/>
     <title text="Leuchtfeuer"/>
     <objectType>tn-w_4.0:Beacon</objectType>
   </layerConfig>
-  <layerConfig name="TN_W_Buoy" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.WaterTransportNetwork.Buoy" styleConfig="//@styleConfig.33">
+  <layerConfig name="TN_W_Beacon_v5" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.WaterTransportNetwork.Beacon" styleConfig="//@styleConfig.48">
+    <title lang="en" text="Beacon"/>
+    <title text="Leuchtfeuer"/>
+    <objectType>tn-w_5.0:Beacon</objectType>
+  </layerConfig>
+  <layerConfig name="TN_W_Buoy" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.WaterTransportNetwork.Buoy" styleConfig="//@styleConfig.45">
     <title lang="en" text="Buoy"/>
     <title text="Tonne"/>
     <objectType>tn-w_4.0:Buoy</objectType>
   </layerConfig>
-  <layerConfig name="TN_W_TrafficSeparationSchemeCrossing" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.WaterTransportNetwork.TrafficSeparationSchemeCrossing" styleConfig="//@styleConfig.32">
+  <layerConfig name="TN_W_Buoy_v5" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.WaterTransportNetwork.Buoy" styleConfig="//@styleConfig.46">
+    <title lang="en" text="Buoy"/>
+    <title text="Tonne"/>
+    <objectType>tn-w_5.0:Buoy</objectType>
+  </layerConfig>
+  <layerConfig name="TN_W_TrafficSeparationSchemeCrossing" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.WaterTransportNetwork.TrafficSeparationSchemeCrossing" styleConfig="//@styleConfig.43">
     <title lang="en" text="Traffic Separation Scheme Crossing"/>
     <title text="Kreuzung eines Verkehrstrennungsgebiets"/>
     <objectType>tn-w_4.0:TrafficSeparationSchemeCrossing</objectType>
   </layerConfig>
-  <layerConfig name="TN_W_TrafficSeparationSchemeSeparator" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.WaterTransportNetwork.TrafficSeparationSchemeSeparator" styleConfig="//@styleConfig.31">
+  <layerConfig name="TN_W_TrafficSeparationSchemeCrossing_v5" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.WaterTransportNetwork.TrafficSeparationSchemeCrossing" styleConfig="//@styleConfig.44">
+    <title lang="en" text="Traffic Separation Scheme Crossing"/>
+    <title text="Kreuzung eines Verkehrstrennungsgebiets"/>
+    <objectType>tn-w_5.0:TrafficSeparationSchemeCrossing</objectType>
+  </layerConfig>
+  <layerConfig name="TN_W_TrafficSeparationSchemeSeparator" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.WaterTransportNetwork.TrafficSeparationSchemeSeparator" styleConfig="//@styleConfig.41">
     <title lang="en" text="Traffic Separation Scheme Separator"/>
     <title text="Übergangszone eines Verkehrstrennungsgebiets"/>
     <objectType>tn-w_4.0:TrafficSeparationSchemeSeparator</objectType>
   </layerConfig>
-  <layerConfig name="PF_ProductionFacility" registryId="" tags="//@tags.0" layerName="PF.ProductionFacility" styleConfig="//@styleConfig.30">
+  <layerConfig name="TN_W_TrafficSeparationSchemeSeparator_v5" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.WaterTransportNetwork.TrafficSeparationSchemeSeparator" styleConfig="//@styleConfig.42">
+    <title lang="en" text="Traffic Separation Scheme Separator"/>
+    <title text="Übergangszone eines Verkehrstrennungsgebiets"/>
+    <objectType>tn-w_5.0:TrafficSeparationSchemeSeparator</objectType>
+  </layerConfig>
+  <layerConfig name="PF_ProductionFacility" registryId="" tags="//@tags.0" layerName="PF.ProductionFacility" styleConfig="//@styleConfig.40">
     <title lang="en" text="Production Facility"/>
     <title text="Produktionsstätte"/>
     <objectType>pf_4.0:ProductionFacility</objectType>
   </layerConfig>
-  <layerConfig name="PF_ProductionBuilding" registryId="http://inspire.ec.europa.eu/layer/PF.ProductionBuilding" tags="//@tags.0 //@tags.2" layerName="PF.ProductionBuilding" styleConfig="//@styleConfig.29">
+  <layerConfig name="PF_ProductionBuilding" registryId="http://inspire.ec.europa.eu/layer/PF.ProductionBuilding" tags="//@tags.0 //@tags.2" layerName="PF.ProductionBuilding" styleConfig="//@styleConfig.39">
     <title lang="en" text="Production And Industrial Building"/>
     <title text="Produktions- und Industriegebäude"/>
     <objectType>pf_4.0:ProductionBuilding</objectType>
   </layerConfig>
-  <layerConfig name="PF_ProductionInstallation" registryId="http://inspire.ec.europa.eu/layer/PF.ProductionInstallation" tags="//@tags.0 //@tags.2" layerName="PF.ProductionInstallation" styleConfig="//@styleConfig.28">
+  <layerConfig name="PF_ProductionInstallation" registryId="http://inspire.ec.europa.eu/layer/PF.ProductionInstallation" tags="//@tags.0 //@tags.2" layerName="PF.ProductionInstallation" styleConfig="//@styleConfig.38">
     <title lang="en" text="Production And Industrial Installation"/>
     <title text="Produktions- und Industrieanlage"/>
     <objectType>pf_4.0:ProductionInstallation</objectType>
   </layerConfig>
-  <layerConfig name="PF_ProductionInstallationPart" registryId="http://inspire.ec.europa.eu/layer/PF.ProductionInstallationPart" tags="//@tags.0 //@tags.2" layerName="PF.ProductionInstallationPart" styleConfig="//@styleConfig.27">
+  <layerConfig name="PF_ProductionInstallationPart" registryId="http://inspire.ec.europa.eu/layer/PF.ProductionInstallationPart" tags="//@tags.0 //@tags.2" layerName="PF.ProductionInstallationPart" styleConfig="//@styleConfig.37">
     <title lang="en" text="Production And Industrial Installation Part"/>
     <title text="Produktions- und Industrieanlagenteil"/>
     <objectType>pf_4.0:ProductionInstallationPart</objectType>
   </layerConfig>
-  <layerConfig name="PF_ProductionPlot" registryId="http://inspire.ec.europa.eu/layer/PF.ProductionPlot" tags="//@tags.0 //@tags.2" layerName="PF.ProductionPlot" styleConfig="//@styleConfig.26">
+  <layerConfig name="PF_ProductionPlot" registryId="http://inspire.ec.europa.eu/layer/PF.ProductionPlot" tags="//@tags.0 //@tags.2" layerName="PF.ProductionPlot" styleConfig="//@styleConfig.36">
     <title lang="en" text="Production And Industrial Plot"/>
     <title text="Produktions- und Industriegelände"/>
     <objectType>pf_4.0:ProductionPlot</objectType>
   </layerConfig>
-  <layerConfig name="PF_ProductionSite" registryId="http://inspire.ec.europa.eu/layer/PF.ProductionSite" tags="//@tags.0 //@tags.2" layerName="PF.ProductionSite" styleConfig="//@styleConfig.25">
+  <layerConfig name="PF_ProductionSite" registryId="http://inspire.ec.europa.eu/layer/PF.ProductionSite" tags="//@tags.0 //@tags.2" layerName="PF.ProductionSite" styleConfig="//@styleConfig.35">
     <title lang="en" text="Production And Industrial Site"/>
     <title text="Produktions- und Industriestandort"/>
     <objectType>pf_4.0:ProductionSite</objectType>
   </layerConfig>
-  <layerConfig name="ER_RenewableAndWasteResource" registryId="http://inspire.ec.europa.eu/layer/ER.RenewableAndWasteResource" tags="//@tags.0" layerName="ER.RenewableAndWasteResource" styleConfig="//@styleConfig.24">
+  <layerConfig name="ER_RenewableAndWasteResource" registryId="http://inspire.ec.europa.eu/layer/ER.RenewableAndWasteResource" tags="//@tags.0" layerName="ER.RenewableAndWasteResource" styleConfig="//@styleConfig.34">
     <title lang="en" text="Renewable And Waste Resource"/>
     <title text="Ressourcen erneuerbarer Energien und Abfallressourcen"/>
     <objectType>er-v_4.0:RenewableAndWasteResource</objectType>
   </layerConfig>
-  <layerConfig name="GE_GeologicUnit_AgeOfRocks" registryId="http://inspire.ec.europa.eu/layer/GE.GeologicUnit" tags="//@tags.0 //@tags.2" layerName="GE.GeologicUnit.AgeOfRocks" styleConfig="//@styleConfig.23">
+  <layerConfig name="GE_GeologicUnit_AgeOfRocks" registryId="http://inspire.ec.europa.eu/layer/GE.GeologicUnit" tags="//@tags.0 //@tags.2" layerName="GE.GeologicUnit.AgeOfRocks" styleConfig="//@styleConfig.33">
     <title lang="en" text="Geologic Units"/>
     <title text="Geologische Einheiten"/>
     <objectType>ge-core_4.0:MappedFeature</objectType>
   </layerConfig>
-  <layerConfig name="GE_Borehole" registryId="http://inspire.ec.europa.eu/layer/GE.Borehole" tags="//@tags.0 //@tags.2" layerName="GE.Borehole" styleConfig="//@styleConfig.133">
+  <layerConfig name="GE_Borehole" registryId="http://inspire.ec.europa.eu/layer/GE.Borehole" tags="//@tags.0 //@tags.2" layerName="GE.Borehole" styleConfig="//@styleConfig.194">
     <title lang="en" text="Boreholes"/>
     <title text="Bohrlöcher"/>
     <objectType>ge-core_4.0:Borehole</objectType>
   </layerConfig>
-  <layerConfig name="BR_BiogeographicalRegion" registryId="http://inspire.ec.europa.eu/layer/BR.Bio-geographicalRegion" tags="//@tags.0 //@tags.2" layerName="BR.Bio-geographicalRegion" styleConfig="//@styleConfig.22">
+  <layerConfig name="BR_BiogeographicalRegion" registryId="http://inspire.ec.europa.eu/layer/BR.Bio-geographicalRegion" tags="//@tags.0 //@tags.2" layerName="BR.Bio-geographicalRegion" styleConfig="//@styleConfig.32">
     <title lang="en" text="Bio-geographical regions"/>
     <title text="Biogeografische Regionen"/>
     <objectType>br_4.0:Bio-geographicalRegion</objectType>
   </layerConfig>
-  <layerConfig name="BR_Natura2000andEmeraldBiogeographicalRegion" registryId="" tags="//@tags.0 //@tags.2" layerName="BR.Natura2000andEmeraldBio-geographicalRegion" styleConfig="//@styleConfig.21">
+  <layerConfig name="BR_Natura2000andEmeraldBiogeographicalRegion" registryId="" tags="//@tags.0 //@tags.2" layerName="BR.Natura2000andEmeraldBio-geographicalRegion" styleConfig="//@styleConfig.31">
     <title lang="en" text="Bio-geographical regions"/>
     <title text="Biogeografische Regionen"/>
     <objectType>br_4.0:Bio-geographicalRegion</objectType>
   </layerConfig>
-  <layerConfig name="SU_VectorStatisticalUnit" registryId="http://inspire.ec.europa.eu/layer/SU.VectorStatisticalUnit" tags="//@tags.0 //@tags.2" layerName="SU.VectorStatisticalUnit" styleConfig="//@styleConfig.19">
+  <layerConfig name="SU_VectorStatisticalUnit" registryId="http://inspire.ec.europa.eu/layer/SU.VectorStatisticalUnit" tags="//@tags.0 //@tags.2" layerName="SU.VectorStatisticalUnit" styleConfig="//@styleConfig.29">
     <title lang="en" text="Vector statistical units"/>
     <title text="Statistische Vektoreinheiten"/>
     <objectType>su-vector_4.0:VectorStatisticalUnit</objectType>
   </layerConfig>
-  <layerConfig name="SU_StatisticalGridCell" registryId="http://inspire.ec.europa.eu/layer/SU.StatisticalGridCell" tags="//@tags.0" layerName="SU.StatisticalGridCell" styleConfig="//@styleConfig.20">
+  <layerConfig name="SU_StatisticalGridCell" registryId="http://inspire.ec.europa.eu/layer/SU.StatisticalGridCell" tags="//@tags.0" layerName="SU.StatisticalGridCell" styleConfig="//@styleConfig.30">
     <title lang="en" text="Statistical grid cells"/>
     <title text="Statistische Vektoreinheiten"/>
     <objectType>su-grid_4.0:StatisticalGridCell</objectType>
   </layerConfig>
-  <layerConfig name="HH_HealthDeterminantMeasure" registryId="http://inspire.ec.europa.eu/layer/HH.HealthDeterminantMeasure" tags="//@tags.0 //@tags.2" layerName="HH.HealthDeterminantMeasure" styleConfig="//@styleConfig.18">
+  <layerConfig name="HH_HealthDeterminantMeasure" registryId="http://inspire.ec.europa.eu/layer/HH.HealthDeterminantMeasure" tags="//@tags.0 //@tags.2" layerName="HH.HealthDeterminantMeasure" styleConfig="//@styleConfig.27">
     <title lang="en" text="Health determinant measure"/>
     <title text="Messwerte für Gesundheitsfaktoren"/>
     <objectType>hh_4.0:EnvHealthDeterminantMeasure</objectType>
   </layerConfig>
-  <layerConfig name="EL_BreakLine" registryId="http://inspire.ec.europa.eu/layer/EL.BreakLine" tags="//@tags.0 //@tags.2" layerName="EL.BreakLine" styleConfig="//@styleConfig.17">
+  <layerConfig name="HH_HealthDeterminantMeasure_v5" registryId="http://inspire.ec.europa.eu/layer/HH.HealthDeterminantMeasure" tags="//@tags.0 //@tags.2" layerName="HH.HealthDeterminantMeasure" styleConfig="//@styleConfig.28">
+    <title lang="en" text="Health determinant measure"/>
+    <title text="Messwerte für Gesundheitsfaktoren"/>
+    <objectType>hh_5.0:EnvHealthDeterminantMeasure</objectType>
+  </layerConfig>
+  <layerConfig name="EL_BreakLine" registryId="http://inspire.ec.europa.eu/layer/EL.BreakLine" tags="//@tags.0 //@tags.2" layerName="EL.BreakLine" styleConfig="//@styleConfig.26">
     <title lang="en" text="Break Line"/>
     <title text="Bruchkante"/>
     <objectType>el-vec_4.0:BreakLine</objectType>
   </layerConfig>
-  <layerConfig name="EL_ContourLine" registryId="http://inspire.ec.europa.eu/layer/EL.ContourLine" tags="//@tags.0 //@tags.2" layerName="EL.ContourLine" styleConfig="//@styleConfig.16">
+  <layerConfig name="EL_ContourLine" registryId="http://inspire.ec.europa.eu/layer/EL.ContourLine" tags="//@tags.0 //@tags.2" layerName="EL.ContourLine" styleConfig="//@styleConfig.25">
     <title lang="en" text="Contour Line"/>
     <title text="Höhenlinie"/>
     <objectType>el-vec_4.0:ContourLine</objectType>
   </layerConfig>
-  <layerConfig name="EL_IsolatedArea" registryId="http://inspire.ec.europa.eu/layer/EL.IsolatedArea" tags="//@tags.0 //@tags.2" layerName="EL.IsolatedArea" styleConfig="//@styleConfig.15">
+  <layerConfig name="EL_IsolatedArea" registryId="http://inspire.ec.europa.eu/layer/EL.IsolatedArea" tags="//@tags.0 //@tags.2" layerName="EL.IsolatedArea" styleConfig="//@styleConfig.24">
     <title lang="en" text="Isolated Area"/>
     <title text="Abgesondertes Gebiet"/>
     <objectType>el-vec_4.0:IsolatedArea</objectType>
   </layerConfig>
-  <layerConfig name="EL_SpotElevation" registryId="http://inspire.ec.europa.eu/layer/EL.SpotElevation" tags="//@tags.0 //@tags.2" layerName="EL.SpotElevation" styleConfig="//@styleConfig.14">
+  <layerConfig name="EL_SpotElevation" registryId="http://inspire.ec.europa.eu/layer/EL.SpotElevation" tags="//@tags.0 //@tags.2" layerName="EL.SpotElevation" styleConfig="//@styleConfig.23">
     <title lang="en" text="Spot Elevation"/>
     <title text="Höhenlagenpunkt"/>
     <objectType>el-vec_4.0:SpotElevation</objectType>
   </layerConfig>
-  <layerConfig name="EL_VoidArea" registryId="http://inspire.ec.europa.eu/layer/EL.VoidArea" tags="//@tags.0 //@tags.2" layerName="EL.VoidArea" styleConfig="//@styleConfig.13">
+  <layerConfig name="EL_VoidArea" registryId="http://inspire.ec.europa.eu/layer/EL.VoidArea" tags="//@tags.0 //@tags.2" layerName="EL.VoidArea" styleConfig="//@styleConfig.22">
     <title lang="en" text="Void Area"/>
     <title text="Leeres Gebiet"/>
     <objectType>el-vec_4.0:VoidArea</objectType>
   </layerConfig>
-  <layerConfig name="EL_ContourLineType" registryId="" tags="//@tags.0 //@tags.2" layerName="EL.ContourLineType" styleConfig="//@styleConfig.12">
+  <layerConfig name="EL_ContourLineType" registryId="" tags="//@tags.0 //@tags.2" layerName="EL.ContourLineType" styleConfig="//@styleConfig.21">
     <title lang="en" text="Contour Line Type"/>
     <title text="Höhenlinie"/>
     <objectType>el-vec_4.0:ContourLine</objectType>
   </layerConfig>
-  <layerConfig name="EL_TIN" registryId="http://inspire.ec.europa.eu/layer/EL.ElevationTIN" tags="//@tags.0" layerName="EL.ElevationTIN" styleConfig="//@styleConfig.11">
+  <layerConfig name="EL_TIN" registryId="http://inspire.ec.europa.eu/layer/EL.ElevationTIN" tags="//@tags.0" layerName="EL.ElevationTIN" styleConfig="//@styleConfig.20">
     <title lang="en" text="Elevation TIN"/>
     <title text="Höhenlagenstruktur-TIN"/>
     <objectType>el-tin_4.0:ElevationTIN</objectType>
   </layerConfig>
-  <layerConfig name="SD_SpeciesDistribution" registryId="" tags="//@tags.0 //@tags.2" layerName="SD.SpeciesDistribution" styleConfig="//@styleConfig.10">
+  <layerConfig name="SD_SpeciesDistribution" registryId="" tags="//@tags.0 //@tags.2" layerName="SD.SpeciesDistribution" styleConfig="//@styleConfig.19">
     <title lang="en" text="Species Distribution"/>
     <title text="Verteilung der Arten"/>
     <objectType>sd_4.0:SpeciesDistributionUnit</objectType>
   </layerConfig>
-  <layerConfig name="TN_RO_RoadNode" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.RoadNode" styleConfig="//@styleConfig.9">
+  <layerConfig name="TN_RO_RoadNode" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.RoadNode" styleConfig="//@styleConfig.17">
     <title lang="en" text="Road Node"/>
     <title text="Strassenknotenpunkt"/>
     <objectType>tn-ro_4.0:RoadNode</objectType>
+  </layerConfig>
+  <layerConfig name="TN_RO_RoadNode_v5" registryId="" tags="//@tags.0 //@tags.2" layerName="TN.RoadNode" styleConfig="//@styleConfig.18">
+    <title lang="en" text="Road Node"/>
+    <title text="Strassenknotenpunkt"/>
+    <objectType>tn-ro_5.0:RoadNode</objectType>
   </layerConfig>
   <layerConfig name="SF_SpatialSamplingFeature" registryId="" tags="//@tags.0 //@tags.2" layerName="SF.SpatialSamplingFeature" styleConfig="//@styleConfig.0">
     <title lang="en" text="Spatial Sampling Feature"/>
@@ -634,29 +897,56 @@
   <styleConfig name="US_UtilityNetworkAppurtenance">
     <remoteStyle featureTypeName="us-net-common_4.0:Appurtenance" url="feature-styles/US_UtilityNetworkAppurtenance.se"/>
   </styleConfig>
+  <styleConfig name="US_UtilityNetworkAppurtenance_v5">
+    <remoteStyle featureTypeName="us-net-common_5.0:Appurtenance" url="feature-styles/US_UtilityNetworkAppurtenance_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="US_UtilityNetworkLink">
     <remoteStyle featureTypeName="us-net-common_4.0:UtilityLink" url="feature-styles/US_UtilityNetworkLink.se"/>
+  </styleConfig>
+  <styleConfig name="US_UtilityNetworkLink_v5">
+    <remoteStyle featureTypeName="us-net-common_5.0:UtilityLink" url="feature-styles/US_UtilityNetworkLink_v5_0.se"/>
   </styleConfig>
   <styleConfig name="US_EnvironmentalManagementFacility">
     <remoteStyle featureTypeName="us-emf_4.0:EnvironmentalManagementFacility" url="feature-styles/US_EnvironmentalManagementFacility.se"/>
   </styleConfig>
+  <styleConfig name="US_EnvironmentalManagementFacility_v5">
+    <remoteStyle featureTypeName="us-emf_5.0:EnvironmentalManagementFacility" url="feature-styles/US_EnvironmentalManagementFacility_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="TN_A_DesignatedPoint">
     <remoteStyle featureTypeName="tn-a_4.0:DesignatedPoint" url="feature-styles/TN_A_DesignatedPoint.se"/>
+  </styleConfig>
+  <styleConfig name="TN_A_DesignatedPoint_v5">
+    <remoteStyle featureTypeName="tn-a_5.0:DesignatedPoint" url="feature-styles/TN_A_DesignatedPoint_v5_0.se"/>
   </styleConfig>
   <styleConfig name="TN_A_Navaid">
     <remoteStyle featureTypeName="tn-a_4.0:Navaid" url="feature-styles/TN_A_Navaid.se"/>
   </styleConfig>
+  <styleConfig name="TN_A_Navaid_v5">
+    <remoteStyle featureTypeName="tn-a_5.0:Navaid" url="feature-styles/TN_A_Navaid_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="TN_A_RunwayCentrelinePoint">
     <remoteStyle featureTypeName="tn-a_4.0:RunwayCentrelinePoint" url="feature-styles/TN_A_RunwayCentrelinePoint.se"/>
+  </styleConfig>
+  <styleConfig name="TN_A_RunwayCentrelinePoint_v5">
+    <remoteStyle featureTypeName="tn-a_5.0:RunwayCentrelinePoint" url="feature-styles/TN_A_RunwayCentrelinePoint_v5_0.se"/>
   </styleConfig>
   <styleConfig name="TN_A_AerodromeNode">
     <remoteStyle featureTypeName="tn-a_4.0:AerodromeNode" url="feature-styles/TN_A_AerodromeNode.se"/>
   </styleConfig>
+  <styleConfig name="TN_A_AerodromeNode_v5">
+    <remoteStyle featureTypeName="tn-a_5.0:AerodromeNode" url="feature-styles/TN_A_AerodromeNode_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="TN_A_TouchDownLiftOff">
     <remoteStyle featureTypeName="tn-a_4.0:TouchDownLiftOff" url="feature-styles/TN_A_TouchDownLiftOff.se"/>
   </styleConfig>
+  <styleConfig name="TN_A_TouchDownLiftOff_v5">
+    <remoteStyle featureTypeName="tn-a_5.0:TouchDownLiftOff" url="feature-styles/TN_A_TouchDownLiftOff_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="TN_RO_RoadNode">
     <remoteStyle featureTypeName="tn-ro_4.0:RoadNode" url="feature-styles/TN_RO_RoadNode.se"/>
+  </styleConfig>
+  <styleConfig name="TN_RO_RoadNode_v5">
+    <remoteStyle featureTypeName="tn-ro_5.0:RoadNode" url="feature-styles/TN_RO_RoadNode_v5_0.se"/>
   </styleConfig>
   <styleConfig name="SD_SpeciesDistribution">
     <remoteStyle featureTypeName="sd_4.0:SpeciesDistributionUnit" url="feature-styles/SD_SpeciesDistribution.se"/>
@@ -684,6 +974,9 @@
   </styleConfig>
   <styleConfig name="HH_HealthDeterminantMeasure">
     <remoteStyle featureTypeName="hh_4.0:EnvHealthDeterminantMeasure" url="feature-styles/HH_HealthDeterminantMeasure.se"/>
+  </styleConfig>
+  <styleConfig name="HH_HealthDeterminantMeasure_v5">
+    <remoteStyle featureTypeName="hh_5.0:EnvHealthDeterminantMeasure" url="feature-styles/HH_HealthDeterminantMeasure_v5_0.se"/>
   </styleConfig>
   <styleConfig name="SU_VectorStatisticalUnit">
     <remoteStyle featureTypeName="su-vector_4.0:VectorStatisticalUnit" url="feature-styles/SU_VectorStatisticalUnit.se"/>
@@ -724,17 +1017,32 @@
   <styleConfig name="TN_W_TrafficSeparationSchemeSeparator">
     <remoteStyle featureTypeName="tn-w_4.0:TrafficSeparationSchemeSeparator" url="feature-styles/TN_W_TrafficSeparationSchemeSeparator.se"/>
   </styleConfig>
+  <styleConfig name="TN_W_TrafficSeparationSchemeSeparator_v5">
+    <remoteStyle featureTypeName="tn-w_5.0:TrafficSeparationSchemeSeparator" url="feature-styles/TN_W_TrafficSeparationSchemeSeparator_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="TN_W_TrafficSeparationSchemeCrossing">
     <remoteStyle featureTypeName="tn-w_4.0:TrafficSeparationSchemeCrossing" url="feature-styles/TN_W_TrafficSeparationSchemeCrossing.se"/>
+  </styleConfig>
+  <styleConfig name="TN_W_TrafficSeparationSchemeCrossing_v5">
+    <remoteStyle featureTypeName="tn-w_5.0:TrafficSeparationSchemeCrossing" url="feature-styles/TN_W_TrafficSeparationSchemeCrossing_v5_0.se"/>
   </styleConfig>
   <styleConfig name="TN_W_Buoy">
     <remoteStyle featureTypeName="tn-w_4.0:Buoy" url="feature-styles/TN_W_Buoy.se"/>
   </styleConfig>
+  <styleConfig name="TN_W_Buoy_v5">
+    <remoteStyle featureTypeName="tn-w_5.0:Buoy" url="feature-styles/TN_W_Buoy_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="TN_W_Beacon">
     <remoteStyle featureTypeName="tn-w_4.0:Beacon" url="feature-styles/TN_W_Beacon.se"/>
   </styleConfig>
+  <styleConfig name="TN_W_Beacon_v5">
+    <remoteStyle featureTypeName="tn-w_5.0:Beacon" url="feature-styles/TN_W_Beacon_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="TN_MarkerPost">
     <remoteStyle featureTypeName="tn_4.0:MarkerPost" url="feature-styles/TN_MarkerPost.se"/>
+  </styleConfig>
+  <styleConfig name="TN_MarkerPost_v5">
+    <remoteStyle featureTypeName="tn_5.0:MarkerPost" url="feature-styles/TN_MarkerPost_v5_0.se"/>
   </styleConfig>
   <styleConfig name="NZ_ObservedEvent">
     <remoteStyle featureTypeName="nz-core_4.0:ObservedEvent" url="feature-styles/NZ_ObservedEvent.se"/>
@@ -817,6 +1125,9 @@
   <styleConfig name="US_GovernmentalService">
     <remoteStyle featureTypeName="us-govserv_4.0:GovernmentalService" url="feature-styles/US_GovernmentalService.se"/>
   </styleConfig>
+  <styleConfig name="US_GovernmentalService_v5">
+    <remoteStyle featureTypeName="us-govserv_5.0:GovernmentalService" url="feature-styles/US_GovernmentalService_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="LU_SupplementaryRegulation">
     <remoteStyle featureTypeName="plu_4.0:SupplementaryRegulation" url="feature-styles/LU_SupplementaryRegulation.se"/>
   </styleConfig>
@@ -886,65 +1197,128 @@
   <styleConfig name="HY_N_WatercourseLink">
     <remoteStyle featureTypeName="hy-n_4.0:WatercourseLink" url="feature-styles/HY_N_WatercourseLink.se"/>
   </styleConfig>
+  <styleConfig name="HY_N_WatercourseLink_v5">
+    <remoteStyle featureTypeName="hy-n_5.0:WatercourseLink" url="feature-styles/HY_N_WatercourseLink_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="HY_N_HydroNode">
     <remoteStyle featureTypeName="hy-n_4.0:HydroNode" url="feature-styles/HY_N_HydroNode.se"/>
+  </styleConfig>
+  <styleConfig name="HY_N_HydroNode_v5">
+    <remoteStyle featureTypeName="hy-n_5.0:HydroNode" url="feature-styles/HY_N_HydroNode_v5_0.se"/>
   </styleConfig>
   <styleConfig name="HY_P_DrainageBasin">
     <remoteStyle featureTypeName="hy-p_4.0:DrainageBasin" url="feature-styles/HY_P_DrainageBasin.se"/>
   </styleConfig>
+  <styleConfig name="HY_P_DrainageBasin_v5">
+    <remoteStyle featureTypeName="hy-p_5.0:DrainageBasin" url="feature-styles/HY_P_DrainageBasin_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="HY_P_RiverBasin">
     <remoteStyle featureTypeName="hy-p_4.0:RiverBasin" url="feature-styles/HY_P_RiverBasin.se"/>
+  </styleConfig>
+  <styleConfig name="HY_P_RiverBasin_v5">
+    <remoteStyle featureTypeName="hy-p_5.0:RiverBasin" url="feature-styles/HY_P_RiverBasin_v5_0.se"/>
   </styleConfig>
   <styleConfig name="HY_P_Rapids">
     <remoteStyle featureTypeName="hy-p_4.0:Rapids" url="feature-styles/HY_P_Rapids.se"/>
   </styleConfig>
+  <styleConfig name="HY_P_Rapids_v5">
+    <remoteStyle featureTypeName="hy-p_5.0:Rapids" url="feature-styles/HY_P_Rapids_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="HY_P_Falls">
     <remoteStyle featureTypeName="hy-p_4.0:Falls" url="feature-styles/HY_P_Falls.se"/>
+  </styleConfig>
+  <styleConfig name="HY_P_Falls_v5">
+    <remoteStyle featureTypeName="hy-p_5.0:Falls" url="feature-styles/HY_P_Falls_v5_0.se"/>
   </styleConfig>
   <styleConfig name="HY_P_LandWaterBoundary">
     <remoteStyle featureTypeName="hy-p_4.0:LandWaterBoundary" url="feature-styles/HY_P_LandWaterBoundary.se"/>
   </styleConfig>
+  <styleConfig name="HY_P_LandWaterBoundary_v5">
+    <remoteStyle featureTypeName="hy-p_5.0:LandWaterBoundary" url="feature-styles/HY_P_LandWaterBoundary_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="HY_P_Crossing">
     <remoteStyle featureTypeName="hy-p_4.0:Crossing" url="feature-styles/HY_P_Crossing.se"/>
+  </styleConfig>
+  <styleConfig name="HY_P_Crossing_v5">
+    <remoteStyle featureTypeName="hy-p_5.0:Crossing" url="feature-styles/HY_P_Crossing_v5_0.se"/>
   </styleConfig>
   <styleConfig name="HY_P_DamOrWeir">
     <remoteStyle featureTypeName="hy-p_4.0:DamOrWeir" url="feature-styles/HY_P_DamOrWeir.se"/>
   </styleConfig>
+  <styleConfig name="HY_P_DamOrWeir_v5">
+    <remoteStyle featureTypeName="hy-p_5.0:DamOrWeir" url="feature-styles/HY_P_DamOrWeir_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="HY_P_ShoreLineConstruction">
     <remoteStyle featureTypeName="hy-p_4.0:ShorelineConstruction" url="feature-styles/HY_P_ShoreLineConstruction.se"/>
+  </styleConfig>
+  <styleConfig name="HY_P_ShoreLineConstruction_v5">
+    <remoteStyle featureTypeName="hy-p_5.0:ShorelineConstruction" url="feature-styles/HY_P_ShoreLineConstruction_v5_0.se"/>
   </styleConfig>
   <styleConfig name="HY_P_Ford">
     <remoteStyle featureTypeName="hy-p_4.0:Ford" url="feature-styles/HY_P_Ford.se"/>
   </styleConfig>
+  <styleConfig name="HY_P_Ford_v5">
+    <remoteStyle featureTypeName="hy-p_5.0:Ford" url="feature-styles/HY_P_Ford_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="HY_P_Lock">
     <remoteStyle featureTypeName="hy-p_4.0:Lock" url="feature-styles/HY_P_Lock.se"/>
+  </styleConfig>
+  <styleConfig name="HY_P_Lock_v5">
+    <remoteStyle featureTypeName="hy-p_5.0:Lock" url="feature-styles/HY_P_Lock_v5_0.se"/>
   </styleConfig>
   <styleConfig name="HY_P_Shore">
     <remoteStyle featureTypeName="hy-p_4.0:Shore" url="feature-styles/HY_P_Shore.se"/>
   </styleConfig>
+  <styleConfig name="HY_P_Shore_v5">
+    <remoteStyle featureTypeName="hy-p_5.0:Shore" url="feature-styles/HY_P_Shore_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="HY_P_Watercourse">
     <remoteStyle featureTypeName="hy-p_4.0:Watercourse" url="feature-styles/HY_P_Watercourse.se"/>
+  </styleConfig>
+  <styleConfig name="HY_P_Watercourse_v5">
+    <remoteStyle featureTypeName="hy-p_5.0:Watercourse" url="feature-styles/HY_P_Watercourse_v5_0.se"/>
   </styleConfig>
   <styleConfig name="HY_P_StandingWater">
     <remoteStyle featureTypeName="hy-p_4.0:StandingWater" url="feature-styles/HY_P_StandingWater.se"/>
   </styleConfig>
+  <styleConfig name="HY_P_StandingWater_v5">
+    <remoteStyle featureTypeName="hy-p_5.0:StandingWater" url="feature-styles/HY_P_StandingWater_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="HY_P_Watercourse_ManMade">
     <remoteStyle featureTypeName="hy-p_4.0:Watercourse" url="feature-styles/HY_P_Watercourse_ManMade.se"/>
+  </styleConfig>
+  <styleConfig name="HY_P_Watercourse_ManMade_v5">
+    <remoteStyle featureTypeName="hy-p_5.0:Watercourse" url="feature-styles/HY_P_Watercourse_ManMade_v5_0.se"/>
   </styleConfig>
   <styleConfig name="HY_P_StandingWater_ManMade">
     <remoteStyle featureTypeName="hy-p_4.0:StandingWater" url="feature-styles/HY_P_StandingWater_ManMade.se"/>
   </styleConfig>
+  <styleConfig name="HY_P_StandingWater_ManMade_v5">
+    <remoteStyle featureTypeName="hy-p_5.0:StandingWater" url="feature-styles/HY_P_StandingWater_ManMade_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="HY_P_WatercoursePersistence">
     <remoteStyle featureTypeName="hy-p_4.0:Watercourse" url="feature-styles/HY_P_WatercoursePersistence.se"/>
+  </styleConfig>
+  <styleConfig name="HY_P_WatercoursePersistence_v5">
+    <remoteStyle featureTypeName="hy-p_5.0:Watercourse" url="feature-styles/HY_P_WatercoursePersistence_v5_0.se"/>
   </styleConfig>
   <styleConfig name="HY_P_WaterbodiesPersistence">
     <remoteStyle featureTypeName="hy-p_4.0:StandingWater" url="feature-styles/HY_P_WaterbodiesPersistence.se"/>
   </styleConfig>
+  <styleConfig name="HY_P_WaterbodiesPersistence_v5">
+    <remoteStyle featureTypeName="hy-p_5.0:StandingWater" url="feature-styles/HY_P_WaterbodiesPersistence_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="HY_P_Wetland">
     <remoteStyle featureTypeName="hy-p_4.0:Wetland" url="feature-styles/HY_P_Wetland.se"/>
   </styleConfig>
+  <styleConfig name="HY_P_Wetland_v5">
+    <remoteStyle featureTypeName="hy-p_5.0:Wetland" url="feature-styles/HY_P_Wetland_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="PS_ProtectedSite">
     <remoteStyle featureTypeName="ps_4.0:ProtectedSite" url="feature-styles/PS_ProtectedSites.se"/>
+  </styleConfig>
+  <styleConfig name="PS_ProtectedSite_v5">
+    <remoteStyle featureTypeName="ps_5.0:ProtectedSite" url="feature-styles/PS_ProtectedSites_v5_0.se"/>
   </styleConfig>
   <styleConfig name="PS_ProtectedSite_v5">
     <remoteStyle featureTypeName="ps_5.0:ProtectedSite" url="feature-styles/PS_ProtectedSites_v5.se"/>
@@ -952,74 +1326,146 @@
   <styleConfig name="TN_A_AerodromeArea">
     <remoteStyle featureTypeName="tn-a_4.0:AerodromeArea" url="feature-styles/TN_A_AerodromeArea.se"/>
   </styleConfig>
+  <styleConfig name="TN_A_AerodromeArea_v5">
+    <remoteStyle featureTypeName="tn-a_5.0:AerodromeArea" url="feature-styles/TN_A_AerodromeArea_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="TN_A_ProcedureLink">
     <remoteStyle featureTypeName="tn-a_4.0:ProcedureLink" url="feature-styles/TN_A_ProcedureLink.se"/>
+  </styleConfig>
+  <styleConfig name="TN_A_ProcedureLink_v5">
+    <remoteStyle featureTypeName="tn-a_5.0:ProcedureLink" url="feature-styles/TN_A_ProcedureLink_v5_0.se"/>
   </styleConfig>
   <styleConfig name="TN_A_AirRouteLink">
     <remoteStyle featureTypeName="tn-a_4.0:AirRouteLink" url="feature-styles/TN_A_AirRouteLink.se"/>
   </styleConfig>
+  <styleConfig name="TN_A_AirRouteLink_v5">
+    <remoteStyle featureTypeName="tn-a_5.0:AirRouteLink" url="feature-styles/TN_A_AirRouteLink_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="TN_A_AirspaceArea">
     <remoteStyle featureTypeName="tn-a_4.0:AirspaceArea" url="feature-styles/TN_A_AirspaceArea.se"/>
+  </styleConfig>
+  <styleConfig name="TN_A_AirspaceArea_v5">
+    <remoteStyle featureTypeName="tn-a_5.0:AirspaceArea" url="feature-styles/TN_A_AirspaceArea_v5_0.se"/>
   </styleConfig>
   <styleConfig name="TN_A_ApronArea">
     <remoteStyle featureTypeName="tn-a_4.0:ApronArea" url="feature-styles/TN_A_ApronArea.se"/>
   </styleConfig>
+  <styleConfig name="TN_A_ApronArea_v5">
+    <remoteStyle featureTypeName="tn-a_5.0:ApronArea" url="feature-styles/TN_A_ApronArea_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="TN_A_RunwayArea">
     <remoteStyle featureTypeName="tn-a_4.0:RunwayArea" url="feature-styles/TN_A_RunwayArea.se"/>
+  </styleConfig>
+  <styleConfig name="TN_A_RunwayArea_v5">
+    <remoteStyle featureTypeName="tn-a_5.0:RunwayArea" url="feature-styles/TN_A_RunwayArea_v5_0.se"/>
   </styleConfig>
   <styleConfig name="TN_A_TaxiwayArea">
     <remoteStyle featureTypeName="tn-a_4.0:TaxiwayArea" url="feature-styles/TN_A_TaxiwayArea.se"/>
   </styleConfig>
+  <styleConfig name="TN_A_TaxiwayArea_v5">
+    <remoteStyle featureTypeName="tn-a_5.0:TaxiwayArea" url="feature-styles/TN_A_TaxiwayArea_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="TN_C_CablewayLink">
     <remoteStyle featureTypeName="tn-c_4.0:CablewayLink" url="feature-styles/TN_C_CablewayLink.se"/>
+  </styleConfig>
+  <styleConfig name="TN_C_CablewayLink_v5">
+    <remoteStyle featureTypeName="tn-c_5.0:CablewayLink" url="feature-styles/TN_C_CablewayLink_v5_0.se"/>
   </styleConfig>
   <styleConfig name="TN_TransportArea">
     <remoteStyle featureTypeName="tn_4.0:TransportArea" url="feature-styles/TN_TransportArea.se"/>
   </styleConfig>
+  <styleConfig name="TN_TransportArea_v5">
+    <remoteStyle featureTypeName="tn_5.0:TransportArea" url="feature-styles/TN_TransportArea_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="TN_TransportLink">
     <remoteStyle featureTypeName="tn_4.0:TransportLink" url="feature-styles/TN_TransportLink.se"/>
+  </styleConfig>
+  <styleConfig name="TN_TransportLink_v5">
+    <remoteStyle featureTypeName="tn_5.0:TransportLink" url="feature-styles/TN_TransportLink_v5_0.se"/>
   </styleConfig>
   <styleConfig name="TN_TransportNode">
     <remoteStyle featureTypeName="tn_4.0:TransportNode" url="feature-styles/TN_TransportNode.se"/>
   </styleConfig>
+  <styleConfig name="TN_TransportNode_v5">
+    <remoteStyle featureTypeName="tn_5.0:TransportNode" url="feature-styles/TN_TransportNode_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="TN_RA_RailwayArea">
     <remoteStyle featureTypeName="tn-ra_4.0:RailwayArea" url="feature-styles/TN_RA_RailwayArea.se"/>
+  </styleConfig>
+  <styleConfig name="TN_RA_RailwayArea_v5">
+    <remoteStyle featureTypeName="tn-ra_5.0:RailwayArea" url="feature-styles/TN_RA_RailwayArea_v5_0.se"/>
   </styleConfig>
   <styleConfig name="TN_RA_RailwayLink">
     <remoteStyle featureTypeName="tn-ra_4.0:RailwayLink" url="feature-styles/TN_RA_RailwayLink.se"/>
   </styleConfig>
+  <styleConfig name="TN_RA_RailwayLink_v5">
+    <remoteStyle featureTypeName="tn-ra_5.0:RailwayLink" url="feature-styles/TN_RA_RailwayLink_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="TN_RA_RailwayStationArea">
     <remoteStyle featureTypeName="tn-ra_4.0:RailwayStationArea" url="feature-styles/TN_RA_RailwayStationArea.se"/>
+  </styleConfig>
+  <styleConfig name="TN_RA_RailwayStationArea_v5">
+    <remoteStyle featureTypeName="tn-ra_5.0:RailwayStationArea" url="feature-styles/TN_RA_RailwayStationArea_v5_0.se"/>
   </styleConfig>
   <styleConfig name="TN_RA_RailwayYardArea">
     <remoteStyle featureTypeName="tn-ra_4.0:RailwayYardArea" url="feature-styles/TN_RA_RailwayYardArea.se"/>
   </styleConfig>
+  <styleConfig name="TN_RA_RailwayYardArea_v5">
+    <remoteStyle featureTypeName="tn-ra_5.0:RailwayYardArea" url="feature-styles/TN_RA_RailwayYardArea_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="TN_RO_RoadArea">
     <remoteStyle featureTypeName="tn-ro_4.0:RoadArea" url="feature-styles/TN_RO_RoadArea.se"/>
+  </styleConfig>
+  <styleConfig name="TN_RO_RoadArea_v5">
+    <remoteStyle featureTypeName="tn-ro_5.0:RoadArea" url="feature-styles/TN_RO_RoadArea_v5_0.se"/>
   </styleConfig>
   <styleConfig name="TN_RO_RoadLink">
     <remoteStyle featureTypeName="tn-ro_4.0:RoadLink" url="feature-styles/TN_RO_RoadLink.se"/>
   </styleConfig>
+  <styleConfig name="TN_RO_RoadLink_v5">
+    <remoteStyle featureTypeName="tn-ro_5.0:RoadLink" url="feature-styles/TN_RO_RoadLink_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="TN_RO_RoadServiceArea">
     <remoteStyle featureTypeName="tn-ro_4.0:RoadServiceArea" url="feature-styles/TN_RO_RoadServiceArea.se"/>
+  </styleConfig>
+  <styleConfig name="TN_RO_RoadServiceArea_v5">
+    <remoteStyle featureTypeName="tn-ro_5.0:RoadServiceArea" url="feature-styles/TN_RO_RoadServiceArea_v5_0.se"/>
   </styleConfig>
   <styleConfig name="TN_RO_VehicleTrafficArea">
     <remoteStyle featureTypeName="tn-ro_4.0:VehicleTrafficArea" url="feature-styles/TN_RO_VehicleTrafficArea.se"/>
   </styleConfig>
+  <styleConfig name="TN_RO_VehicleTrafficArea_v5">
+    <remoteStyle featureTypeName="tn-ro_5.0:VehicleTrafficArea" url="feature-styles/TN_RO_VehicleTrafficArea_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="TN_W_FairwayArea">
     <remoteStyle featureTypeName="tn-w_4.0:FairwayArea" url="feature-styles/TN_W_FairwayArea.se"/>
+  </styleConfig>
+  <styleConfig name="TN_W_FairwayArea_v5">
+    <remoteStyle featureTypeName="tn-w_5.0:FairwayArea" url="feature-styles/TN_W_FairwayArea_v5_0.se"/>
   </styleConfig>
   <styleConfig name="TN_W_PortArea">
     <remoteStyle featureTypeName="tn-w_4.0:PortArea" url="feature-styles/TN_W_PortArea.se"/>
   </styleConfig>
+  <styleConfig name="TN_W_PortArea_v5">
+    <remoteStyle featureTypeName="tn-w_5.0:PortArea" url="feature-styles/TN_W_PortArea_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="TN_W_WaterwayLink">
     <remoteStyle featureTypeName="tn-w_4.0:WaterwayLink" url="feature-styles/TN_W_WaterwayLink.se"/>
+  </styleConfig>
+  <styleConfig name="TN_W_WaterwayLink_v5">
+    <remoteStyle featureTypeName="tn-w_5.0:WaterwayLink" url="feature-styles/TN_W_WaterwayLink_v5_0.se"/>
   </styleConfig>
   <styleConfig name="LC_LandCoverSurfaces">
     <remoteStyle featureTypeName="lcv_4.0:LandCoverUnit" url="feature-styles/LC_LandCoverSurfaces.se"/>
   </styleConfig>
+  <styleConfig name="LC_LandCoverSurfaces_v5">
+    <remoteStyle featureTypeName="lcv_5.0:LandCoverUnit" url="feature-styles/LC_LandCoverSurfaces_v5_0.se"/>
+  </styleConfig>
   <styleConfig name="LC_LandCoverPoints">
     <remoteStyle featureTypeName="lcv_4.0:LandCoverUnit" url="feature-styles/LC_LandCoverPoints.se"/>
+  </styleConfig>
+  <styleConfig name="LC_LandCoverPoints_v5">
+    <remoteStyle featureTypeName="lcv_5.0:LandCoverUnit" url="feature-styles/LC_LandCoverPoints_v5_0.se"/>
   </styleConfig>
   <styleConfig name="BU_Building">
     <remoteStyle featureTypeName="bu-core2d_4.0:Building" url="feature-styles/BU_Building.se"/>

--- a/generated/feature-styles/HH_HealthDeterminantMeasure_v5_0.se
+++ b/generated/feature-styles/HH_HealthDeterminantMeasure_v5_0.se
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:hh="http://inspire.ec.europa.eu/schemas/hh/5.0" 
+xmlns:ogc="http://www.opengis.net/ogc" 
+xmlns:se="http://www.opengis.net/se" 
+xmlns:sld="http://www.opengis.net/sld" 
+xmlns:xlink="http://www.w3.org/1999/xlink" 
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+version="1.1.0" xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd">
+  <se:Name>HH.HealthDeterminantMeasure.Default</se:Name>
+  <se:Description>
+    <se:Title>Health Determinant Measure Default Style</se:Title>
+    <se:Abstract>Geometries are rendered in solid blue (#0000FF) outline with a stroke width of 1 pixel.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>hh:EnvHealthDeterminantMeasure</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Human health: polygons</se:Title>
+    </se:Description>
+    <ogc:Filter>
+    	<ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsSurface">
+        		<ogc:PropertyName>hh:location</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+   	</ogc:Filter>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hh:location</ogc:PropertyName>
+      </se:Geometry>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#0000FF</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">3</se:SvgParameter>
+      </se:Stroke>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Human health: lines</se:Title>
+    </se:Description>
+    <ogc:Filter>
+    	<ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsCurve">
+        		<ogc:PropertyName>hh:location</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+   	</ogc:Filter>
+    <se:LineSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hh:location</ogc:PropertyName>
+      </se:Geometry>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#0000FF</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">3</se:SvgParameter>
+      </se:Stroke>
+    </se:LineSymbolizer>
+  </se:Rule>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Human health: points</se:Title>
+    </se:Description>
+    <ogc:Filter>
+    	<ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsPoint">
+        		<ogc:PropertyName>hh:location</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+   	</ogc:Filter>
+    <se:PointSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hh:location</ogc:PropertyName>
+      </se:Geometry>
+      <se:Graphic>
+        <se:Mark>
+          <se:WellKnownName>circle</se:WellKnownName>
+          <se:Fill>
+            <se:SvgParameter name="fill">#0000FF</se:SvgParameter>
+          </se:Fill>
+          <se:Stroke>
+            <se:SvgParameter name="stroke">#0000FF</se:SvgParameter>
+            <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+          </se:Stroke>
+        </se:Mark>
+        <se:Size>3</se:Size>
+      </se:Graphic>
+    </se:PointSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/generated/feature-styles/HY_N_HydroNode_v5_0.se
+++ b/generated/feature-styles/HY_N_HydroNode_v5_0.se
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:hy-n="http://inspire.ec.europa.eu/schemas/hy-n/5.0" 
+xmlns:net="http://inspire.ec.europa.eu/schemas/net/5.0" xmlns:ogc="http://www.opengis.net/ogc" 
+xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:xlink="http://www.w3.org/1999/xlink" 
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd"
+version="1.1.0">
+  <se:Name>HY.Network.Default</se:Name>
+  <se:Description>
+    <se:Title>Hydrographic Network Default Style</se:Title>
+    <se:Abstract>Hydrographic network where the hydro node category depends to outlet, junction and source is rendered by solid blue (#33CCFF) lines with stroke width of 1 pixel and 3 pixel size filled light blue (#CCFFFF) circles with black (#000000) border. Hydrographic network where the hydro node category depends to flow constriction and regulation is rendered by 3 pixel size filled black circles (#000000). Hydrographic network where the hydro node category depends to boundary is rendered by 3 pixel size filled red circles (#FF0000) with black (#000000) border.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>hy-n:HydroNode</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Hydro node default</se:Title>
+    </se:Description>
+    <se:PointSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>net:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Graphic>
+        <se:Mark>
+          <se:WellKnownName>circle</se:WellKnownName>
+          <se:Fill>
+            <se:SvgParameter name="fill">#000000</se:SvgParameter>
+          </se:Fill>
+          <se:Stroke>
+            <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+          </se:Stroke>
+        </se:Mark>
+        <se:Size>3</se:Size>
+      </se:Graphic>
+    </se:PointSymbolizer>
+  </se:Rule>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Hydro node outlet, junction or source</se:Title>
+    </se:Description>
+    <ogc:Filter>
+      <ogc:Or>
+        <ogc:PropertyIsEqualTo>
+          <ogc:PropertyName>hy-n:hydroNodeCategory/@xlink:href</ogc:PropertyName>
+          <ogc:Literal>http://inspire.ec.europa.eu/codelist/HydroNodeCategoryValue/outlet</ogc:Literal>
+        </ogc:PropertyIsEqualTo>
+        <ogc:PropertyIsEqualTo>
+          <ogc:PropertyName>hy-n:hydroNodeCategory/@xlink:href</ogc:PropertyName>
+          <ogc:Literal>http://inspire.ec.europa.eu/codelist/HydroNodeCategoryValue/junction</ogc:Literal>
+        </ogc:PropertyIsEqualTo>
+        <ogc:PropertyIsEqualTo>
+          <ogc:PropertyName>hy-n:hydroNodeCategory/@xlink:href</ogc:PropertyName>
+          <ogc:Literal>http://inspire.ec.europa.eu/codelist/HydroNodeCategoryValue/source</ogc:Literal>
+        </ogc:PropertyIsEqualTo>
+      </ogc:Or>
+    </ogc:Filter>
+    <se:PointSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>net:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Graphic>
+        <se:Mark>
+          <se:WellKnownName>circle</se:WellKnownName>
+          <se:Fill>
+            <se:SvgParameter name="fill">#CCFFFF</se:SvgParameter>
+          </se:Fill>
+          <se:Stroke>
+            <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+          </se:Stroke>
+        </se:Mark>
+        <se:Size>3</se:Size>
+      </se:Graphic>
+    </se:PointSymbolizer>
+  </se:Rule>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Hydro node flow constriction or regulation</se:Title>
+    </se:Description>
+    <ogc:Filter>
+      <ogc:Or>
+        <ogc:PropertyIsEqualTo>
+          <ogc:PropertyName>hy-n:hydroNodeCategory/@xlink:href</ogc:PropertyName>
+          <ogc:Literal>http://inspire.ec.europa.eu/codelist/HydroNodeCategoryValue/flowConstriction</ogc:Literal>
+        </ogc:PropertyIsEqualTo>
+        <ogc:PropertyIsEqualTo>
+          <ogc:PropertyName>hy-n:hydroNodeCategory/@xlink:href</ogc:PropertyName>
+          <ogc:Literal>http://inspire.ec.europa.eu/codelist/HydroNodeCategoryValue/flowRegulation</ogc:Literal>
+        </ogc:PropertyIsEqualTo>
+      </ogc:Or>
+    </ogc:Filter>
+    <se:PointSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>net:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Graphic>
+        <se:Mark>
+          <se:WellKnownName>circle</se:WellKnownName>
+          <se:Fill>
+            <se:SvgParameter name="fill">#000000</se:SvgParameter>
+          </se:Fill>
+        </se:Mark>
+        <se:Size>3</se:Size>
+      </se:Graphic>
+    </se:PointSymbolizer>
+  </se:Rule>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Hydro node boundary</se:Title>
+    </se:Description>
+    <ogc:Filter>
+      <ogc:PropertyIsEqualTo>
+        <ogc:PropertyName>hy-n:hydroNodeCategory/@xlink:href</ogc:PropertyName>
+        <ogc:Literal>http://inspire.ec.europa.eu/codelist/HydroNodeCategoryValue/boundary</ogc:Literal>
+      </ogc:PropertyIsEqualTo>
+    </ogc:Filter>
+    <se:PointSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>net:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Graphic>
+        <se:Mark>
+          <se:WellKnownName>circle</se:WellKnownName>
+          <se:Fill>
+            <se:SvgParameter name="fill">#FF0000</se:SvgParameter>
+          </se:Fill>
+          <se:Stroke>
+            <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+          </se:Stroke>
+        </se:Mark>
+        <se:Size>3</se:Size>
+      </se:Graphic>
+    </se:PointSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/generated/feature-styles/HY_N_WatercourseLink_v5_0.se
+++ b/generated/feature-styles/HY_N_WatercourseLink_v5_0.se
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:hy-n="http://inspire.ec.europa.eu/schemas/hy-n/5.0" 
+xmlns:net="http://inspire.ec.europa.eu/schemas/net/5.0" xmlns:ogc="http://www.opengis.net/ogc" 
+xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:xlink="http://www.w3.org/1999/xlink" 
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd"
+version="1.1.0">
+  <se:Name>HY.Network.Default</se:Name>
+  <se:Description>
+    <se:Title>Hydrographic Network Default Style</se:Title>
+    <se:Abstract>Hydrographic network where the hydro node category depends to outlet, junction and source is rendered by solid blue (#33CCFF) lines with stroke width of 1 pixel and 3 pixel size filled light blue (#CCFFFF) circles with black (#000000) border. Hydrographic network where the hydro node category depends to flow constriction and regulation is rendered by 3 pixel size filled black circles (#000000). Hydrographic network where the hydro node category depends to boundary is rendered by 3 pixel size filled red circles (#FF0000) with black (#000000) border.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>hy-n:WatercourseLink</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Watercourse link</se:Title>
+    </se:Description>
+    <se:LineSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>net:centrelineGeometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#33CCFF</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+      </se:Stroke>
+    </se:LineSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/generated/feature-styles/HY_P_Crossing_v5_0.se
+++ b/generated/feature-styles/HY_P_Crossing_v5_0.se
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:hy-p="http://inspire.ec.europa.eu/schemas/hy-p/5.0" 
+xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" 
+xmlns:sld="http://www.opengis.net/sld" xmlns:xlink="http://www.w3.org/1999/xlink" 
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd"
+version="1.1.0">
+  <se:Name>HY.PhysicalWaters.ManMadeObject.Default</se:Name>
+  <se:Description>
+    <se:Title>Man-Made Objects Default Style</se:Title>
+    <se:Abstract>There are only depicted the fully functional objects. Punctual objects are depicted with symbols; if the geometry is a curve they are depicted in solid or dashed lines with different stroke width and different colours depending on the feature type; if the geometry is a surface it will be a filled polygon of solid colour adding or not some marks, depending on the feature type. Point geometries of crossings are rendered as a 10 sized picture. Line geometries of crossings are rendered as a grey (#999999) line and a stroke-width of 2 pixel. Polygon geometries of crossings are rendered using a light grey (#CCCCCC) fill and a dark grey (#999999) outline with a stroke width of 2 pixel. Point geometries of dams or weirs are rendered as a 12 sized cross with a light grey (#666666) color. Line geometries of dams or weirs are rendered as a light grey (#666666) line and a stroke-width of 3 pixel. Polygon geometries of dams or weirs are rendered using a dark grey (#999999) fill and a light grey (#666666) outline with a stroke width of 3 pixel. Point geometries of shoreline constructions are rendered as a 10 sized triangle with a light grey (#666666) color. Line geometries of shoreline constructions are rendered as a light grey (#666666) line and a stroke-width of 2 pixel. Polygon geometries of shoreline constructions are rendered using a dark grey (#999999) fill and a light grey (#666666) outline with a stroke width of 2 pixel. Point geometries of fords are rendered as a 3 sized square with a light red (#FFCCCC) color and light blue (#CCFFFF) border and a 50% transparence. Line geometries of fords are rendered as a light red (#FFCCCC) line and a stroke-width of 1 pixel. Polygon geometries of fords are rendered using a light red (#FFCCCC) fill and a 50% transparence. Point geometries of locks are rendered as a 8 sized cross with a light grey (#666666) color. Line geometries of locks are rendered as a light grey (#666666) line and a stroke-width of 1 pixel. Polygon geometries of locks are rendered using a dark grey (#999999) fill and a light grey (#666666) outline with a stroke width of 2 pixel. </se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>hy-p:Crossing</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Crossing</se:Title>
+    </se:Description>
+    <ogc:Filter>
+      <ogc:And>
+        <ogc:PropertyIsEqualTo>
+          <ogc:PropertyName>hy-p:condition/@xlink:href</ogc:PropertyName>
+          <ogc:Literal>http://inspire.ec.europa.eu/codelist/ConditionOfFacilityValue/functional</ogc:Literal>
+        </ogc:PropertyIsEqualTo>
+        <ogc:PropertyIsEqualTo>
+          <ogc:PropertyName>hy-p:type/@xlink:href</ogc:PropertyName>
+          <ogc:Literal>http://inspire.ec.europa.eu/codelist/CrossingTypeValue/bridge</ogc:Literal>
+        </ogc:PropertyIsEqualTo>
+        <ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsPoint">
+        		<ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+      </ogc:And>
+    </ogc:Filter>
+    <se:PointSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Graphic>
+        <se:Mark>
+          <se:WellKnownName>square</se:WellKnownName>
+          <se:Fill>
+            <se:SvgParameter name="fill">#ffffff</se:SvgParameter>
+          </se:Fill>
+          <se:Stroke>
+            <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+            <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+          </se:Stroke>
+        </se:Mark>
+        <se:Size>10.0</se:Size>
+      </se:Graphic>
+    </se:PointSymbolizer>
+    </se:Rule>
+      <se:Rule>
+    <se:Description>
+      <se:Title>Crossing</se:Title>
+    </se:Description>
+    <ogc:Filter>
+      <ogc:And>
+        <ogc:PropertyIsEqualTo>
+          <ogc:PropertyName>hy-p:condition/@xlink:href</ogc:PropertyName>
+          <ogc:Literal>http://inspire.ec.europa.eu/codelist/ConditionOfFacilityValue/functional</ogc:Literal>
+        </ogc:PropertyIsEqualTo>
+        <ogc:PropertyIsEqualTo>
+          <ogc:PropertyName>hy-p:type/@xlink:href</ogc:PropertyName>
+          <ogc:Literal>http://inspire.ec.europa.eu/codelist/CrossingTypeValue/bridge</ogc:Literal>
+        </ogc:PropertyIsEqualTo>
+        <ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsCurve">
+        		<ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+      </ogc:And>
+    </ogc:Filter>
+    <se:LineSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#999999</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">2</se:SvgParameter>
+      </se:Stroke>
+    </se:LineSymbolizer>
+    </se:Rule>
+      <se:Rule>
+    <se:Description>
+      <se:Title>Crossing</se:Title>
+    </se:Description>
+    <ogc:Filter>
+      <ogc:And>
+        <ogc:PropertyIsEqualTo>
+          <ogc:PropertyName>hy-p:condition/@xlink:href</ogc:PropertyName>
+          <ogc:Literal>http://inspire.ec.europa.eu/codelist/ConditionOfFacilityValue/functional</ogc:Literal>
+        </ogc:PropertyIsEqualTo>
+        <ogc:PropertyIsEqualTo>
+          <ogc:PropertyName>hy-p:type/@xlink:href</ogc:PropertyName>
+          <ogc:Literal>http://inspire.ec.europa.eu/codelist/CrossingTypeValue/bridge</ogc:Literal>
+        </ogc:PropertyIsEqualTo>
+        <ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsSurface">
+        		<ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+      </ogc:And>
+    </ogc:Filter>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Fill>
+        <se:SvgParameter name="fill">#CCCCCC</se:SvgParameter>
+      </se:Fill>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#999999</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">2</se:SvgParameter>
+      </se:Stroke>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/generated/feature-styles/HY_P_DamOrWeir_v5_0.se
+++ b/generated/feature-styles/HY_P_DamOrWeir_v5_0.se
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:hy-p="http://inspire.ec.europa.eu/schemas/hy-p/5.0" 
+xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" 
+xmlns:sld="http://www.opengis.net/sld" xmlns:xlink="http://www.w3.org/1999/xlink" 
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd"
+version="1.1.0">
+  <se:Name>HY.PhysicalWaters.ManMadeObject.Default</se:Name>
+  <se:Description>
+    <se:Title>Man-Made Objects Default Style</se:Title>
+    <se:Abstract>There are only depicted the fully functional objects. Punctual objects are depicted with symbols; if the geometry is a curve they are depicted in solid or dashed lines with different stroke width and different colours depending on the feature type; if the geometry is a surface it will be a filled polygon of solid colour adding or not some marks, depending on the feature type. Point geometries of crossings are rendered as a 10 sized picture. Line geometries of crossings are rendered as a grey (#999999) line and a stroke-width of 2 pixel. Polygon geometries of crossings are rendered using a light grey (#CCCCCC) fill and a dark grey (#999999) outline with a stroke width of 2 pixel. Point geometries of dams or weirs are rendered as a 12 sized cross with a light grey (#666666) color. Line geometries of dams or weirs are rendered as a light grey (#666666) line and a stroke-width of 3 pixel. Polygon geometries of dams or weirs are rendered using a dark grey (#999999) fill and a light grey (#666666) outline with a stroke width of 3 pixel. Point geometries of shoreline constructions are rendered as a 10 sized triangle with a light grey (#666666) color. Line geometries of shoreline constructions are rendered as a light grey (#666666) line and a stroke-width of 2 pixel. Polygon geometries of shoreline constructions are rendered using a dark grey (#999999) fill and a light grey (#666666) outline with a stroke width of 2 pixel. Point geometries of fords are rendered as a 3 sized square with a light red (#FFCCCC) color and light blue (#CCFFFF) border and a 50% transparence. Line geometries of fords are rendered as a light red (#FFCCCC) line and a stroke-width of 1 pixel. Polygon geometries of fords are rendered using a light red (#FFCCCC) fill and a 50% transparence. Point geometries of locks are rendered as a 8 sized cross with a light grey (#666666) color. Line geometries of locks are rendered as a light grey (#666666) line and a stroke-width of 1 pixel. Polygon geometries of locks are rendered using a dark grey (#999999) fill and a light grey (#666666) outline with a stroke width of 2 pixel. </se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>hy-p:DamOrWeir</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Dam or weir</se:Title>
+    </se:Description>
+    <ogc:Filter>
+    <ogc:And>
+      <ogc:PropertyIsEqualTo>
+        <ogc:PropertyName>hy-p:condition/@xlink:href</ogc:PropertyName>
+        <ogc:Literal>http://inspire.ec.europa.eu/codelist/ConditionOfFacilityValue/functional</ogc:Literal>
+      </ogc:PropertyIsEqualTo>
+      <ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsPoint">
+        		<ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+      </ogc:And>
+    </ogc:Filter>
+    <se:PointSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Graphic>
+        <se:Mark>
+          <se:WellKnownName>X</se:WellKnownName>
+          <se:Fill>
+            <se:SvgParameter name="fill">#666666</se:SvgParameter>
+          </se:Fill>
+        </se:Mark>
+        <se:Size>12.0</se:Size>
+      </se:Graphic>
+    </se:PointSymbolizer>
+    </se:Rule>
+    <se:Rule>
+    <se:Description>
+      <se:Title>Dam or weir</se:Title>
+    </se:Description>
+    <ogc:Filter>
+    <ogc:And>
+      <ogc:PropertyIsEqualTo>
+        <ogc:PropertyName>hy-p:condition/@xlink:href</ogc:PropertyName>
+        <ogc:Literal>http://inspire.ec.europa.eu/codelist/ConditionOfFacilityValue/functional</ogc:Literal>
+      </ogc:PropertyIsEqualTo>
+      <ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsCurve">
+        		<ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+      </ogc:And>
+    </ogc:Filter>
+    <se:LineSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#666666</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">3</se:SvgParameter>
+      </se:Stroke>
+    </se:LineSymbolizer>
+    </se:Rule>
+    <se:Rule>
+    <se:Description>
+      <se:Title>Dam or weir</se:Title>
+    </se:Description>
+    <ogc:Filter>
+    <ogc:And>
+      <ogc:PropertyIsEqualTo>
+        <ogc:PropertyName>hy-p:condition/@xlink:href</ogc:PropertyName>
+        <ogc:Literal>http://inspire.ec.europa.eu/codelist/ConditionOfFacilityValue/functional</ogc:Literal>
+      </ogc:PropertyIsEqualTo>
+      <ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsSurface">
+        		<ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+      </ogc:And>
+    </ogc:Filter>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Fill>
+        <se:SvgParameter name="fill">#999999</se:SvgParameter>
+      </se:Fill>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#666666</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">3</se:SvgParameter>
+      </se:Stroke>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/generated/feature-styles/HY_P_DrainageBasin_v5_0.se
+++ b/generated/feature-styles/HY_P_DrainageBasin_v5_0.se
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:hy-p="http://inspire.ec.europa.eu/schemas/hy-p/5.0" 
+xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" 
+xmlns:sld="http://www.opengis.net/sld" xmlns:xlink="http://www.w3.org/1999/xlink" 
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd"
+version="1.1.0">
+  <se:Name>HY.PhysicalWaters.Catchments.Default</se:Name>
+  <se:Description>
+    <se:Title>Catchments Default Style</se:Title>
+    <se:Abstract>Drainage Basin areas are portrayed by no filled polygons with a solid blue (#0066FF) border with stroke width of 4 pixel the RiverBasin features and with stroke width of 2 pixel the DrainageBasin ones.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>hy-p:DrainageBasin</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Drainage basin</se:Title>
+    </se:Description>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#0066FF</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">2</se:SvgParameter>
+      </se:Stroke>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/generated/feature-styles/HY_P_Falls_v5_0.se
+++ b/generated/feature-styles/HY_P_Falls_v5_0.se
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:hy-p="http://inspire.ec.europa.eu/schemas/hy-p/5.0" 
+xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" 
+xmlns:sld="http://www.opengis.net/sld" xmlns:xlink="http://www.w3.org/1999/xlink" 
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd"
+version="1.1.0">
+  <se:Name>HY.PhysicalWaters.HydroPointOfInterest.Default</se:Name>
+  <se:Description>
+    <se:Title>Hydrographic Points Of Interest Default Style</se:Title>
+    <se:Abstract>Fluvial points as rapids or falls are depicted with symbols; if the geometry is a curve they are depicted in aligned blue (#0066FF) marks (stars for Falls and crosses for Rapids); if the geometry is a surface it will be an area with blue (#0066FF) marks (stars for Falls and crosses for Rapids).</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>hy-p:Falls</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Falls</se:Title>
+    </se:Description>
+  	<ogc:Filter>
+       <ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsPoint">
+        		<ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+    </ogc:Filter>
+    <se:PointSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Graphic>
+        <se:Mark>
+          <se:WellKnownName>star</se:WellKnownName>
+          <se:Fill>
+            <se:SvgParameter name="fill">#0066FF</se:SvgParameter>
+          </se:Fill>
+           <se:Stroke>
+            <se:SvgParameter name="stroke">#0066FF</se:SvgParameter>
+          </se:Stroke>
+        </se:Mark>
+        <se:Size>10.0</se:Size>
+      </se:Graphic>
+    </se:PointSymbolizer>
+    </se:Rule>
+    <se:Rule>
+    <se:Description>
+      <se:Title>Falls</se:Title>
+    </se:Description>
+  	<ogc:Filter>
+       <ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsCurve">
+        		<ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+    </ogc:Filter>
+    <se:LineSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Stroke>
+        <se:GraphicStroke>
+          <se:Graphic>
+            <se:Mark>
+              <se:WellKnownName>star</se:WellKnownName>
+              <se:Fill>
+                <se:SvgParameter name="fill">#0066FF</se:SvgParameter>
+              </se:Fill>
+              <se:Stroke>
+            	<se:SvgParameter name="stroke">#0066FF</se:SvgParameter>
+          	</se:Stroke>
+            </se:Mark>
+            <se:Size>5.0</se:Size>
+          </se:Graphic>
+        </se:GraphicStroke>
+      </se:Stroke>
+    </se:LineSymbolizer>
+    </se:Rule>
+    <se:Rule>
+    <se:Description>
+      <se:Title>Falls</se:Title>
+    </se:Description>
+  	<ogc:Filter>
+       <ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsSurface">
+        		<ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+    </ogc:Filter>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Fill>
+        <se:GraphicFill>
+          <se:Graphic>
+            <se:Mark>
+              <se:WellKnownName>star</se:WellKnownName>
+              <se:Fill>
+                <se:SvgParameter name="fill">#0066FF</se:SvgParameter>
+              </se:Fill>
+              <se:Stroke>
+            	<se:SvgParameter name="stroke">#0066FF</se:SvgParameter>
+          	</se:Stroke>
+            </se:Mark>
+            <se:Size>5.0</se:Size>
+          </se:Graphic>
+        </se:GraphicFill>
+      </se:Fill>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/generated/feature-styles/HY_P_Ford_v5_0.se
+++ b/generated/feature-styles/HY_P_Ford_v5_0.se
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:hy-p="http://inspire.ec.europa.eu/schemas/hy-p/5.0" 
+xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" 
+xmlns:sld="http://www.opengis.net/sld" xmlns:xlink="http://www.w3.org/1999/xlink" 
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd"
+version="1.1.0">
+  <se:Name>HY.PhysicalWaters.ManMadeObject.Default</se:Name>
+  <se:Description>
+    <se:Title>Man-Made Objects Default Style</se:Title>
+    <se:Abstract>There are only depicted the fully functional objects. Punctual objects are depicted with symbols; if the geometry is a curve they are depicted in solid or dashed lines with different stroke width and different colours depending on the feature type; if the geometry is a surface it will be a filled polygon of solid colour adding or not some marks, depending on the feature type. Point geometries of crossings are rendered as a 10 sized picture. Line geometries of crossings are rendered as a grey (#999999) line and a stroke-width of 2 pixel. Polygon geometries of crossings are rendered using a light grey (#CCCCCC) fill and a dark grey (#999999) outline with a stroke width of 2 pixel. Point geometries of dams or weirs are rendered as a 12 sized cross with a light grey (#666666) color. Line geometries of dams or weirs are rendered as a light grey (#666666) line and a stroke-width of 3 pixel. Polygon geometries of dams or weirs are rendered using a dark grey (#999999) fill and a light grey (#666666) outline with a stroke width of 3 pixel. Point geometries of shoreline constructions are rendered as a 10 sized triangle with a light grey (#666666) color. Line geometries of shoreline constructions are rendered as a light grey (#666666) line and a stroke-width of 2 pixel. Polygon geometries of shoreline constructions are rendered using a dark grey (#999999) fill and a light grey (#666666) outline with a stroke width of 2 pixel. Point geometries of fords are rendered as a 3 sized square with a light red (#FFCCCC) color and light blue (#CCFFFF) border and a 50% transparence. Line geometries of fords are rendered as a light red (#FFCCCC) line and a stroke-width of 1 pixel. Polygon geometries of fords are rendered using a light red (#FFCCCC) fill and a 50% transparence. Point geometries of locks are rendered as a 8 sized cross with a light grey (#666666) color. Line geometries of locks are rendered as a light grey (#666666) line and a stroke-width of 1 pixel. Polygon geometries of locks are rendered using a dark grey (#999999) fill and a light grey (#666666) outline with a stroke width of 2 pixel. </se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>hy-p:Ford</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Ford</se:Title>
+    </se:Description>
+    <ogc:Filter>
+    <ogc:And>
+      <ogc:PropertyIsEqualTo>
+        <ogc:PropertyName>hy-p:condition/@xlink:href</ogc:PropertyName>
+        <ogc:Literal>http://inspire.ec.europa.eu/codelist/ConditionOfFacilityValue/functional</ogc:Literal>
+      </ogc:PropertyIsEqualTo>
+       <ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsPoint">
+        		<ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+    </ogc:And>
+    </ogc:Filter>
+    <se:PointSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Graphic>
+        <se:Mark>
+          <se:WellKnownName>square</se:WellKnownName>
+          <se:Fill>
+            <se:SvgParameter name="fill">#FFCCCC</se:SvgParameter>
+          </se:Fill>
+          <se:Stroke>
+            <se:SvgParameter name="stroke">#CCFFFF</se:SvgParameter>
+          </se:Stroke>
+        </se:Mark>
+        <se:Opacity>0.5</se:Opacity>
+        <se:Size>3</se:Size>
+      </se:Graphic>
+    </se:PointSymbolizer>
+    </se:Rule>
+    <se:Rule>
+    <se:Description>
+      <se:Title>Ford</se:Title>
+    </se:Description>
+    <ogc:Filter>
+    <ogc:And>
+      <ogc:PropertyIsEqualTo>
+        <ogc:PropertyName>hy-p:condition/@xlink:href</ogc:PropertyName>
+        <ogc:Literal>http://inspire.ec.europa.eu/codelist/ConditionOfFacilityValue/functional</ogc:Literal>
+      </ogc:PropertyIsEqualTo>
+       <ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsCurve">
+        		<ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+    </ogc:And>
+    </ogc:Filter>
+    <se:LineSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#FFCCCC</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+      </se:Stroke>
+    </se:LineSymbolizer>
+    </se:Rule>
+    <se:Rule>
+    <se:Description>
+      <se:Title>Ford</se:Title>
+    </se:Description>
+    <ogc:Filter>
+    <ogc:And>
+      <ogc:PropertyIsEqualTo>
+        <ogc:PropertyName>hy-p:condition/@xlink:href</ogc:PropertyName>
+        <ogc:Literal>http://inspire.ec.europa.eu/codelist/ConditionOfFacilityValue/functional</ogc:Literal>
+      </ogc:PropertyIsEqualTo>
+       <ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsSurface">
+        		<ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+    </ogc:And>
+    </ogc:Filter>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Fill>
+        <se:SvgParameter name="fill">#FFCCCC</se:SvgParameter>
+        <se:SvgParameter name="fill-opacity">0.5</se:SvgParameter>
+      </se:Fill>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/generated/feature-styles/HY_P_LandWaterBoundary_v5_0.se
+++ b/generated/feature-styles/HY_P_LandWaterBoundary_v5_0.se
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:hy-p="http://inspire.ec.europa.eu/schemas/hy-p/5.0" 
+xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" 
+xmlns:sld="http://www.opengis.net/sld" xmlns:xlink="http://www.w3.org/1999/xlink" 
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd"
+version="1.1.0">
+  <se:Name>HY.PhysicalWaters.LandWaterBoundary.Default</se:Name>
+  <se:Description>
+    <se:Title>Land Water Boundary Well-Defined Style</se:Title>
+    <se:Abstract>The contact line between a land mass and a water body is portrayed by a solid blue (#33CCFF) line with stroke width of 1 pixel.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>hy-p:LandWaterBoundary</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Land water boundary</se:Title>
+    </se:Description>
+    <ogc:Filter>
+    	 <ogc:PropertyIsEqualTo>
+        <ogc:PropertyName>hy-p:origin</ogc:PropertyName>
+        <ogc:Literal>natural</ogc:Literal>
+      </ogc:PropertyIsEqualTo>
+    </ogc:Filter>
+    <se:LineSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#33CCFF</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+      </se:Stroke>
+    </se:LineSymbolizer>
+  </se:Rule>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Land water boundary</se:Title>
+    </se:Description>
+    <ogc:Filter>
+    	 <ogc:PropertyIsEqualTo>
+        <ogc:PropertyName>hy-p:origin</ogc:PropertyName>
+        <ogc:Literal>manMade</ogc:Literal>
+      </ogc:PropertyIsEqualTo>
+    </ogc:Filter>
+    <se:LineSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+      </se:Stroke>
+    </se:LineSymbolizer>
+  </se:Rule>
+  
+</se:FeatureTypeStyle>

--- a/generated/feature-styles/HY_P_Lock_v5_0.se
+++ b/generated/feature-styles/HY_P_Lock_v5_0.se
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:hy-p="http://inspire.ec.europa.eu/schemas/hy-p/5.0" xmlns:ogc="http://www.opengis.net/ogc" 
+xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" 
+xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd"
+version="1.1.0">
+  <se:Name>HY.PhysicalWaters.ManMadeObject.Default</se:Name>
+  <se:Description>
+    <se:Title>Man-Made Objects Default Style</se:Title>
+    <se:Abstract>There are only depicted the fully functional objects. Punctual objects are depicted with symbols; if the geometry is a curve they are depicted in solid or dashed lines with different stroke width and different colours depending on the feature type; if the geometry is a surface it will be a filled polygon of solid colour adding or not some marks, depending on the feature type. Point geometries of crossings are rendered as a 10 sized picture. Line geometries of crossings are rendered as a grey (#999999) line and a stroke-width of 2 pixel. Polygon geometries of crossings are rendered using a light grey (#CCCCCC) fill and a dark grey (#999999) outline with a stroke width of 2 pixel. Point geometries of dams or weirs are rendered as a 12 sized cross with a light grey (#666666) color. Line geometries of dams or weirs are rendered as a light grey (#666666) line and a stroke-width of 3 pixel. Polygon geometries of dams or weirs are rendered using a dark grey (#999999) fill and a light grey (#666666) outline with a stroke width of 3 pixel. Point geometries of shoreline constructions are rendered as a 10 sized triangle with a light grey (#666666) color. Line geometries of shoreline constructions are rendered as a light grey (#666666) line and a stroke-width of 2 pixel. Polygon geometries of shoreline constructions are rendered using a dark grey (#999999) fill and a light grey (#666666) outline with a stroke width of 2 pixel. Point geometries of fords are rendered as a 3 sized square with a light red (#FFCCCC) color and light blue (#CCFFFF) border and a 50% transparence. Line geometries of fords are rendered as a light red (#FFCCCC) line and a stroke-width of 1 pixel. Polygon geometries of fords are rendered using a light red (#FFCCCC) fill and a 50% transparence. Point geometries of locks are rendered as a 8 sized cross with a light grey (#666666) color. Line geometries of locks are rendered as a light grey (#666666) line and a stroke-width of 1 pixel. Polygon geometries of locks are rendered using a dark grey (#999999) fill and a light grey (#666666) outline with a stroke width of 2 pixel. </se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>hy-p:Lock</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Lock</se:Title>
+    </se:Description>
+    <ogc:Filter>
+    <ogc:And>
+      <ogc:PropertyIsEqualTo>
+        <ogc:PropertyName>hy-p:condition/@xlink:href</ogc:PropertyName>
+        <ogc:Literal>http://inspire.ec.europa.eu/codelist/ConditionOfFacilityValue/functional</ogc:Literal>
+      </ogc:PropertyIsEqualTo>
+      <ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsPoint">
+        		<ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+     </ogc:And>
+    </ogc:Filter>
+    <se:PointSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Graphic>
+        <se:Mark>
+          <se:WellKnownName>X</se:WellKnownName>
+          <se:Fill>
+            <se:SvgParameter name="fill">#666666</se:SvgParameter>
+          </se:Fill>
+        </se:Mark>
+        <se:Size>8</se:Size>
+      </se:Graphic>
+    </se:PointSymbolizer>
+    </se:Rule>
+    <se:Rule>
+    <se:Description>
+      <se:Title>Lock</se:Title>
+    </se:Description>
+    <ogc:Filter>
+    <ogc:And>
+      <ogc:PropertyIsEqualTo>
+        <ogc:PropertyName>hy-p:condition/@xlink:href</ogc:PropertyName>
+        <ogc:Literal>http://inspire.ec.europa.eu/codelist/ConditionOfFacilityValue/functional</ogc:Literal>
+      </ogc:PropertyIsEqualTo>
+      <ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsCurve">
+        		<ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+     </ogc:And>
+    </ogc:Filter>
+    <se:LineSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#666666</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+      </se:Stroke>
+    </se:LineSymbolizer>
+    </se:Rule>
+    <se:Rule>
+    <se:Description>
+      <se:Title>Lock</se:Title>
+    </se:Description>
+    <ogc:Filter>
+    <ogc:And>
+      <ogc:PropertyIsEqualTo>
+        <ogc:PropertyName>hy-p:condition/@xlink:href</ogc:PropertyName>
+        <ogc:Literal>http://inspire.ec.europa.eu/codelist/ConditionOfFacilityValue/functional</ogc:Literal>
+      </ogc:PropertyIsEqualTo>
+      <ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsSurface">
+        		<ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+     </ogc:And>
+    </ogc:Filter>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Fill>
+        <se:SvgParameter name="fill">#999999</se:SvgParameter>
+      </se:Fill>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#666666</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+      </se:Stroke>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/generated/feature-styles/HY_P_Rapids_v5_0.se
+++ b/generated/feature-styles/HY_P_Rapids_v5_0.se
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:hy-p="http://inspire.ec.europa.eu/schemas/hy-p/5.0" xmlns:ogc="http://www.opengis.net/ogc" 
+xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:xlink="http://www.w3.org/1999/xlink" 
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd"
+version="1.1.0">
+  <se:Name>HY.PhysicalWaters.HydroPointOfInterest.Default</se:Name>
+  <se:Description>
+    <se:Title>Hydrographic Points Of Interest Default Style</se:Title>
+    <se:Abstract>Fluvial points as rapids or falls are depicted with symbols; if the geometry is a curve they are depicted in aligned blue (#0066FF) 
+    marks (stars for Falls and crosses for Rapids); if the geometry is a surface it will be an area with blue (#0066FF) marks (stars for Falls and 
+    crosses for Rapids).</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>hy-p:Rapids</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Rapids</se:Title>
+    </se:Description>
+  	<ogc:Filter>
+       <ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsPoint">
+        		<ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+    </ogc:Filter>
+    <se:PointSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Graphic>
+        <se:Mark>
+          <se:WellKnownName>cross</se:WellKnownName>
+          <se:Fill>
+            <se:SvgParameter name="fill">#0066FF</se:SvgParameter>
+          </se:Fill>
+          <se:Stroke>
+            <se:SvgParameter name="stroke">#0066FF</se:SvgParameter>
+          </se:Stroke>
+        </se:Mark>
+        <se:Size>10.0</se:Size>
+      </se:Graphic>
+    </se:PointSymbolizer>
+    </se:Rule>
+    <se:Rule>
+    <se:Description>
+      <se:Title>Rapids</se:Title>
+    </se:Description>
+  	<ogc:Filter>
+       <ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsCurve">
+        		<ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+    </ogc:Filter>
+    <se:LineSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Stroke>
+        <se:GraphicStroke>
+          <se:Graphic>
+            <se:Mark>
+              <se:WellKnownName>cross</se:WellKnownName>
+              <se:Fill>
+                <se:SvgParameter name="fill">#0066FF</se:SvgParameter>
+              </se:Fill>
+              <se:Stroke>
+            <se:SvgParameter name="stroke">#0066FF</se:SvgParameter>
+          	</se:Stroke>
+            </se:Mark>
+            <se:Size>5.0</se:Size>
+          </se:Graphic>
+        </se:GraphicStroke>
+      </se:Stroke>
+    </se:LineSymbolizer>
+    </se:Rule>
+    <se:Rule>
+    <se:Description>
+      <se:Title>Rapids</se:Title>
+    </se:Description>
+  	<ogc:Filter>
+       <ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsSurface">
+        		<ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+    </ogc:Filter>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Fill>
+        <se:GraphicFill>
+          <se:Graphic>
+            <se:Mark>
+              <se:WellKnownName>cross</se:WellKnownName>
+              <se:Fill>
+                <se:SvgParameter name="fill">#0066FF</se:SvgParameter>
+              </se:Fill>
+              <se:Stroke>
+            	<se:SvgParameter name="stroke">#0066FF</se:SvgParameter>
+          	 </se:Stroke>
+            </se:Mark>
+            <se:Size>5.0</se:Size>
+          </se:Graphic>
+        </se:GraphicFill>
+      </se:Fill>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/generated/feature-styles/HY_P_RiverBasin_v5_0.se
+++ b/generated/feature-styles/HY_P_RiverBasin_v5_0.se
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:hy-p="http://inspire.ec.europa.eu/schemas/hy-p/5.0" xmlns:ogc="http://www.opengis.net/ogc" 
+xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:xlink="http://www.w3.org/1999/xlink" 
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd"
+version="1.1.0">
+  <se:Name>HY.PhysicalWaters.Catchments.Default</se:Name>
+  <se:Description>
+    <se:Title>Catchments Default Style</se:Title>
+    <se:Abstract>Drainage Basin areas are portrayed by no filled polygons with a solid blue (#0066FF) border with stroke width of 4 pixel the RiverBasin features and with stroke width of 2 pixel the DrainageBasin ones.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>hy-p:RiverBasin</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>River basin</se:Title>
+    </se:Description>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#0066FF</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">4</se:SvgParameter>
+      </se:Stroke>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/generated/feature-styles/HY_P_ShoreLineConstruction_v5_0.se
+++ b/generated/feature-styles/HY_P_ShoreLineConstruction_v5_0.se
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:hy-p="http://inspire.ec.europa.eu/schemas/hy-p/5.0" 
+xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" 
+xmlns:sld="http://www.opengis.net/sld" xmlns:xlink="http://www.w3.org/1999/xlink" 
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd"
+version="1.1.0">
+  <se:Name>HY.PhysicalWaters.ManMadeObject.Default</se:Name>
+  <se:Description>
+    <se:Title>Man-Made Objects Default Style</se:Title>
+    <se:Abstract>There are only depicted the fully functional objects. Punctual objects are depicted with symbols; if the geometry is a curve they are depicted in solid or dashed lines with different stroke width and different colours depending on the feature type; if the geometry is a surface it will be a filled polygon of solid colour adding or not some marks, depending on the feature type. Point geometries of crossings are rendered as a 10 sized picture. Line geometries of crossings are rendered as a grey (#999999) line and a stroke-width of 2 pixel. Polygon geometries of crossings are rendered using a light grey (#CCCCCC) fill and a dark grey (#999999) outline with a stroke width of 2 pixel. Point geometries of dams or weirs are rendered as a 12 sized cross with a light grey (#666666) color. Line geometries of dams or weirs are rendered as a light grey (#666666) line and a stroke-width of 3 pixel. Polygon geometries of dams or weirs are rendered using a dark grey (#999999) fill and a light grey (#666666) outline with a stroke width of 3 pixel. Point geometries of shoreline constructions are rendered as a 10 sized triangle with a light grey (#666666) color. Line geometries of shoreline constructions are rendered as a light grey (#666666) line and a stroke-width of 2 pixel. Polygon geometries of shoreline constructions are rendered using a dark grey (#999999) fill and a light grey (#666666) outline with a stroke width of 2 pixel. Point geometries of fords are rendered as a 3 sized square with a light red (#FFCCCC) color and light blue (#CCFFFF) border and a 50% transparence. Line geometries of fords are rendered as a light red (#FFCCCC) line and a stroke-width of 1 pixel. Polygon geometries of fords are rendered using a light red (#FFCCCC) fill and a 50% transparence. Point geometries of locks are rendered as a 8 sized cross with a light grey (#666666) color. Line geometries of locks are rendered as a light grey (#666666) line and a stroke-width of 1 pixel. Polygon geometries of locks are rendered using a dark grey (#999999) fill and a light grey (#666666) outline with a stroke width of 2 pixel. </se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>hy-p:ShorelineConstruction</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Shoreline construction</se:Title>
+    </se:Description>
+    <ogc:Filter>
+    <ogc:And>
+      <ogc:PropertyIsEqualTo>
+        <ogc:PropertyName>hy-p:condition/@xlink:href</ogc:PropertyName>
+        <ogc:Literal>http://inspire.ec.europa.eu/codelist/ConditionOfFacilityValue/functional</ogc:Literal>
+      </ogc:PropertyIsEqualTo>
+      <ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsPoint">
+        		<ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+    </ogc:And>
+    </ogc:Filter>
+    <se:PointSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Graphic>
+        <se:Mark>
+          <se:WellKnownName>triangle</se:WellKnownName>
+          <se:Fill>
+            <se:SvgParameter name="fill">#666666</se:SvgParameter>
+          </se:Fill>
+        </se:Mark>
+        <se:Size>10</se:Size>
+      </se:Graphic>
+    </se:PointSymbolizer>
+    </se:Rule>
+    <se:Rule>
+    <se:Description>
+      <se:Title>Shoreline construction</se:Title>
+    </se:Description>
+    <ogc:Filter>
+    <ogc:And>
+      <ogc:PropertyIsEqualTo>
+        <ogc:PropertyName>hy-p:condition/@xlink:href</ogc:PropertyName>
+        <ogc:Literal>http://inspire.ec.europa.eu/codelist/ConditionOfFacilityValue/functional</ogc:Literal>
+      </ogc:PropertyIsEqualTo>
+      <ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsCurve">
+        		<ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+    </ogc:And>
+    </ogc:Filter>
+    <se:LineSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#666666</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">2</se:SvgParameter>
+      </se:Stroke>
+    </se:LineSymbolizer>
+    </se:Rule>
+    <se:Rule>
+    <se:Description>
+      <se:Title>Shoreline construction</se:Title>
+    </se:Description>
+    <ogc:Filter>
+    <ogc:And>
+      <ogc:PropertyIsEqualTo>
+        <ogc:PropertyName>hy-p:condition/@xlink:href</ogc:PropertyName>
+        <ogc:Literal>http://inspire.ec.europa.eu/codelist/ConditionOfFacilityValue/functional</ogc:Literal>
+      </ogc:PropertyIsEqualTo>
+      <ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsSurface">
+        		<ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+    </ogc:And>
+    </ogc:Filter>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Fill>
+        <se:SvgParameter name="fill">#999999</se:SvgParameter>
+      </se:Fill>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#666666</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">2</se:SvgParameter>
+      </se:Stroke>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/generated/feature-styles/HY_P_Shore_v5_0.se
+++ b/generated/feature-styles/HY_P_Shore_v5_0.se
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:hy-p="http://inspire.ec.europa.eu/schemas/hy-p/5.0" xmlns:ogc="http://www.opengis.net/ogc" 
+xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" 
+xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd"
+version="1.1.0">
+  <se:Name>HY.PhysicalWaters.Shore.Default</se:Name>
+  <se:Description>
+    <se:Title>Shore Default Style</se:Title>
+    <se:Abstract>Shore areas are portrayed as pale yellow (#FFFFCC) surfaces.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>hy-p:Shore</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Shore</se:Title>
+    </se:Description>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Fill>
+        <se:SvgParameter name="fill">#FFFFCC</se:SvgParameter>
+      </se:Fill>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/generated/feature-styles/HY_P_StandingWater_ManMade_v5_0.se
+++ b/generated/feature-styles/HY_P_StandingWater_ManMade_v5_0.se
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:hy-p="http://inspire.ec.europa.eu/schemas/hy-p/5.0" 
+xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" 
+xmlns:sld="http://www.opengis.net/sld" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd" 
+version="1.1.0">
+  <se:Name>HY.PhysicalWaters.Waterbodies.Man.Made</se:Name>
+  <se:Description>
+    <se:Title>Waterbodies Man-Made Default Style</se:Title>
+    <se:Abstract>Physical waters as watercourses or standing water are depicted taking into account if they are natural or man-made. Natural water bodies are depicted using a light blue (#CCFFFF) filled polygon and a solid blue (#33CCFF) border with stroke width of 1 pixel.Man-made water bodies are depicted using a light blue (#CCFFFF) filled polygon and a solid blue (#0066FF) border with stroke width of 1 pixel.Natural standing waters are rendered by 6 pixel size filled blue circles (#0066FF) on a light blue (#CCFFFF) filled polygon.Man-made standing waters are rendered by 6 pixel size filled blue circles (#0066FF) with a black (?) (#0000) border on a light blue (#0000) filled polygon with a black (?) (#0000) border and a stroke width of 1 pixel.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>hy-p:StandingWater</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Standing waters natural: points</se:Title>
+    </se:Description>
+    <ogc:Filter>
+    <ogc:And>
+      <ogc:PropertyIsEqualTo>
+        <ogc:PropertyName>hy-p:origin</ogc:PropertyName>
+        <ogc:Literal>natural</ogc:Literal>
+      </ogc:PropertyIsEqualTo>
+      <ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsPoint">
+        		<ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+      </ogc:And>
+    </ogc:Filter>
+    <se:PointSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Graphic>
+        <se:Mark>
+          <se:WellKnownName>circle</se:WellKnownName>
+          <se:Fill>
+            <se:SvgParameter name="fill">#0066FF</se:SvgParameter>
+          </se:Fill>
+          <se:Stroke>
+            <se:SvgParameter name="stroke">#0066FF</se:SvgParameter>
+          </se:Stroke>
+        </se:Mark>
+        <se:Size>6</se:Size>
+      </se:Graphic>
+    </se:PointSymbolizer>
+    </se:Rule>
+    <se:Rule>
+    <se:Description>
+      <se:Title>Standing waters natural: polygons</se:Title>
+    </se:Description>
+    <ogc:Filter>
+    <ogc:And>
+      <ogc:PropertyIsEqualTo>
+        <ogc:PropertyName>hy-p:origin</ogc:PropertyName>
+        <ogc:Literal>natural</ogc:Literal>
+      </ogc:PropertyIsEqualTo>
+      <ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsSurface">
+        		<ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+      </ogc:And>
+    </ogc:Filter>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Fill>
+        <se:SvgParameter name="fill">#CCFFFF</se:SvgParameter>
+      </se:Fill>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Standing waters man-made: points</se:Title>
+    </se:Description>
+    <ogc:Filter>
+    <ogc:And>
+      <ogc:PropertyIsEqualTo>
+        <ogc:PropertyName>hy-p:origin</ogc:PropertyName>
+        <ogc:Literal>manMade</ogc:Literal>
+      </ogc:PropertyIsEqualTo>
+      <ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsPoint">
+        		<ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+      </ogc:And>
+    </ogc:Filter>
+    <se:PointSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Graphic>
+        <se:Mark>
+          <se:WellKnownName>circle</se:WellKnownName>
+          <se:Fill>
+            <se:SvgParameter name="fill">#0066FF</se:SvgParameter>
+          </se:Fill>
+          <se:Stroke>
+            <se:SvgParameter name="stroke">#0000</se:SvgParameter>
+          </se:Stroke>
+        </se:Mark>
+        <se:Size>6</se:Size>
+      </se:Graphic>
+    </se:PointSymbolizer>
+    </se:Rule>
+    <se:Rule>
+       <se:Description>
+      <se:Title>Standing waters man-made: polygons</se:Title>
+    </se:Description>
+        <ogc:Filter>
+    <ogc:And>
+      <ogc:PropertyIsEqualTo>
+        <ogc:PropertyName>hy-p:origin</ogc:PropertyName>
+        <ogc:Literal>manMade</ogc:Literal>
+      </ogc:PropertyIsEqualTo>
+      <ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsSurface">
+        		<ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+      </ogc:And>
+    </ogc:Filter>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Fill>
+        <se:SvgParameter name="fill">#CCFFFF</se:SvgParameter>
+      </se:Fill>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#0000</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+      </se:Stroke>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/generated/feature-styles/HY_P_StandingWater_v5_0.se
+++ b/generated/feature-styles/HY_P_StandingWater_v5_0.se
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:hy-p="http://inspire.ec.europa.eu/schemas/hy-p/5.0" xmlns:ogc="http://www.opengis.net/ogc" 
+xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" 
+xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd" 
+version="1.1.0">
+  <se:Name>HY.PhysicalWaters.Waterbodies.Default</se:Name>
+  <se:Description>
+    <se:Title>Waterbodies Default Style</se:Title>
+    <se:Abstract>Physical waters as watercourses or standing water can be portrayed with different geometries depending on its dimensions and the level of detail or resolution. Lineal watercourses are depicted by solid blue (#33CCFF) lines with stroke width of 1 pixel and the superficial ones are depicted by filled blue light polygons (#CCFFFF) without border. Punctual standing waters are depicted by dark blue (#0066FF) circles with size of 6 pixel and the superficial ones are depicted by filled blue light polygons (#CCFFFF) without border.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>hy-p:StandingWater</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Standing water</se:Title>
+    </se:Description>
+    <ogc:Filter>
+    	<ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsPoint">
+        		<ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+   	</ogc:Filter>
+   	<se:PointSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Graphic>
+        <se:Mark>
+          <se:WellKnownName>circle</se:WellKnownName>
+          <se:Fill>
+            <se:SvgParameter name="fill">#0066FF</se:SvgParameter>
+          </se:Fill>
+          <se:Stroke>
+            <se:SvgParameter name="stroke">#0066FF</se:SvgParameter>
+          </se:Stroke>
+        </se:Mark>
+        <se:Size>6</se:Size>
+      </se:Graphic>
+    </se:PointSymbolizer>
+     </se:Rule>
+     <se:Rule>
+    <se:Description>
+      <se:Title>Standing water</se:Title>
+    </se:Description>
+     <ogc:Filter>
+    	<ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsSurface">
+        		<ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+   	</ogc:Filter>
+    <se:PolygonSymbolizer>
+   	<se:Geometry>
+    	<ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+    </se:Geometry>
+    <se:Fill>
+    	<se:SvgParameter name="fill">#CCFFFF</se:SvgParameter>
+    </se:Fill>
+   </se:PolygonSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/generated/feature-styles/HY_P_WaterbodiesPersistence_v5_0.se
+++ b/generated/feature-styles/HY_P_WaterbodiesPersistence_v5_0.se
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:hy-p="http://inspire.ec.europa.eu/schemas/hy-p/5.0" 
+xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" 
+xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd"
+version="1.1.0">
+  <se:Name>HY.PhysicalWaters.Waterbodies.Persistence</se:Name>
+  <se:Description>
+    <se:Title>Water Bodies Persistence Default Style</se:Title>
+    <se:Abstract>Physical waters as watercourses or standing water are depicted taking into account their water persistence. Intermittent water bodies are depicted using a dashed (10 to 5) blue (#33CCFF) line with a stroke width of 1 pixel and a non filled polygon with a dashed (10 to 5) blue (#33CCFF) line with a stroke width of 1 pixel. Ephemeral or dry waterbodies are depicted using a dashed (5 to 5) blue (#33CCFF) line with a strole width of 1 pixel and a non filled polygon with a dashed (5 to 5) blue (#33CCFF) line with a stroke width of 1 pixel. Perennial standing waters are depicted using a 6 pixel size filled solid blue circles (#0066FF) on a light blue (#CCFFFF) filled polygon. Intermittent standing waters are depicted using a non filled polygon with a dashed (10 to 5) blue (#33CCFF) line with a stroke width of 1 pixel. Ephemeral or dry standing waters are depicted using a non filled polygon with a dashed (5 to 5) blue (#33CCFF) line with a stroke width of 1 pixel.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>hy-p:StandingWater</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Standing waters persistence: perennial points</se:Title>
+    </se:Description>
+    <ogc:Filter>
+    <ogc:And>
+      <ogc:PropertyIsEqualTo>
+        <ogc:PropertyName>hy-p:persistence/@xlink:href</ogc:PropertyName>
+        <ogc:Literal>http://inspire.ec.europa.eu/codelist/HydrologicalPersistenceValue/perennial</ogc:Literal>
+      </ogc:PropertyIsEqualTo>
+   	  <ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsPoint">
+        		<ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       </ogc:PropertyIsEqualTo>
+    </ogc:And>
+    </ogc:Filter>
+    <se:PointSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Graphic>
+        <se:Mark>
+          <se:WellKnownName>circle</se:WellKnownName>
+          <se:Fill>
+            <se:SvgParameter name="fill">#0066FF</se:SvgParameter>
+          </se:Fill>
+          <se:Stroke>
+            <se:SvgParameter name="stroke">#0066FF</se:SvgParameter>
+          </se:Stroke>
+        </se:Mark>
+        <se:Size>6</se:Size>
+      </se:Graphic>
+    </se:PointSymbolizer>
+    </se:Rule>
+    <se:Rule>
+    <se:Description>
+      <se:Title>Standing waters persistence: perennial polygons</se:Title>
+    </se:Description>
+    <ogc:Filter>
+    <ogc:And>
+      <ogc:PropertyIsEqualTo>
+        <ogc:PropertyName>hy-p:persistence/@xlink:href</ogc:PropertyName>
+        <ogc:Literal>http://inspire.ec.europa.eu/codelist/HydrologicalPersistenceValue/perennial</ogc:Literal>
+      </ogc:PropertyIsEqualTo>
+   	  <ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsSurface">
+        		<ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       </ogc:PropertyIsEqualTo>
+    </ogc:And>
+    </ogc:Filter>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Fill>
+        <se:SvgParameter name="fill">#CCFFFF</se:SvgParameter>
+      </se:Fill>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Standing waters persistence: intermittent polygons</se:Title>
+    </se:Description>
+    <ogc:Filter>
+      <ogc:PropertyIsEqualTo>
+        <ogc:PropertyName>hy-p:persistence/@xlink:href</ogc:PropertyName>
+        <ogc:Literal>http://inspire.ec.europa.eu/codelist/HydrologicalPersistenceValue/intermittent</ogc:Literal>
+      </ogc:PropertyIsEqualTo>
+    </ogc:Filter>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#33CCFF</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+        <se:SvgParameter name="stroke-dasharray">10 5 10 5</se:SvgParameter>
+      </se:Stroke>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Standing waters persistence: ephemeral or dry polygons</se:Title>
+    </se:Description>
+    <ogc:Filter>
+      <ogc:Or>
+        <ogc:PropertyIsEqualTo>
+          <ogc:PropertyName>hy-p:persistence/@xlink:href</ogc:PropertyName>
+          <ogc:Literal>http://inspire.ec.europa.eu/codelist/HydrologicalPersistenceValue/ephemeral</ogc:Literal>
+        </ogc:PropertyIsEqualTo>
+        <ogc:PropertyIsEqualTo>
+          <ogc:PropertyName>hy-p:persistence/@xlink:href</ogc:PropertyName>
+          <ogc:Literal>http://inspire.ec.europa.eu/codelist/HydrologicalPersistenceValue/dry</ogc:Literal>
+        </ogc:PropertyIsEqualTo>
+      </ogc:Or>
+    </ogc:Filter>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#33CCFF</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+        <se:SvgParameter name="stroke-dasharray">5 5 5 5</se:SvgParameter>
+      </se:Stroke>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/generated/feature-styles/HY_P_WatercoursePersistence_v5_0.se
+++ b/generated/feature-styles/HY_P_WatercoursePersistence_v5_0.se
@@ -1,0 +1,220 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:hy-p="http://inspire.ec.europa.eu/schemas/hy-p/5.0" xmlns:ogc="http://www.opengis.net/ogc" 
+xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:xlink="http://www.w3.org/1999/xlink" 
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd"
+version="1.1.0">
+  <se:Name>HY.PhysicalWaters.Waterbodies.Persistence</se:Name>
+  <se:Description>
+    <se:Title>Water Bodies Persistence Default Style</se:Title>
+    <se:Abstract>Physical waters as watercourses or standing water are depicted taking into account their water persistence. Intermittent water bodies are depicted using a dashed (10 to 5) blue (#33CCFF) line with a strole width of 1 pixel and a non filled polygon with a dashed (10 to 5) blue (#33CCFF) line with a stroke width of 1 pixel. Ephemeral or dry waterbodies are depicted using a dashed (5 to 5) blue (#33CCFF) line with a strole width of 1 pixel and a non filled polygon with a dashed (5 to 5) blue (#33CCFF) line with a stroke width of 1 pixel. Perennial standing waters are depicted using a 6 pixel size filled solid blue circles (#0066FF) on a light blue (#CCFFFF) filled polygon. Intermittent standing waters are depicted using a non filled polygon with a dashed (10 to 5) blue (#33CCFF) line with a stroke width of 1 pixel. Ephemeral or dry standing waters are depicted using a non filled polygon with a dashed (5 to 5) blue (#33CCFF) line with a stroke width of 1 pixel.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>hy-p:Watercourse</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Waterbodies persistence: perennial lines</se:Title>
+    </se:Description>
+    <ogc:Filter>
+      <ogc:And>
+        <ogc:PropertyIsEqualTo>
+          <ogc:PropertyName>hy-p:persistence/@xlink:href</ogc:PropertyName>
+          <ogc:Literal>http://inspire.ec.europa.eu/codelist/HydrologicalPersistenceValue/perennial</ogc:Literal>
+        </ogc:PropertyIsEqualTo>
+        <ogc:PropertyIsEqualTo>
+          <ogc:PropertyName>hy-p:delineationKnown</ogc:PropertyName>
+          <ogc:Literal>true</ogc:Literal>
+        </ogc:PropertyIsEqualTo>
+        <ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsCurve">
+        		<ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+      </ogc:And>
+    </ogc:Filter>
+    <se:LineSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#33CCFF</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+      </se:Stroke>
+    </se:LineSymbolizer>
+    </se:Rule>
+    <se:Rule>
+     <se:Description>
+      <se:Title>Waterbodies persistence: perennial polygons</se:Title>
+    </se:Description>
+    <ogc:Filter>
+      <ogc:And>
+        <ogc:PropertyIsEqualTo>
+          <ogc:PropertyName>hy-p:persistence/@xlink:href</ogc:PropertyName>
+          <ogc:Literal>http://inspire.ec.europa.eu/codelist/HydrologicalPersistenceValue/perennial</ogc:Literal>
+        </ogc:PropertyIsEqualTo>
+        <ogc:PropertyIsEqualTo>
+          <ogc:PropertyName>hy-p:delineationKnown</ogc:PropertyName>
+          <ogc:Literal>true</ogc:Literal>
+        </ogc:PropertyIsEqualTo>
+        <ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsSurface">
+        		<ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+      </ogc:And>
+    </ogc:Filter>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Fill>
+        <se:SvgParameter name="fill">#CCFFFF</se:SvgParameter>
+      </se:Fill>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Waterbodies persistence: intermittent lines</se:Title>
+    </se:Description>
+   <ogc:Filter>
+      <ogc:And>
+        <ogc:PropertyIsEqualTo>
+          <ogc:PropertyName>hy-p:persistence/@xlink:href</ogc:PropertyName>
+          <ogc:Literal>http://inspire.ec.europa.eu/codelist/HydrologicalPersistenceValue/intermittent</ogc:Literal>
+        </ogc:PropertyIsEqualTo>
+        <ogc:PropertyIsEqualTo>
+          <ogc:PropertyName>hy-p:delineationKnown</ogc:PropertyName>
+          <ogc:Literal>true</ogc:Literal>
+        </ogc:PropertyIsEqualTo>
+        <ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsCurve">
+        		<ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+      </ogc:And>
+    </ogc:Filter>
+    <se:LineSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#33CCFF</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+        <se:SvgParameter name="stroke-dasharray">10 5 10 5</se:SvgParameter>
+      </se:Stroke>
+    </se:LineSymbolizer>
+    </se:Rule>
+    <se:Rule>
+      <se:Description>
+      <se:Title>Waterbodies persistence: intermittent polygons</se:Title>
+    </se:Description>
+   <ogc:Filter>
+      <ogc:And>
+        <ogc:PropertyIsEqualTo>
+          <ogc:PropertyName>hy-p:persistence/@xlink:href</ogc:PropertyName>
+          <ogc:Literal>http://inspire.ec.europa.eu/codelist/HydrologicalPersistenceValue/intermittent</ogc:Literal>
+        </ogc:PropertyIsEqualTo>
+        <ogc:PropertyIsEqualTo>
+          <ogc:PropertyName>hy-p:delineationKnown</ogc:PropertyName>
+          <ogc:Literal>true</ogc:Literal>
+        </ogc:PropertyIsEqualTo>
+        <ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsSurface">
+        		<ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+      </ogc:And>
+    </ogc:Filter>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#33CCFF</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+        <se:SvgParameter name="stroke-dasharray">10 5 10 5</se:SvgParameter>
+      </se:Stroke>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Waterbodies persistence: ephemeral or dry lines</se:Title>
+    </se:Description>
+    <ogc:Filter>
+      <ogc:And>
+      <ogc:PropertyIsEqualTo>
+          <ogc:PropertyName>hy-p:delineationKnown</ogc:PropertyName>
+          <ogc:Literal>true</ogc:Literal>
+        </ogc:PropertyIsEqualTo>
+        <ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsCurve">
+        		<ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+        <ogc:Or>
+        <ogc:PropertyIsEqualTo>
+          <ogc:PropertyName>hy-p:persistence/@xlink:href</ogc:PropertyName>
+          <ogc:Literal>http://inspire.ec.europa.eu/codelist/HydrologicalPersistenceValue/dry</ogc:Literal>
+        </ogc:PropertyIsEqualTo>
+        <ogc:PropertyIsEqualTo>
+          <ogc:PropertyName>hy-p:persistence/@xlink:href</ogc:PropertyName>
+          <ogc:Literal>http://inspire.ec.europa.eu/codelist/HydrologicalPersistenceValue/ephemeral</ogc:Literal>
+        </ogc:PropertyIsEqualTo>
+        </ogc:Or>
+      </ogc:And>
+    </ogc:Filter>
+    <se:LineSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#33CCFF</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+        <se:SvgParameter name="stroke-dasharray">5 5 5 5</se:SvgParameter>
+      </se:Stroke>
+    </se:LineSymbolizer>
+    </se:Rule>
+    <se:Rule>
+    <se:Description>
+      <se:Title>Waterbodies persistence: ephemeral or dry polygons</se:Title>
+    </se:Description>
+    <ogc:Filter>
+      <ogc:And>
+      <ogc:PropertyIsEqualTo>
+          <ogc:PropertyName>hy-p:delineationKnown</ogc:PropertyName>
+          <ogc:Literal>true</ogc:Literal>
+        </ogc:PropertyIsEqualTo>
+        <ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsSurface">
+        		<ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+        <ogc:Or>
+        <ogc:PropertyIsEqualTo>
+          <ogc:PropertyName>hy-p:persistence/@xlink:href</ogc:PropertyName>
+          <ogc:Literal>http://inspire.ec.europa.eu/codelist/HydrologicalPersistenceValue/dry</ogc:Literal>
+        </ogc:PropertyIsEqualTo>
+        <ogc:PropertyIsEqualTo>
+          <ogc:PropertyName>hy-p:persistence/@xlink:href</ogc:PropertyName>
+          <ogc:Literal>http://inspire.ec.europa.eu/codelist/HydrologicalPersistenceValue/ephemeral</ogc:Literal>
+        </ogc:PropertyIsEqualTo>
+        </ogc:Or>
+      </ogc:And>
+    </ogc:Filter>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#33CCFF</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+        <se:SvgParameter name="stroke-dasharray">5 5 5 5</se:SvgParameter>
+      </se:Stroke>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/generated/feature-styles/HY_P_Watercourse_ManMade_v5_0.se
+++ b/generated/feature-styles/HY_P_Watercourse_ManMade_v5_0.se
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:hy-p="http://inspire.ec.europa.eu/schemas/hy-p/5.0" xmlns:ogc="http://www.opengis.net/ogc" 
+xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:xlink="http://www.w3.org/1999/xlink" 
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd"
+version="1.1.0">
+  <se:Name>HY.PhysicalWaters.Waterbodies.Man.Made</se:Name>
+  <se:Description>
+    <se:Title>Waterbodies Man-Made Default Style</se:Title>
+    <se:Abstract>Physical waters as watercourses or standing water are depicted taking into account if they are natural or man-made. Natural water bodies are depicted using a light blue (#CCFFFF) filled polygon and a solid blue (#33CCFF) border with stroke width of 1 pixel.Man-made water bodies are depicted using a light blue (#CCFFFF) filled polygon and a solid blue (#0066FF) border with stroke width of 1 pixel.Natural standing waters are rendered by 6 pixel size filled blue circles (#0066FF) on a light blue (#CCFFFF) filled polygon.Man-made standing waters are rendered by 6 pixel size filled blue circles (#0066FF) with a black (?) (#0000) border on a light blue (#0000) filled polygon with a black (?) (#0000) border and a stroke width of 1 pixel.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>hy-p:Watercourse</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Waterbodies natural: lines</se:Title>
+    </se:Description>
+    <ogc:Filter>
+      <ogc:And>
+        <ogc:PropertyIsEqualTo>
+          <ogc:PropertyName>hy-p:delineationKnown</ogc:PropertyName>
+          <ogc:Literal>true</ogc:Literal>
+        </ogc:PropertyIsEqualTo>
+        <ogc:PropertyIsEqualTo>
+          <ogc:PropertyName>hy-p:origin</ogc:PropertyName>
+          <ogc:Literal>natural</ogc:Literal>
+        </ogc:PropertyIsEqualTo>
+        <ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsCurve">
+        		<ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+      </ogc:And>
+    </ogc:Filter>
+    <se:LineSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#33CCFF</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+      </se:Stroke>
+    </se:LineSymbolizer>
+    </se:Rule>
+    <se:Rule>
+     <se:Description>
+      <se:Title>Waterbodies natural: polygons</se:Title>
+    </se:Description>
+    <ogc:Filter>
+      <ogc:And>
+        <ogc:PropertyIsEqualTo>
+          <ogc:PropertyName>hy-p:delineationKnown</ogc:PropertyName>
+          <ogc:Literal>true</ogc:Literal>
+        </ogc:PropertyIsEqualTo>
+        <ogc:PropertyIsEqualTo>
+          <ogc:PropertyName>hy-p:origin</ogc:PropertyName>
+          <ogc:Literal>natural</ogc:Literal>
+        </ogc:PropertyIsEqualTo>
+        <ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsSurface">
+        		<ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+      </ogc:And>
+    </ogc:Filter>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Fill>
+        <se:SvgParameter name="fill">#CCFFFF</se:SvgParameter>
+      </se:Fill>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Waterbodies man-made: lines</se:Title>
+    </se:Description>
+    <ogc:Filter>
+      <ogc:And>
+        <ogc:PropertyIsEqualTo>
+          <ogc:PropertyName>hy-p:delineationKnown</ogc:PropertyName>
+          <ogc:Literal>true</ogc:Literal>
+        </ogc:PropertyIsEqualTo>
+        <ogc:PropertyIsEqualTo>
+          <ogc:PropertyName>hy-p:origin</ogc:PropertyName>
+          <ogc:Literal>manMade</ogc:Literal>
+        </ogc:PropertyIsEqualTo>
+        <ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsCurve">
+        		<ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+      </ogc:And>
+    </ogc:Filter>
+    <se:LineSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#0066FF</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+      </se:Stroke>
+    </se:LineSymbolizer>
+    </se:Rule>
+    <se:Rule>
+        <se:Description>
+      <se:Title>Waterbodies man-made: polygons</se:Title>
+    </se:Description>
+    <ogc:Filter>
+      <ogc:And>
+        <ogc:PropertyIsEqualTo>
+          <ogc:PropertyName>hy-p:delineationKnown</ogc:PropertyName>
+          <ogc:Literal>true</ogc:Literal>
+        </ogc:PropertyIsEqualTo>
+        <ogc:PropertyIsEqualTo>
+          <ogc:PropertyName>hy-p:origin</ogc:PropertyName>
+          <ogc:Literal>manMade</ogc:Literal>
+        </ogc:PropertyIsEqualTo>
+        <ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsSurface">
+        		<ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+      </ogc:And>
+    </ogc:Filter>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Fill>
+        <se:SvgParameter name="fill">#CCFFFF</se:SvgParameter>
+      </se:Fill>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#0000</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+      </se:Stroke>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/generated/feature-styles/HY_P_Watercourse_v5_0.se
+++ b/generated/feature-styles/HY_P_Watercourse_v5_0.se
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:hy-p="http://inspire.ec.europa.eu/schemas/hy-p/5.0" 
+xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" 
+xmlns:sld="http://www.opengis.net/sld" xmlns:xlink="http://www.w3.org/1999/xlink" 
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0"
+xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd">
+  <se:Name>HY.PhysicalWaters.Waterbodies.Default</se:Name>
+  <se:Description>
+    <se:Title>Waterbodies Default Style</se:Title>
+    <se:Abstract>Physical waters as watercourses or standing water can be portrayed with different geometries depending on its dimensions and the level of detail or resolution. Lineal watercourses are depicted by solid blue (#33CCFF) lines with stroke width of 1 pixel and the superficial ones are depicted by filled blue light polygons (#CCFFFF) without border. Punctual standing waters are depicted by dark blue (#0066FF) circles with size of 6 pixel and the superficial ones are depicted by filled blue light polygons (#CCFFFF) without border.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>hy-p:Watercourse</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Watercourse</se:Title>
+    </se:Description>
+    <ogc:Filter>
+      	<ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsCurve">
+        		<ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+    </ogc:Filter>
+    <se:LineSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#33CCFF</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+      </se:Stroke>
+    </se:LineSymbolizer>
+     </se:Rule>
+     <se:Rule>
+     <se:Description>
+      <se:Title>Watercourse</se:Title>
+    </se:Description>
+    <ogc:Filter>
+      	<ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsSurface">
+        		<ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+    </ogc:Filter>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Fill>
+        <se:SvgParameter name="fill">#CCFFFF</se:SvgParameter>
+      </se:Fill>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/generated/feature-styles/HY_P_Wetland_v5_0.se
+++ b/generated/feature-styles/HY_P_Wetland_v5_0.se
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:hy-p="http://inspire.ec.europa.eu/schemas/hy-p/5.0" 
+xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" 
+xmlns:sld="http://www.opengis.net/sld" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd"
+version="1.1.0">
+  <se:Name>HY.PhysicalWaters.Wetland.Default</se:Name>
+  <se:Description>
+    <se:Title>Wetland Default Style</se:Title>
+    <se:Abstract>Wetlands are depicted with blue-green (#00CCCC) filled polygons.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>hy-p:Wetland</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Wetlands</se:Title>
+    </se:Description>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>hy-p:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Fill>
+        <se:SvgParameter name="fill">#00CCCC</se:SvgParameter>
+      </se:Fill>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/generated/feature-styles/LC_LandCoverPoints_v5_0.se
+++ b/generated/feature-styles/LC_LandCoverPoints_v5_0.se
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:lcv="http://inspire.ec.europa.eu/schemas/lcv/5.0" xmlns:net="http://inspire.ec.europa.eu/schemas/net/5.0" xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0" xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd">
+  <se:Name>LC.LandCoverPoints.Default</se:Name>
+  <se:Description>
+    <se:Title>LandCoverPoints Default Style</se:Title>
+    <se:Abstract>This Style defines the default INSPIRE style for Land Cover data supported by a set of points. As there is no required nomenclature, only the geometry is represented, ie as a circle with a size of 3 pixels, with a black (#000000) fill and a black outline (#000000).</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>lcv:LandCoverUnit</se:FeatureTypeName> 
+  <se:Rule>
+  	<se:Description>
+      <se:Title>Land cover unit</se:Title>
+    </se:Description>
+    <ogc:Filter>
+    	<ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsPoint">
+            	<ogc:PropertyName>lcv:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+     	</ogc:PropertyIsEqualTo>
+   	</ogc:Filter>
+    <se:PointSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>lcv:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Graphic>
+        <se:Mark>
+          <se:WellKnownName>circle</se:WellKnownName>
+          <se:Fill>
+            <se:SvgParameter name="fill">#000000</se:SvgParameter>
+          </se:Fill>
+          <se:Stroke>
+            <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+          </se:Stroke>
+        </se:Mark>
+        <se:Size>3</se:Size>
+      </se:Graphic>
+    </se:PointSymbolizer>
+  </se:Rule>  
+ </se:FeatureTypeStyle>   
+   

--- a/generated/feature-styles/LC_LandCoverSurfaces_v5_0.se
+++ b/generated/feature-styles/LC_LandCoverSurfaces_v5_0.se
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:lcv="http://inspire.ec.europa.eu/schemas/lcv/5.0" 
+xmlns:net="http://inspire.ec.europa.eu/schemas/net/5.0" 
+xmlns:ogc="http://www.opengis.net/ogc" 
+xmlns:se="http://www.opengis.net/se" 
+xmlns:sld="http://www.opengis.net/sld" 
+xmlns:xlink="http://www.w3.org/1999/xlink" 
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+version="1.1.0"
+xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd">
+  <se:Name>LC.LandCoverSurfaces.Default</se:Name>
+  <se:Description>
+    <se:Title>LandCoverSurfaces Default Style</se:Title>
+    <se:Abstract>This Style defines the default INSPIRE style for Land Cover data supported by a set of non overlapping polygons. As there is no required nomenclature, only the geometry is represented, ie only polygons with a white (#FFFFFF) fill and a black outline (#000000) of 3 pixels width. </se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>lcv:LandCoverUnit</se:FeatureTypeName> 
+  <se:Rule>
+  	<se:Description>
+      <se:Title>Land cover unit</se:Title>
+    </se:Description>
+    <ogc:Filter>
+    	<ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsSurface">
+            	<ogc:PropertyName>lcv:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+     	</ogc:PropertyIsEqualTo>
+   	</ogc:Filter>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>lcv:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Fill>
+      	<se:SvgParameter name="fill">#FFFFFF</se:SvgParameter>
+      </se:Fill>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">0.5</se:SvgParameter>
+      </se:Stroke>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+ </se:FeatureTypeStyle>

--- a/generated/feature-styles/PS_ProtectedSites_v5_0.se
+++ b/generated/feature-styles/PS_ProtectedSites_v5_0.se
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:PS="urn:xinspire:specification:ProtectedSites:3.1" xmlns:ogc="http://www.opengis.net/ogc" xmlns:ps="http://inspire.ec.europa.eu/schemas/ps/5.0" xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0" xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd">
+  <se:Name>PS.ProtectedSite.Default</se:Name>
+  <se:Description>
+    <se:Title>Protected Sites Default Style</se:Title>
+    <se:Abstract>Point geometries are rendered as a square with a size of 6 pixels, with a 50% grey (#808080) fill and a black (#000000) outline. Line geometries are rendered as a solid black line with a stroke width of 1 pixel. Polygon geometries are rendered using a 50% grey (#808080) fill and a solid black outline with a stroke width of 1 pixel.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>ps:ProtectedSite</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Protected sites: polygons</se:Title>
+    </se:Description>
+    <ogc:Filter>
+    	<ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsSurface">
+        		<ogc:PropertyName>ps:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+   	</ogc:Filter>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>ps:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Fill>
+        <se:SvgParameter name="fill">#808080</se:SvgParameter>
+      </se:Fill>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+      </se:Stroke>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Protected sites: lines</se:Title>
+    </se:Description>
+    <ogc:Filter>
+    	<ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsCurve">
+        		<ogc:PropertyName>ps:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+   	</ogc:Filter>
+    <se:LineSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>ps:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+      </se:Stroke>
+    </se:LineSymbolizer>
+  </se:Rule>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Protected sites: points</se:Title>
+    </se:Description>
+    <ogc:Filter>
+    	<ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsPoint">
+        		<ogc:PropertyName>ps:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+   	</ogc:Filter>
+    <se:PointSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>ps:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Graphic>
+        <se:Mark>
+          <se:WellKnownName>square</se:WellKnownName>
+          <se:Fill>
+            <se:SvgParameter name="fill">#808080</se:SvgParameter>
+          </se:Fill>
+          <se:Stroke>
+            <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+            <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+          </se:Stroke>
+        </se:Mark>
+        <se:Size>6</se:Size>
+      </se:Graphic>
+    </se:PointSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/generated/feature-styles/TN_A_AerodromeArea_v5_0.se
+++ b/generated/feature-styles/TN_A_AerodromeArea_v5_0.se
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:net="http://inspire.ec.europa.eu/schemas/net/5.0" xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:tn-a="http://inspire.ec.europa.eu/schemas/tn-a/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
+  <se:Name>TN.AirTransportNetwork.AerodromeArea.Default</se:Name>
+  <se:Description>
+    <se:Title>Aerodrome Area Default Style</se:Title>
+    <se:Abstract>The geometry is rendered using a 50% Blue (#0000CD) fill and a solid Blue (#0000CD) outline with a stroke width of 1 pixel.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>tn-a:AerodromeArea</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Aerodrome area</se:Title>
+    </se:Description>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>net:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Fill>
+        <se:SvgParameter name="fill">#0000CD</se:SvgParameter>
+        <se:SvgParameter name="fill-opacity">0.5</se:SvgParameter>
+      </se:Fill>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#0000CD</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+      </se:Stroke>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/generated/feature-styles/TN_A_AerodromeNode_v5_0.se
+++ b/generated/feature-styles/TN_A_AerodromeNode_v5_0.se
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" 
+xmlns:sld="http://www.opengis.net/sld" xmlns:net="http://inspire.ec.europa.eu/schemas/net/5.0" 
+xmlns:tn-a="http://inspire.ec.europa.eu/schemas/tn-a/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" 
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd" version="1.1.0">
+  <se:Name>TN.AirTransportNetwork.AerodromeNode.Default</se:Name>
+  <se:Description>
+    <se:Title>Aerodrome Node Default Style</se:Title>
+    <se:Abstract>The geometry is rendered using a yellow (#FFFF00) fill.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>tn-a:AerodromeNode</se:FeatureTypeName>
+  <se:Rule>
+  <se:Description>
+      <se:Title>Aerodrome node</se:Title>
+    </se:Description>
+    <se:PointSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>net:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Graphic>
+        <se:Mark>
+          <se:WellKnownName>square</se:WellKnownName>
+          <se:Fill>
+            <se:SvgParameter name="fill">#FFFF00</se:SvgParameter>
+          </se:Fill>
+          <se:Stroke>
+            <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+            <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+          </se:Stroke>
+        </se:Mark>
+        <se:Size>6</se:Size>
+      </se:Graphic>
+    </se:PointSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/generated/feature-styles/TN_A_AirRouteLink_v5_0.se
+++ b/generated/feature-styles/TN_A_AirRouteLink_v5_0.se
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:net="http://inspire.ec.europa.eu/schemas/net/5.0" xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:tn-a="http://inspire.ec.europa.eu/schemas/tn-a/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
+  <se:Name>TN.AirTransportNetwork.AirLink.Default</se:Name>
+  <se:Description>
+    <se:Title>Air Link Default Style</se:Title>
+    <se:Abstract>The geometry is rendered as a solid Maroon (#800000)line with a stroke width of 3 pixel . Ends are rounded and have a 2 pixel black (#000000) casing.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>tn-a:AirRouteLink</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Air link</se:Title>
+    </se:Description>
+    <se:LineSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>net:centrelineGeometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">7</se:SvgParameter>
+        <se:SvgParameter name="stroke-linejoin">bevel</se:SvgParameter>
+        <se:SvgParameter name="stroke-linecap">round</se:SvgParameter>
+      </se:Stroke>
+    </se:LineSymbolizer>
+    <se:LineSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>net:centrelineGeometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#800000</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">3</se:SvgParameter>
+        <se:SvgParameter name="stroke-linejoin">bevel</se:SvgParameter>
+        <se:SvgParameter name="stroke-linecap">round</se:SvgParameter>
+      </se:Stroke>
+    </se:LineSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/generated/feature-styles/TN_A_AirspaceArea_v5_0.se
+++ b/generated/feature-styles/TN_A_AirspaceArea_v5_0.se
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:tn-a="http://inspire.ec.europa.eu/schemas/tn-a/4.0" 
+xmlns:net="http://inspire.ec.europa.eu/schemas/net/5.0" xmlns:xlink="http://www.w3.org/1999/xlink" 
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd" version="1.1.0">
+  <se:Name>TN.AirTransportNetwork.AirSpaceArea.Default</se:Name>
+  <se:Description>
+    <se:Title>Air Space Area Default Style</se:Title>
+    <se:Abstract>The geometry is rendered using a 25% Magenta (#8B008B) fill and a solid Magenta (#8B008B) outline with a stroke width of 2 pixel.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>tn-a:AirspaceArea</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Air space area</se:Title>
+    </se:Description>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>net:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Fill>
+        <se:SvgParameter name="fill">#8B008B</se:SvgParameter>
+        <se:SvgParameter name="fill-opacity">0.25</se:SvgParameter>
+      </se:Fill>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#808080</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">2</se:SvgParameter>
+      </se:Stroke>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/generated/feature-styles/TN_A_ApronArea_v5_0.se
+++ b/generated/feature-styles/TN_A_ApronArea_v5_0.se
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:net="http://inspire.ec.europa.eu/schemas/net/5.0" xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:tn-a="http://inspire.ec.europa.eu/schemas/tn-a/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
+  <se:Name>TN.AirTransportNetwork.ApronArea.Default</se:Name>
+  <se:Description>
+    <se:Title>Apron Area Default Style</se:Title>
+    <se:Abstract>The geometry is rendered using a 50% grey (#808080) fill and a solid black outline with a stroke width of 1 pixel.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>tn-a:ApronArea</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Apron area</se:Title>
+    </se:Description>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>net:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Fill>
+        <se:SvgParameter name="fill">#808080</se:SvgParameter>
+        <se:SvgParameter name="fill-opacity">0.5</se:SvgParameter>
+      </se:Fill>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+      </se:Stroke>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/generated/feature-styles/TN_A_DesignatedPoint_v5_0.se
+++ b/generated/feature-styles/TN_A_DesignatedPoint_v5_0.se
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" 
+xmlns:sld="http://www.opengis.net/sld" xmlns:net="http://inspire.ec.europa.eu/schemas/net/5.0" 
+xmlns:tn-a="http://inspire.ec.europa.eu/schemas/tn-a/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" 
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd" version="1.1.0">
+  <se:Name>TN.AirTransportNetwork.DesignatedPoint.Default</se:Name>
+  <se:Description>
+    <se:Title>Designated Point Default Style</se:Title>
+    <se:Abstract>The geometry is rendered using an orange (#FF4500) fill.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>tn-a:DesignatedPoint</se:FeatureTypeName>
+  <se:Rule>
+  <se:Description>
+      <se:Title>Designated point</se:Title>
+    </se:Description>
+   <se:PointSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>net:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Graphic>
+        <se:Mark>
+          <se:WellKnownName>circle</se:WellKnownName>
+          <se:Fill>
+            <se:SvgParameter name="fill">#FF4500</se:SvgParameter>
+          </se:Fill>
+          <se:Stroke>
+            <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+            <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+          </se:Stroke>
+        </se:Mark>
+        <se:Size>6</se:Size>
+      </se:Graphic>
+    </se:PointSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/generated/feature-styles/TN_A_Navaid_v5_0.se
+++ b/generated/feature-styles/TN_A_Navaid_v5_0.se
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" 
+xmlns:sld="http://www.opengis.net/sld" xmlns:net="http://inspire.ec.europa.eu/schemas/net/5.0" 
+xmlns:tn-a="http://inspire.ec.europa.eu/schemas/tn-a/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" 
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd" version="1.1.0">
+  <se:Name>TN.AirTransportNetwork.Navaid.Default</se:Name>
+  <se:Description>
+    <se:Title>Navaid Default Style</se:Title>
+    <se:Abstract>The geometry is rendered using a dark blue (#00008B) fill.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>tn-a:Navaid</se:FeatureTypeName>
+   <se:Rule>
+   <se:Description>
+      <se:Title>Navaid</se:Title>
+    </se:Description>
+    <se:PointSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>net:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Graphic>
+        <se:Mark>
+          <se:WellKnownName>circle</se:WellKnownName>
+          <se:Fill>
+            <se:SvgParameter name="fill">#00008B</se:SvgParameter>
+          </se:Fill>
+          <se:Stroke>
+            <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+            <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+          </se:Stroke>
+        </se:Mark>
+        <se:Size>6</se:Size>
+      </se:Graphic>
+    </se:PointSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/generated/feature-styles/TN_A_ProcedureLink_v5_0.se
+++ b/generated/feature-styles/TN_A_ProcedureLink_v5_0.se
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:net="http://inspire.ec.europa.eu/schemas/net/5.0" xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:tn-a="http://inspire.ec.europa.eu/schemas/tn-a/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
+  <se:Name>TN.AirTransportNetwork.ProcedureLink.Default</se:Name>
+  <se:Description>
+    <se:Title>Air Link Default Style</se:Title>
+    <se:Abstract>The geometry is rendered as a solid Maroon (#800000)line with a stroke width of 3 pixel . Ends are rounded and have a 2 pixel black (#000000) casing.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>tn-a:ProcedureLink</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Air link</se:Title>
+    </se:Description>
+    <se:LineSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>net:centrelineGeometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">7</se:SvgParameter>
+        <se:SvgParameter name="stroke-linejoin">bevel</se:SvgParameter>
+        <se:SvgParameter name="stroke-linecap">round</se:SvgParameter>
+      </se:Stroke>
+    </se:LineSymbolizer>
+    <se:LineSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>net:centrelineGeometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#800000</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">3</se:SvgParameter>
+        <se:SvgParameter name="stroke-linejoin">bevel</se:SvgParameter>
+        <se:SvgParameter name="stroke-linecap">round</se:SvgParameter>
+      </se:Stroke>
+    </se:LineSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/generated/feature-styles/TN_A_RunwayArea_v5_0.se
+++ b/generated/feature-styles/TN_A_RunwayArea_v5_0.se
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" 
+xmlns:sld="http://www.opengis.net/sld" xmlns:net="http://inspire.ec.europa.eu/schemas/net/5.0" 
+xmlns:tn-a="http://inspire.ec.europa.eu/schemas/tn-a/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" 
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd" version="1.1.0">
+  <se:Name>TN.AirTransportNetwork.RunwayArea.Default</se:Name>
+  <se:Description>
+    <se:Title>Runway Area Default Style</se:Title>
+    <se:Abstract>The geometry is rendered using a White (#FFFFFF) fill and a solid Blue (#0000CD)outline with a stroke width of 2 pixel.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>tn-a:RunwayArea</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Runway area</se:Title>
+    </se:Description>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>net:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Fill>
+        <se:SvgParameter name="fill">#FFFFFF</se:SvgParameter>
+      </se:Fill>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#0000CD</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">2</se:SvgParameter>
+      </se:Stroke>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/generated/feature-styles/TN_A_RunwayCentrelinePoint_v5_0.se
+++ b/generated/feature-styles/TN_A_RunwayCentrelinePoint_v5_0.se
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" 
+xmlns:sld="http://www.opengis.net/sld" xmlns:net="http://inspire.ec.europa.eu/schemas/net/5.0" 
+xmlns:tn-a="http://inspire.ec.europa.eu/schemas/tn-a/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" 
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd" version="1.1.0">
+  <se:Name>TN.AirTransportNetwork.RunwayCentrelinePoint.Default</se:Name>
+  <se:Description>
+    <se:Title>Runway Centreline Point Default Style</se:Title>
+    <se:Abstract>The geometry is rendered using a red (#FF0000) fill.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>tn-a:RunwayCentrelinePoint</se:FeatureTypeName>
+  <se:Rule>
+  <se:Description>
+      <se:Title>Runway centreline point</se:Title>
+    </se:Description>
+    <se:PointSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>net:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Graphic>
+        <se:Mark>
+          <se:WellKnownName>triangle</se:WellKnownName>
+          <se:Fill>
+            <se:SvgParameter name="fill">#FF0000</se:SvgParameter>
+          </se:Fill>
+          <se:Stroke>
+            <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+            <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+          </se:Stroke>
+        </se:Mark>
+        <se:Size>6</se:Size>
+      </se:Graphic>
+    </se:PointSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/generated/feature-styles/TN_A_TaxiwayArea_v5_0.se
+++ b/generated/feature-styles/TN_A_TaxiwayArea_v5_0.se
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:net="http://inspire.ec.europa.eu/schemas/net/5.0" xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:tn-a="http://inspire.ec.europa.eu/schemas/tn-a/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
+  <se:Name>TN.AirTransportNetwork.TaxiwayArea.Default</se:Name>
+  <se:Description>
+    <se:Title>Taxiway Area Default Style</se:Title>
+    <se:Abstract>The geometry is rendered using a Blue (#B0E0E6) fill and a solid black outline with a stroke width of 1 pixel.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>tn-a:TaxiwayArea</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Taxiway area</se:Title>
+    </se:Description>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>net:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Fill>
+        <se:SvgParameter name="fill">#B0E0E6</se:SvgParameter>
+      </se:Fill>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+      </se:Stroke>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/generated/feature-styles/TN_A_TouchDownLiftOff_v5_0.se
+++ b/generated/feature-styles/TN_A_TouchDownLiftOff_v5_0.se
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" 
+xmlns:sld="http://www.opengis.net/sld" xmlns:net="http://inspire.ec.europa.eu/schemas/net/5.0" 
+xmlns:tn-a="http://inspire.ec.europa.eu/schemas/tn-a/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" 
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd" version="1.1.0">
+  <se:Name>TN.AirTransportNetwork.TouchDownLiftOff.Default</se:Name>
+  <se:Description>
+    <se:Title>Touch Down Lift Off Default Style</se:Title>
+    <se:Abstract>The geometry is rendered using a purple (#CC8899) fill.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>tn-a:TouchDownLiftOff</se:FeatureTypeName>
+  <se:Rule>
+  <se:Description>
+      <se:Title>Touch down lift off</se:Title>
+    </se:Description>
+    <se:PointSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>net:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Graphic>
+        <se:Mark>
+          <se:WellKnownName>star</se:WellKnownName>
+          <se:Fill>
+            <se:SvgParameter name="fill">#CC8899</se:SvgParameter>
+          </se:Fill>
+          <se:Stroke>
+            <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+            <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+          </se:Stroke>
+        </se:Mark>
+        <se:Size>6</se:Size>
+      </se:Graphic>
+    </se:PointSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/generated/feature-styles/TN_C_CablewayLink_v5_0.se
+++ b/generated/feature-styles/TN_C_CablewayLink_v5_0.se
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:net="http://inspire.ec.europa.eu/schemas/net/5.0" xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:tn-c="http://inspire.ec.europa.eu/schemas/tn-c/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
+  <se:Name>TN.CableTransportNetwork.CablewayLink.Default</se:Name>
+  <se:Description>
+    <se:Title>Cableway Link Default Style</se:Title>
+    <se:Abstract> The geometry is rendered as a solid magenta line with a stroke width of 3 pixel (#B10787). Ends are rounded and have a 2 pixel black casing (#000000).</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>tn-c:CablewayLink</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Cableway link</se:Title>
+    </se:Description>
+    <se:LineSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>net:centrelineGeometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">7</se:SvgParameter>
+        <se:SvgParameter name="stroke-linejoin">bevel</se:SvgParameter>
+        <se:SvgParameter name="stroke-linecap">round</se:SvgParameter>
+      </se:Stroke>
+    </se:LineSymbolizer>
+    <se:LineSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>net:centrelineGeometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#B10787</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">3</se:SvgParameter>
+        <se:SvgParameter name="stroke-linejoin">bevel</se:SvgParameter>
+        <se:SvgParameter name="stroke-linecap">round</se:SvgParameter>
+      </se:Stroke>
+    </se:LineSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/generated/feature-styles/TN_MarkerPost_v5_0.se
+++ b/generated/feature-styles/TN_MarkerPost_v5_0.se
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" 
+xmlns:tn="http://inspire.ec.europa.eu/schemas/tn/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
+  <se:Name>TN.CommonTransportElements.MarkerPost.Default</se:Name>
+  <se:Description>
+    <se:Title>Marker Post Default Style</se:Title>
+    <se:Abstract>The geometry is rendered as a circle with a size of 3 pixels, with a red (#FF0000) fill and a black outline (#000000).</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>tn:MarkerPost</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Marker post</se:Title>
+    </se:Description>
+    <se:PointSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>tn:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Graphic>
+        <se:Mark>
+          <se:WellKnownName>circle</se:WellKnownName>
+          <se:Fill>
+            <se:SvgParameter name="fill">#FF0000</se:SvgParameter>
+          </se:Fill>
+          <se:Stroke>
+            <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+            <se:SvgParameter name="stroke-width">0.5</se:SvgParameter>
+          </se:Stroke>
+        </se:Mark>
+        <se:Size>3</se:Size>
+      </se:Graphic>
+    </se:PointSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/generated/feature-styles/TN_RA_RailwayArea_v5_0.se
+++ b/generated/feature-styles/TN_RA_RailwayArea_v5_0.se
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:net="http://inspire.ec.europa.eu/schemas/net/5.0" xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:tn-ra="http://inspire.ec.europa.eu/schemas/tn-ra/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
+  <se:Name>TN.RailTransportNetwork.RailwayArea.Default</se:Name>
+  <se:Description>
+    <se:Title>Railway Area Default Style</se:Title>
+    <se:Abstract>The geometry is rendered using a Brown (#8B4513) fill and a solid black (#000000) outline with a stroke width of 1 pixel.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>tn-ra:RailwayArea</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Railway area</se:Title>
+    </se:Description>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>net:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Fill>
+        <se:SvgParameter name="fill">#8B4513</se:SvgParameter>
+      </se:Fill>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+      </se:Stroke>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/generated/feature-styles/TN_RA_RailwayLink_v5_0.se
+++ b/generated/feature-styles/TN_RA_RailwayLink_v5_0.se
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:net="http://inspire.ec.europa.eu/schemas/net/5.0" xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:tn-ra="http://inspire.ec.europa.eu/schemas/tn-ra/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
+  <se:Name>TN.RailTransportNetwork.RailwayLink.Default</se:Name>
+  <se:Description>
+    <se:Title>Railway Link Default Style</se:Title>
+    <se:Abstract>The geometry is rendered as a solid Black (#000000) line with a stroke width of 3 pixel. Ends are rounded and have a 2 pixel black (#000000) casing.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>tn-ra:RailwayLink</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Railway link</se:Title>
+    </se:Description>
+    <se:LineSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>net:centrelineGeometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">5</se:SvgParameter>
+        <se:SvgParameter name="stroke-linejoin">bevel</se:SvgParameter>
+        <se:SvgParameter name="stroke-linecap">round</se:SvgParameter>
+      </se:Stroke>
+    </se:LineSymbolizer>
+    <se:LineSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>net:centrelineGeometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">2</se:SvgParameter>
+        <se:SvgParameter name="stroke-linejoin">bevel</se:SvgParameter>
+        <se:SvgParameter name="stroke-linecap">round</se:SvgParameter>
+      </se:Stroke>
+    </se:LineSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/generated/feature-styles/TN_RA_RailwayStationArea_v5_0.se
+++ b/generated/feature-styles/TN_RA_RailwayStationArea_v5_0.se
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" 
+xmlns:net="http://inspire.ec.europa.eu/schemas/net/5.0"
+xmlns:sld="http://www.opengis.net/sld" xmlns:tn-ra="http://inspire.ec.europa.eu/schemas/tn-ra/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
+  <se:Name>TN.RailTransportNetwork.RailwayStationArea.Default</se:Name>
+  <se:Description>
+    <se:Title>Railway Station Area Default Style</se:Title>
+    <se:Abstract>The geometry is rendered using a Brown (#8B4513) fill and a solid black (#000000) outline with a stroke width of 1 pixel.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>tn-ra:RailwayStationArea</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Railway station area</se:Title>
+    </se:Description>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>net:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Fill>
+        <se:SvgParameter name="fill">#8B4513</se:SvgParameter>
+      </se:Fill>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+      </se:Stroke>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/generated/feature-styles/TN_RA_RailwayYardArea_v5_0.se
+++ b/generated/feature-styles/TN_RA_RailwayYardArea_v5_0.se
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:ogc="http://www.opengis.net/ogc" 
+xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" 
+xmlns:net="http://inspire.ec.europa.eu/schemas/net/5.0"
+xmlns:tn-ra="http://inspire.ec.europa.eu/schemas/tn-ra/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
+  <se:Name>TN.RailTransportNetwork.RailwayYardArea.Default</se:Name>
+  <se:Description>
+    <se:Title>Railway Yard Area Default Style</se:Title>
+    <se:Abstract>The geometry is rendered using a Brown (#8B4513) fill and a solid black (#000000) outline with a stroke width of 1 pixel.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>tn-ra:RailwayYardArea</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Railway yard area</se:Title>
+    </se:Description>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>net:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Fill>
+        <se:SvgParameter name="fill">#8B4513</se:SvgParameter>
+      </se:Fill>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+      </se:Stroke>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/generated/feature-styles/TN_RO_RoadArea_v5_0.se
+++ b/generated/feature-styles/TN_RO_RoadArea_v5_0.se
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:net="http://inspire.ec.europa.eu/schemas/net/5.0" xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:tn-ro="http://inspire.ec.europa.eu/schemas/tn-ro/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
+  <se:Name>TN.RoadTransportNetwork.RoadArea.Default</se:Name>
+  <se:Description>
+    <se:Title>Road Area Default Style</se:Title>
+    <se:Abstract>The geometry is rendered using a grey (#A9A9A9) fill and a solid black (#000000) outline with a stroke width of 1 pixel.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>tn-ro:RoadArea</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Road area</se:Title>
+    </se:Description>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>net:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Fill>
+        <se:SvgParameter name="fill">#A9A9A9</se:SvgParameter>
+      </se:Fill>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+      </se:Stroke>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/generated/feature-styles/TN_RO_RoadLink_v5_0.se
+++ b/generated/feature-styles/TN_RO_RoadLink_v5_0.se
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:net="http://inspire.ec.europa.eu/schemas/net/5.0" xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:tn-ro="http://inspire.ec.europa.eu/schemas/tn-ro/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
+  <se:Name>TN.RoadTransportNetwork.RoadLink.Default</se:Name>
+  <se:Description>
+    <se:Title>Road Link Default Style</se:Title>
+    <se:Abstract>The geometry is rendered as a solid Green (#008000) line with a stroke width of 3 pixel. Ends are rounded and have a 2 pixel black (#000000) casing.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>tn-ro:RoadLink</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Road link</se:Title>
+    </se:Description>
+    <se:LineSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>net:centrelineGeometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">5</se:SvgParameter>
+        <se:SvgParameter name="stroke-linejoin">bevel</se:SvgParameter>
+        <se:SvgParameter name="stroke-linecap">round</se:SvgParameter>
+      </se:Stroke>
+    </se:LineSymbolizer>
+    <se:LineSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>net:centrelineGeometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#008000</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">2</se:SvgParameter>
+        <se:SvgParameter name="stroke-linejoin">bevel</se:SvgParameter>
+        <se:SvgParameter name="stroke-linecap">round</se:SvgParameter>
+      </se:Stroke>
+    </se:LineSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/generated/feature-styles/TN_RO_RoadNode_v5_0.se
+++ b/generated/feature-styles/TN_RO_RoadNode_v5_0.se
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle
+version="1.1.0"   
+xmlns:net="http://inspire.ec.europa.eu/schemas/net/5.0" 
+xmlns:ogc="http://www.opengis.net/ogc" 
+xmlns:se="http://www.opengis.net/se" 
+xmlns:sld="http://www.opengis.net/sld" 
+xmlns:tn-ro="http://inspire.ec.europa.eu/schemas/tn-ro/4.0" 
+xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd">
+      <se:Name>TN.RoadTransportNetwork.RoadNode.Default</se:Name>
+	  <se:Description>
+		<se:Title>Road Node Default Style</se:Title>
+		<se:Abstract>The geometry is rendered using a red (#FF0000) fill and a solid black (#000000) outline with a stroke width of 1 pixel.</se:Abstract>
+	  </se:Description>
+		  <se:FeatureTypeName>tn-ro:RoadNode</se:FeatureTypeName>
+		  <se:Rule>
+			<se:Description>
+			  <se:Title>Road node</se:Title>
+			</se:Description>
+			<se:PointSymbolizer>
+			  <se:Geometry>
+				<ogc:PropertyName>net:geometry</ogc:PropertyName>
+			  </se:Geometry>
+			     <se:Graphic>
+					<se:Mark>
+						<se:WellKnownName>circle</se:WellKnownName>
+						<se:Fill>
+							<se:SvgParameter name="fill">#FF0000</se:SvgParameter>
+						</se:Fill>
+						<se:Stroke>
+							<se:SvgParameter name="stroke">#000000</se:SvgParameter>
+							<se:SvgParameter name="stroke-width">1</se:SvgParameter>
+						</se:Stroke>
+					</se:Mark>
+					<se:Size>3</se:Size>
+				</se:Graphic>
+			</se:PointSymbolizer>
+		  </se:Rule>
+		</se:FeatureTypeStyle>

--- a/generated/feature-styles/TN_RO_RoadServiceArea_v5_0.se
+++ b/generated/feature-styles/TN_RO_RoadServiceArea_v5_0.se
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:net="http://inspire.ec.europa.eu/schemas/net/5.0" xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:tn-ro="http://inspire.ec.europa.eu/schemas/tn-ro/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
+  <se:Name>TN.RoadTransportNetwork.RoadServiceArea.Default</se:Name>
+  <se:Description>
+    <se:Title>Road Service Area Default Style</se:Title>
+    <se:Abstract>The geometry is rendered using a grey (#A9A9A9) fill and a solid black (#000000) outline with a stroke width of 1 pixel.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>tn-ro:RoadServiceArea</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Road service area</se:Title>
+    </se:Description>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>net:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Fill>
+        <se:SvgParameter name="fill">#A9A9A9</se:SvgParameter>
+      </se:Fill>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+      </se:Stroke>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/generated/feature-styles/TN_RO_VehicleTrafficArea_v5_0.se
+++ b/generated/feature-styles/TN_RO_VehicleTrafficArea_v5_0.se
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:net="http://inspire.ec.europa.eu/schemas/net/5.0" xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:tn-ro="http://inspire.ec.europa.eu/schemas/tn-ro/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
+  <se:Name>TN.RoadTransportNetwork.VehicleTrafficArea.Default</se:Name>
+  <se:Description>
+    <se:Title>Vehicle Traffic Area Default Style</se:Title>
+    <se:Abstract>The geometry is rendered using a grey (#A9A9A9) fill and a solid black (#000000) outline with a stroke width of 1 pixel.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>tn-ro:VehicleTrafficArea</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Vehicle traffic area</se:Title>
+    </se:Description>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>net:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Fill>
+        <se:SvgParameter name="fill">#A9A9A9</se:SvgParameter>
+      </se:Fill>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+      </se:Stroke>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/generated/feature-styles/TN_TransportArea_v5_0.se
+++ b/generated/feature-styles/TN_TransportArea_v5_0.se
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:tn="http://inspire.ec.europa.eu/schemas/tn/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
+  <se:Name>TN.CommonTransportElements.TransportArea.Default</se:Name>
+  <se:Description>
+    <se:Title>Transport Area Default Style</se:Title>
+    <se:Abstract>The geometry is rendered using a grey (#A9A9A9) fill and a solid black (#000000) outline with a stroke width of 1 pixel.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>tn:TransportArea</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Transport area</se:Title>
+    </se:Description>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>tn:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Fill>
+        <se:SvgParameter name="fill">#A9A9A9</se:SvgParameter>
+      </se:Fill>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+      </se:Stroke>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/generated/feature-styles/TN_TransportLink_v5_0.se
+++ b/generated/feature-styles/TN_TransportLink_v5_0.se
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:net="http://inspire.ec.europa.eu/schemas/net/4.0" xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:tn="http://inspire.ec.europa.eu/schemas/tn/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
+  <se:Name>TN.CommonTransportElements.TransportLink.Default</se:Name>
+  <se:Description>
+    <se:Title>Transport Link Default Style</se:Title>
+    <se:Abstract>The geometry is rendered as a solid Black line with a stroke width of 3 pixel (#000000). Ends are rounded and have a 2 pixel black casing (#000000).</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>tn:TransportLink</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Transport link</se:Title>
+    </se:Description>
+    <se:LineSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>net:centrelineGeometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">7</se:SvgParameter>
+        <se:SvgParameter name="stroke-linejoin">bevel</se:SvgParameter>
+        <se:SvgParameter name="stroke-linecap">round</se:SvgParameter>
+      </se:Stroke>
+    </se:LineSymbolizer>
+    <se:LineSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>net:centrelineGeometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">3</se:SvgParameter>
+        <se:SvgParameter name="stroke-linejoin">bevel</se:SvgParameter>
+        <se:SvgParameter name="stroke-linecap">round</se:SvgParameter>
+      </se:Stroke>
+    </se:LineSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/generated/feature-styles/TN_TransportNode_v5_0.se
+++ b/generated/feature-styles/TN_TransportNode_v5_0.se
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:tn="http://inspire.ec.europa.eu/schemas/tn/4.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
+  <se:Name>TN.CommonTransportElements.TransportNode.Default</se:Name>
+  <se:Description>
+    <se:Title>Transport Node Default Style</se:Title>
+    <se:Abstract>The geometry is rendered as a circle with a size of 3 pixels, with a red (#FF0000) fill and a black outline (#000000).</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>tn:TransportNode</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Transport node</se:Title>
+    </se:Description>
+    <se:PointSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>tn:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Graphic>
+        <se:Mark>
+          <se:WellKnownName>circle</se:WellKnownName>
+          <se:Fill>
+            <se:SvgParameter name="fill">#FF0000</se:SvgParameter>
+          </se:Fill>
+          <se:Stroke>
+            <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+            <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+          </se:Stroke>
+        </se:Mark>
+        <se:Size>3</se:Size>
+      </se:Graphic>
+    </se:PointSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/generated/feature-styles/TN_W_Beacon_v5_0.se
+++ b/generated/feature-styles/TN_W_Beacon_v5_0.se
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" 
+xmlns:net="http://inspire.ec.europa.eu/schemas/net/5.0"
+xmlns:tn="http://inspire.ec.europa.eu/schemas/tn/5.0"
+xmlns:sld="http://www.opengis.net/sld" xmlns:tn-w="http://inspire.ec.europa.eu/schemas/tn-w/5.0" xmlns:xlink="http://www.w3.org/1999/xlink" 
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
+  <se:Name>TN.WaterTransportNetwork.Beacon.Default</se:Name>
+  <se:Description>
+    <se:Title>Beacon Default Style</se:Title>
+    <se:Abstract>The geometry is rendered as a circle with a size of 3 pixels, with an orange (#FF6600) fill and a black outline (#000000).</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>tn-w:Beacon</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Beacon</se:Title>
+    </se:Description>
+    <se:PointSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>tn:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Graphic>
+        <se:Mark>
+          <se:WellKnownName>circle</se:WellKnownName>
+          <se:Fill>
+            <se:SvgParameter name="fill">#FF6600</se:SvgParameter>
+          </se:Fill>
+          <se:Stroke>
+            <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+            <se:SvgParameter name="stroke-width">0.5</se:SvgParameter>
+          </se:Stroke>
+        </se:Mark>
+        <se:Size>3</se:Size>
+      </se:Graphic>
+    </se:PointSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/generated/feature-styles/TN_W_Buoy_v5_0.se
+++ b/generated/feature-styles/TN_W_Buoy_v5_0.se
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" 
+xmlns:net="http://inspire.ec.europa.eu/schemas/net/5.0"
+xmlns:tn-w="http://inspire.ec.europa.eu/schemas/tn-w/5.0"
+xmlns:sld="http://www.opengis.net/sld" xmlns:tn="http://inspire.ec.europa.eu/schemas/tn/5.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
+  <se:Name>TN.WaterTransportNetwork.Buoy.Default</se:Name>
+  <se:Description>
+    <se:Title>Buoy Default Style</se:Title>
+    <se:Abstract>The geometry is rendered as a circle with a size of 3 pixels, with a green (#008000) fill and a black outline (#000000).</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>tn-w:Buoy</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Buoy</se:Title>
+    </se:Description>
+    <se:PointSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>tn:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Graphic>
+        <se:Mark>
+          <se:WellKnownName>circle</se:WellKnownName>
+          <se:Fill>
+            <se:SvgParameter name="fill">#008000</se:SvgParameter>
+          </se:Fill>
+          <se:Stroke>
+            <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+            <se:SvgParameter name="stroke-width">0.5</se:SvgParameter>
+          </se:Stroke>
+        </se:Mark>
+        <se:Size>3</se:Size>
+      </se:Graphic>
+    </se:PointSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/generated/feature-styles/TN_W_FairwayArea_v5_0.se
+++ b/generated/feature-styles/TN_W_FairwayArea_v5_0.se
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:ogc="http://www.opengis.net/ogc" 
+xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" 
+xmlns:net="http://inspire.ec.europa.eu/schemas/net/5.0"
+xmlns:tn-w="http://inspire.ec.europa.eu/schemas/tn-w/5.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
+  <se:Name>TN.WaterTransportNetwork.FairwayArea.Default</se:Name>
+  <se:Description>
+    <se:Title>Fairway Area Default Style</se:Title>
+    <se:Abstract>The geometry is rendered using a Blue (#4169E1) fill and a solid black (#000000) outline with a stroke width of 1 pixel.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>tn-w:FairwayArea</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Fairway area</se:Title>
+    </se:Description>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>net:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Fill>
+        <se:SvgParameter name="fill">#4169E1</se:SvgParameter>
+      </se:Fill>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+      </se:Stroke>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/generated/feature-styles/TN_W_PortArea_v5_0.se
+++ b/generated/feature-styles/TN_W_PortArea_v5_0.se
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" 
+xmlns:net="http://inspire.ec.europa.eu/schemas/net/5.0"
+xmlns:sld="http://www.opengis.net/sld" xmlns:tn-w="http://inspire.ec.europa.eu/schemas/tn-w/5.0" 
+xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
+  <se:Name>TN.WaterTransportNetwork.PortArea.Default</se:Name>
+  <se:Description>
+    <se:Title>Port Area Default Style</se:Title>
+    <se:Abstract>The geometry is rendered using a Grey (#696969) fill and a solid black (#000000) outline with a stroke width of 1 pixel.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>tn-w:PortArea</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Port area</se:Title>
+    </se:Description>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>net:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Fill>
+        <se:SvgParameter name="fill">#696969</se:SvgParameter>
+      </se:Fill>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+      </se:Stroke>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/generated/feature-styles/TN_W_TrafficSeparationSchemeCrossing_v5_0.se
+++ b/generated/feature-styles/TN_W_TrafficSeparationSchemeCrossing_v5_0.se
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" 
+xmlns:tn-w="http://inspire.ec.europa.eu/schemas/tn-w/5.0" xmlns:xlink="http://www.w3.org/1999/xlink" 
+xmlns:net="http://inspire.ec.europa.eu/schemas/net/5.0"
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
+  <se:Name>TN.WaterTransportNetwork.TrafficSeparationSchemeCrossing.Default</se:Name>
+  <se:Description>
+    <se:Title>Traffic Separation Scheme Crossing Default Style</se:Title>
+    <se:Abstract>The geometry is rendered using an opaque yellow (#FFCC00) fill and a solid yellow (#FFCC00) outline with a stroke width of 1 pixel.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>tn-w:TrafficSeparationSchemeCrossing</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Traffic separation scheme crossing</se:Title>
+    </se:Description>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>net:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Fill>
+        <se:SvgParameter name="fill">#FFCC00</se:SvgParameter>
+         <se:SvgParameter name="fill-opacity">0.5</se:SvgParameter>
+      </se:Fill>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#FFCC00</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+      </se:Stroke>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/generated/feature-styles/TN_W_TrafficSeparationSchemeSeparator_v5_0.se
+++ b/generated/feature-styles/TN_W_TrafficSeparationSchemeSeparator_v5_0.se
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" 
+xmlns:sld="http://www.opengis.net/sld" xmlns:tn-w="http://inspire.ec.europa.eu/schemas/tn-w/5.0" 
+xmlns:net="http://inspire.ec.europa.eu/schemas/net/5.0"
+xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
+  <se:Name>TN.WaterTransportNetwork.TrafficSeparationSchemeSeparator.Default</se:Name>
+  <se:Description>
+    <se:Title>Traffic Separation Scheme Separator Default Style</se:Title>
+    <se:Abstract>The geometry is rendered using an opaque red (#FF0000) fill and a solid red (#FF0000) outline with a stroke width of 1 pixel.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>tn-w:TrafficSeparationSchemeSeparator</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Traffic separation scheme separator</se:Title>
+    </se:Description>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>net:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Fill>
+        <se:SvgParameter name="fill">#FF0000</se:SvgParameter>
+        <se:SvgParameter name="fill-opacity">0.5</se:SvgParameter> 
+      </se:Fill>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#FF0000</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+      </se:Stroke>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/generated/feature-styles/TN_W_WaterwayLink_v5_0.se
+++ b/generated/feature-styles/TN_W_WaterwayLink_v5_0.se
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:net="http://inspire.ec.europa.eu/schemas/net/5.0" xmlns:ogc="http://www.opengis.net/ogc" 
+xmlns:se="http://www.opengis.net/se" xmlns:sld="http://www.opengis.net/sld" xmlns:tn-w="http://inspire.ec.europa.eu/schemas/tn-w/5.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
+  <se:Name>TN.WaterTransportNetwork.WaterwayLink.Default</se:Name>
+  <se:Description>
+    <se:Title>Waterway Link Default Style</se:Title>
+    <se:Abstract>The geometry is rendered as a solid violet (#EE82EE) line with a stroke width of 3 pixel. Ends are rounded and have a 2 pixel black (#000000) casing.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>tn-w:WaterwayLink</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Waterway link</se:Title>
+    </se:Description>
+    <se:LineSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>net:centrelineGeometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">5</se:SvgParameter>
+        <se:SvgParameter name="stroke-linejoin">bevel</se:SvgParameter>
+        <se:SvgParameter name="stroke-linecap">round</se:SvgParameter>
+      </se:Stroke>
+    </se:LineSymbolizer>
+    <se:LineSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>net:centrelineGeometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#EE82EE</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">2</se:SvgParameter>
+        <se:SvgParameter name="stroke-linejoin">bevel</se:SvgParameter>
+        <se:SvgParameter name="stroke-linecap">round</se:SvgParameter>
+      </se:Stroke>
+    </se:LineSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/generated/feature-styles/US_EnvironmentalManagementFacility_v5_0.se
+++ b/generated/feature-styles/US_EnvironmentalManagementFacility_v5_0.se
@@ -1,0 +1,230 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:us-emf="http://inspire.ec.europa.eu/schemas/us-emf/4.0"
+xmlns:act-core="http://inspire.ec.europa.eu/schemas/act-core/4.0"
+xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se"
+xmlns:sld="http://www.opengis.net/sld" xmlns:xlink="http://www.w3.org/1999/xlink"
+xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd"
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
+	<se:Name>US.EnvironmentalManagementFacility</se:Name>
+	<se:Description>
+    	<se:Title>Environmental Management Facility</se:Title>
+    	<se:Abstract>Point geometries are rendered as a triangle with a size of 5 pixels, with a 50% grey (#808080) fill and a black outline. Line geometries are rendered as a solid black line with a stroke width of 1 pixel.
+		Polygon geometries are rendered using a 50% grey (#808080) fill and a solid black outline with a stroke width of 1 pixel. Installation and site styles are applied when present in data.</se:Abstract>
+	</se:Description>
+	<se:FeatureTypeName>us-emf:EnvironmentalManagementFacility</se:FeatureTypeName>
+  	<se:Rule>
+			<se:Description>
+	      <se:Title>Environmental management facility default</se:Title>
+	    </se:Description>
+  	<ogc:Filter>
+    	<ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsSurface">
+        		<ogc:PropertyName>act-core:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+   		</ogc:Filter>
+	    <se:PolygonSymbolizer>
+	      <se:Geometry>
+	        <ogc:PropertyName>act-core:geometry</ogc:PropertyName>
+	      </se:Geometry>
+	      <se:Fill>
+	      	<se:SvgParameter name="fill">#808080</se:SvgParameter>
+	      	<se:SvgParameter name="fill-opacity">0.50</se:SvgParameter>
+	      </se:Fill>
+	      <se:Stroke>
+	        <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+	        <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+	      </se:Stroke>
+	    </se:PolygonSymbolizer>
+	  </se:Rule>
+	  <se:Rule>
+			<se:Description>
+	      <se:Title>Environmental management facility default</se:Title>
+	    </se:Description>
+		<ogc:Filter>
+    		<ogc:PropertyIsEqualTo>
+        		<ogc:Function name="IsPoint">
+        			<ogc:PropertyName>act-core:geometry</ogc:PropertyName>
+       			</ogc:Function>
+       			<ogc:Literal>true</ogc:Literal>
+       		</ogc:PropertyIsEqualTo>
+   		</ogc:Filter>
+	    <se:PointSymbolizer>
+	      <se:Geometry>
+	        <ogc:PropertyName>act-core:geometry</ogc:PropertyName>
+	      </se:Geometry>
+	      <se:Graphic>
+	        <se:Mark>
+	          <se:WellKnownName>triangle</se:WellKnownName>
+	          <se:Fill>
+	            <se:SvgParameter name="fill">#808080</se:SvgParameter>
+	            <se:SvgParameter name="fill-opacity">0.50</se:SvgParameter>
+	          </se:Fill>
+	          <se:Stroke>
+	            <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+	            <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+	          </se:Stroke>
+	        </se:Mark>
+	        <se:Size>5</se:Size>
+	      </se:Graphic>
+	    </se:PointSymbolizer>
+	</se:Rule>
+	<se:Rule>
+		<se:Description>
+			<se:Title>Environmental management facility default</se:Title>
+		</se:Description>
+		<ogc:Filter>
+    		<ogc:PropertyIsEqualTo>
+        		<ogc:Function name="IsCurve">
+        			<ogc:PropertyName>act-core:geometry</ogc:PropertyName>
+       			</ogc:Function>
+       			<ogc:Literal>true</ogc:Literal>
+       		</ogc:PropertyIsEqualTo>
+   		</ogc:Filter>
+	    <se:LineSymbolizer>
+	      <se:Geometry>
+	        <ogc:PropertyName>act-core:geometry</ogc:PropertyName>
+	      </se:Geometry>
+	      <se:Stroke>
+	      	<se:SvgParameter name="stroke">#000000</se:SvgParameter>
+	        <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+	      </se:Stroke>
+	    </se:LineSymbolizer>
+  	</se:Rule>
+		<se:Rule>
+	   <se:Description>
+      <se:Title>Installation</se:Title>
+    </se:Description>
+    <ogc:Filter>
+    	<ogc:And>
+    		<ogc:PropertyIsEqualTo>
+        		<ogc:Function name="IsPoint">
+        			<ogc:PropertyName>act-core:geometry</ogc:PropertyName>
+       			</ogc:Function>
+       			<ogc:Literal>true</ogc:Literal>
+       		</ogc:PropertyIsEqualTo>
+		<ogc:PropertyIsEqualTo>
+				<ogc:PropertyName>us-emf:type/@xlink:href</ogc:PropertyName>
+				<ogc:Literal>http://inspire.ec.europa.eu/codelist/EnvironmentalManagementFacilityTypeValue/installation</ogc:Literal>
+			</ogc:PropertyIsEqualTo>
+		 </ogc:And>
+   	</ogc:Filter>
+	    <se:PointSymbolizer>
+	      <se:Geometry>
+	        <ogc:PropertyName>act-core:geometry</ogc:PropertyName>
+	      </se:Geometry>
+	      <se:Graphic>
+	        <se:Mark>
+	          <se:WellKnownName>triangle</se:WellKnownName>
+	          <se:Fill>
+	            <se:SvgParameter name="fill">#808080</se:SvgParameter>
+	          </se:Fill>
+	          <se:Stroke>
+	            <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+	            <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+	          </se:Stroke>
+	        </se:Mark>
+	        <se:Size>5</se:Size>
+	      </se:Graphic>
+	    </se:PointSymbolizer>
+		</se:Rule>
+		<se:Rule>
+  	 <se:Description>
+      <se:Title>Site</se:Title>
+    </se:Description>
+  	<ogc:Filter>
+    	<ogc:And>
+    		<ogc:PropertyIsEqualTo>
+        		<ogc:Function name="IsSurface">
+        			<ogc:PropertyName>act-core:geometry</ogc:PropertyName>
+       			</ogc:Function>
+       			<ogc:Literal>true</ogc:Literal>
+       		</ogc:PropertyIsEqualTo>
+		<ogc:PropertyIsEqualTo>
+				<ogc:PropertyName>us-emf:type/@xlink:href</ogc:PropertyName>
+				<ogc:Literal>http://inspire.ec.europa.eu/codelist/EnvironmentalManagementFacilityTypeValue/site</ogc:Literal>
+			</ogc:PropertyIsEqualTo>
+		 </ogc:And>
+   	</ogc:Filter>
+	    <se:PolygonSymbolizer>
+	      <se:Geometry>
+	        <ogc:PropertyName>act-core:geometry</ogc:PropertyName>
+	      </se:Geometry>
+	      <se:Fill>
+	      	<se:SvgParameter name="fill">#808080</se:SvgParameter>
+	      	<se:SvgParameter name="fill-opacity">0.50</se:SvgParameter>
+	      </se:Fill>
+	      <se:Stroke>
+	        <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+	        <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+	      </se:Stroke>
+	    </se:PolygonSymbolizer>
+	  </se:Rule>
+	  <se:Rule>
+	   <se:Description>
+      <se:Title>Site</se:Title>
+    </se:Description>
+		<ogc:Filter>
+    	<ogc:And>
+    		<ogc:PropertyIsEqualTo>
+        		<ogc:Function name="IsPoint">
+        			<ogc:PropertyName>act-core:geometry</ogc:PropertyName>
+       			</ogc:Function>
+       			<ogc:Literal>true</ogc:Literal>
+       		</ogc:PropertyIsEqualTo>
+		<ogc:PropertyIsEqualTo>
+				<ogc:PropertyName>us-emf:type/@xlink:href</ogc:PropertyName>
+				<ogc:Literal>http://inspire.ec.europa.eu/codelist/EnvironmentalManagementFacilityTypeValue/site</ogc:Literal>
+			</ogc:PropertyIsEqualTo>
+		 </ogc:And>
+   	</ogc:Filter>
+	    <se:PointSymbolizer>
+	      <se:Geometry>
+	        <ogc:PropertyName>act-core:geometry</ogc:PropertyName>
+	      </se:Geometry>
+	      <se:Graphic>
+	        <se:Mark>
+	          <se:WellKnownName>triangle</se:WellKnownName>
+	          <se:Fill>
+	            <se:SvgParameter name="fill">#808080</se:SvgParameter>
+	            <se:SvgParameter name="fill-opacity">0.50</se:SvgParameter>
+	          </se:Fill>
+	          <se:Stroke>
+	            <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+	            <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+	          </se:Stroke>
+	        </se:Mark>
+	        <se:Size>5</se:Size>
+	      </se:Graphic>
+	    </se:PointSymbolizer>
+	</se:Rule>
+	<se:Rule>
+	 <se:Description>
+      <se:Title>Site</se:Title>
+    </se:Description>
+	<ogc:Filter>
+    	<ogc:And>
+    		<ogc:PropertyIsEqualTo>
+        		<ogc:Function name="IsCurve">
+        			<ogc:PropertyName>act-core:geometry</ogc:PropertyName>
+       			</ogc:Function>
+       			<ogc:Literal>true</ogc:Literal>
+       		</ogc:PropertyIsEqualTo>
+		<ogc:PropertyIsEqualTo>
+				<ogc:PropertyName>us-emf:type/@xlink:href</ogc:PropertyName>
+				<ogc:Literal>http://inspire.ec.europa.eu/codelist/EnvironmentalManagementFacilityTypeValue/site</ogc:Literal>
+			</ogc:PropertyIsEqualTo>
+		 </ogc:And>
+   	</ogc:Filter>
+	    <se:LineSymbolizer>
+	      <se:Geometry>
+	        <ogc:PropertyName>act-core:geometry</ogc:PropertyName>
+	      </se:Geometry>
+	      <se:Stroke>
+	      	<se:SvgParameter name="stroke">#000000</se:SvgParameter>
+	        <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+	      </se:Stroke>
+	    </se:LineSymbolizer>
+  	</se:Rule>
+  	</se:FeatureTypeStyle>

--- a/generated/feature-styles/US_GovernmentalService_v5_0.se
+++ b/generated/feature-styles/US_GovernmentalService_v5_0.se
@@ -1,0 +1,178 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle  xmlns:us="http://inspire.ec.europa.eu/schemas/us-govserv/5.0" 
+xmlns:net="http://inspire.ec.europa.eu/schemas/net/5.0" 
+xmlns:ogc="http://www.opengis.net/ogc" 
+xmlns:se="http://www.opengis.net/se" 
+xmlns:sld="http://www.opengis.net/sld" 
+xmlns:gml="http://www.opengis.net/gml/3.2"
+xmlns:xlink="http://www.w3.org/1999/xlink" 
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+version="1.1.0" 
+xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd">
+  <se:Name>US.AdministrativeAndSocialGovernmentalServices.Default</se:Name>
+  <se:Description>
+    <se:Title>Administrative and Social Governmental Services Default Style</se:Title>
+    <se:Abstract>The location of the service shall be portrayed as point symbols.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>us:GovernmentalService</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Administrative and social governmental services default</se:Title>
+    </se:Description>
+    <ogc:Filter>
+    	<ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsSurface">
+        		<ogc:PropertyName>us:areaOfResponsibility/us:AreaOfResponsibilityType/us:areaOfResponsibilityByPolygon</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+   	</ogc:Filter>
+   	<se:MinScaleDenominator>1.0</se:MinScaleDenominator>
+    <se:MaxScaleDenominator>500000.0</se:MaxScaleDenominator>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>us:areaOfResponsibility/us:AreaOfResponsibilityType/us:areaOfResponsibilityByPolygon</ogc:PropertyName>
+      </se:Geometry>
+      <se:Fill>
+        <se:SvgParameter name="fill">#808080</se:SvgParameter>
+      </se:Fill>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+      </se:Stroke>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Administrative and social governmental services default</se:Title>
+    </se:Description>
+    <ogc:Filter>
+    	<ogc:PropertyIsEqualTo>
+        	<ogc:Function name="IsSurface">
+        		<ogc:PropertyName>us:areaOfResponsibility/us:AreaOfResponsibilityType/us:areaOfResponsibilityByAdministrativeUnit/au:geometry</ogc:PropertyName>
+       		</ogc:Function>
+       		<ogc:Literal>true</ogc:Literal>
+       	</ogc:PropertyIsEqualTo>
+   	</ogc:Filter>
+   	  <se:MinScaleDenominator>1.0</se:MinScaleDenominator>
+    <se:MaxScaleDenominator>500000.0</se:MaxScaleDenominator>
+    <se:PolygonSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>us:areaOfResponsibility/us:AreaOfResponsibilityType/us:areaOfResponsibilityByAdministrativeUnit/au:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Fill>
+        <se:SvgParameter name="fill">#000000</se:SvgParameter>
+      </se:Fill>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+      </se:Stroke>
+    </se:PolygonSymbolizer>
+  </se:Rule>
+    <se:Rule>
+  <se:Description>
+      <se:Title>Administrative and social governmental services default</se:Title>
+    </se:Description>
+    <se:MinScaleDenominator>1.0</se:MinScaleDenominator>
+    <se:MaxScaleDenominator>500000.0</se:MaxScaleDenominator>
+    <se:PointSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>us:serviceLocation/us:ServiceLocationType/us:serviceLocationByGeometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Graphic>
+        <se:Mark>
+          <se:WellKnownName>circle</se:WellKnownName>
+          <se:Fill>
+            <se:SvgParameter name="fill">#FF0000</se:SvgParameter>
+          </se:Fill>
+          <se:Stroke>
+            <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+            <se:SvgParameter name="stroke-width">0.5</se:SvgParameter>
+          </se:Stroke>
+        </se:Mark>
+        <se:Size>6</se:Size>
+      </se:Graphic>
+    </se:PointSymbolizer>
+  </se:Rule> 
+  
+<!--  
+  <se:Rule>
+  <se:Description>
+      <se:Title>Administrative and social governmental services - Education - point symbol</se:Title>
+    </se:Description>
+    <ogc:Filter>
+		<ogc:PropertyIsEqualTo> 
+			<ogc:PropertyName>us:serviceType/@xlink:href</ogc:PropertyName>
+			<ogc:Literal>http://inspire.ec.europa.eu/codelist/ServiceTypeValue/administrationForEducation</ogc:Literal>
+		</ogc:PropertyIsEqualTo>
+	</ogc:Filter>
+    <se:MinScaleDenominator>1.0</se:MinScaleDenominator>
+    <se:MaxScaleDenominator>500000.0</se:MaxScaleDenominator>
+    <se:PointSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>us:serviceLocation/us:ServiceLocationType/us:serviceLocationByGeometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Graphic>
+        <se:ExternalGraphic>
+        	<se:OnlineResource xlink:type="simple"
+        	xlink:href="https://wetransform.box.com/s/4wwic9yuphf8yxhinzatkqm6a2et3gg8"/>
+        	<se:Format>image/svg</se:Format>
+        </se:ExternalGraphic>
+        <se:Size>20</se:Size>
+      </se:Graphic>
+    </se:PointSymbolizer>
+  </se:Rule>
+ <se:Rule>
+    <se:Description>
+      <se:Title>Administrative and social governmental services - Education - point symbol</se:Title>
+    </se:Description>
+    <ogc:Filter>
+		<ogc:PropertyIsEqualTo> 
+			<ogc:PropertyName>us:serviceType/@xlink:href</ogc:PropertyName>
+			<ogc:Literal>http://inspire.ec.europa.eu/codelist/ServiceTypeValue/administrationForEducation</ogc:Literal>
+		</ogc:PropertyIsEqualTo>
+	</ogc:Filter>
+    <se:MinScaleDenominator>1.0</se:MinScaleDenominator>
+    <se:MaxScaleDenominator>500000.0</se:MaxScaleDenominator>
+    <se:PointSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>us:serviceLocation/us:ServiceLocationType/us:serviceLocationByGeometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Graphic>
+        <se:ExternalGraphic>
+        	<se:OnlineResource xlink:type="simple"
+        	xlink:href="https://wetransform.box.com/s/4wwic9yuphf8yxhinzatkqm6a2et3gg8"/>
+        	<se:Format>image/svg</se:Format>
+        </se:ExternalGraphic>
+        <se:Size>20</se:Size>
+      </se:Graphic>
+    </se:PointSymbolizer>
+  </se:Rule>
+    <se:Rule>
+    <se:Description>
+      <se:Title>Administrative and social governmental services - Police - point symbol</se:Title>
+    </se:Description>
+    <ogc:Filter>
+		<ogc:PropertyIsEqualTo> 
+			<ogc:PropertyName>us:serviceType/@xlink:href</ogc:PropertyName>
+			<ogc:Literal>http://inspire.ec.europa.eu/codelist/ServiceTypeValue/policeService</ogc:Literal>
+		</ogc:PropertyIsEqualTo>
+	</ogc:Filter>
+    <se:MinScaleDenominator>1.0</se:MinScaleDenominator>
+    <se:MaxScaleDenominator>500000.0</se:MaxScaleDenominator>
+    <se:PointSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>us:serviceLocation/us:ServiceLocationType/us:serviceLocationByGeometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Graphic>
+        <se:ExternalGraphic>
+        	<se:OnlineResource xlink:type="simple"
+        	xlink:href="https://upload.wikimedia.org/wikipedia/commons/thumb/b/ba/Flag_of_Germany.svg/800px-Flag_of_Germany.svg.png"/>
+        	<se:Format>image/png</se:Format>
+        </se:ExternalGraphic>
+        <se:Size>20</se:Size>
+      </se:Graphic>
+    </se:PointSymbolizer>
+  </se:Rule>
+  -->
+</se:FeatureTypeStyle>

--- a/generated/feature-styles/US_UtilityNetworkAppurtenance_v5_0.se
+++ b/generated/feature-styles/US_UtilityNetworkAppurtenance_v5_0.se
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" 
+xmlns:sld="http://www.opengis.net/sld" xmlns:net="http://inspire.ec.europa.eu/schemas/net/5.0" 
+xmlns:us-net-common="http://inspire.ec.europa.eu/schemas/us-net-common/5.0" xmlns:xlink="http://www.w3.org/1999/xlink" 
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+xsi:schemaLocation="http://www.opengis.net/se http://schemas.opengis.net/se/1.1.0/FeatureStyle.xsd" version="1.1.0">
+  <se:Name>US.UtilityNetworkAppurtenance.Default</se:Name>
+  <se:Description>
+    <se:Title>Appurtenance Default Style</se:Title>
+    <se:Abstract>The geometry is rendered using a yellow (#FFFF00) fill.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>us-net-common:Appurtenance</se:FeatureTypeName>
+  <se:Rule>
+  <se:Description>
+      <se:Title>Appurtenance</se:Title>
+    </se:Description>
+    <se:PointSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>net:geometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Graphic>
+        <se:Mark>
+          <se:WellKnownName>square</se:WellKnownName>
+          <se:Fill>
+            <se:SvgParameter name="fill">#FFFF00</se:SvgParameter>
+          </se:Fill>
+          <se:Stroke>
+            <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+            <se:SvgParameter name="stroke-width">1</se:SvgParameter>
+          </se:Stroke>
+        </se:Mark>
+        <se:Size>10</se:Size>
+      </se:Graphic>
+    </se:PointSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/generated/feature-styles/US_UtilityNetworkLink_v5_0.se
+++ b/generated/feature-styles/US_UtilityNetworkLink_v5_0.se
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<se:FeatureTypeStyle xmlns:net="http://inspire.ec.europa.eu/schemas/net/5.0" 
+xmlns:ogc="http://www.opengis.net/ogc" xmlns:se="http://www.opengis.net/se" 
+xmlns:sld="http://www.opengis.net/sld" xmlns:us-net-common="http://inspire.ec.europa.eu/schemas/us-net-common/5.0" 
+xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.1.0">
+  <se:Name>US.UtilityNetworkLink.Default</se:Name>
+  <se:Description>
+    <se:Title>Utility Link Default Style</se:Title>
+    <se:Abstract>The geometry is rendered as a solid maroon (#800000)line with a stroke width of 3 pixel. Ends are rounded and have a 2 pixel black (#000000) casing.</se:Abstract>
+  </se:Description>
+  <se:FeatureTypeName>us-net-common:UtilityLink</se:FeatureTypeName>
+  <se:Rule>
+    <se:Description>
+      <se:Title>Utility link</se:Title>
+    </se:Description>
+    <se:LineSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>net:centrelineGeometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#000000</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">7</se:SvgParameter>
+        <se:SvgParameter name="stroke-linejoin">bevel</se:SvgParameter>
+        <se:SvgParameter name="stroke-linecap">round</se:SvgParameter>
+      </se:Stroke>
+    </se:LineSymbolizer>
+    <se:LineSymbolizer>
+      <se:Geometry>
+        <ogc:PropertyName>net:centrelineGeometry</ogc:PropertyName>
+      </se:Geometry>
+      <se:Stroke>
+        <se:SvgParameter name="stroke">#800000</se:SvgParameter>
+        <se:SvgParameter name="stroke-width">3</se:SvgParameter>
+        <se:SvgParameter name="stroke-linejoin">bevel</se:SvgParameter>
+        <se:SvgParameter name="stroke-linecap">round</se:SvgParameter>
+      </se:Stroke>
+    </se:LineSymbolizer>
+  </se:Rule>
+</se:FeatureTypeStyle>

--- a/generated/generated.style
+++ b/generated/generated.style
@@ -115,71 +115,141 @@ tags: inspire production Name: "HY.Network.WatercourseLink"
 Title: en "Hydrographic network - WatercourseLink"
 , de "Hydrografisches Netzwerk- WatercourseLink"
 SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/hy-n/4.0:WatercourseLink
-Styles: HY_N_WatercourseLink } Layer { id: "HY_Network_HydroNode"
+Styles: HY_N_WatercourseLink } Layer { id: "HY_Network_WatercourseLink_v5"
+registry-id: ""
+tags: inspire production Name: "HY.Network.WatercourseLink"
+Title: en "Hydrographic network - WatercourseLink"
+, de "Hydrografisches Netzwerk- WatercourseLink"
+SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/hy-n/5.0:WatercourseLink
+Styles: HY_N_WatercourseLink_v5 } Layer { id: "HY_Network_HydroNode"
 registry-id: ""
 tags: inspire production Name: "HY.Network.HydroNode"
 Title: en "Hydrographic network - HydroNode"
 , de "Hydrografisches Netzwerk- HydroNode"
 SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/hy-n/4.0:HydroNode
-Styles: HY_N_HydroNode } Layer { id: "HY_Physica"
+Styles: HY_N_HydroNode } Layer { id: "HY_Network_HydroNode_v5"
+registry-id: ""
+tags: inspire production Name: "HY.Network.HydroNode"
+Title: en "Hydrographic network - HydroNode"
+, de "Hydrografisches Netzwerk- HydroNode"
+SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/hy-n/5.0:HydroNode
+Styles: HY_N_HydroNode_v5 } Layer { id: "HY_Physica"
 registry-id: "http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.Catchments"
 tags: inspire production Name: "HY.PhysicalWaters.Catchments"
 Title: en "Catchment"
 , de "Einzugsgebiete"
 SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/hy-p/4.0:DrainageBasin
-, http://inspire.ec.europa.eu/schemas/hy-p/4.0:RiverBasin Styles: HY_P_DrainageBasin , HY_P_RiverBasin } Layer { id: "HY_Physica_1"
+, http://inspire.ec.europa.eu/schemas/hy-p/4.0:RiverBasin Styles: HY_P_DrainageBasin , HY_P_RiverBasin } Layer { id: "HY_Physica_v5"
+registry-id: "http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.Catchments"
+tags: inspire production Name: "HY.PhysicalWaters.Catchments"
+Title: en "Catchment"
+, de "Einzugsgebiete"
+SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/hy-p/5.0:DrainageBasin
+, http://inspire.ec.europa.eu/schemas/hy-p/5.0:RiverBasin Styles: HY_P_DrainageBasin_v5 , HY_P_RiverBasin_v5 } Layer { id: "HY_Physica_1"
 registry-id: "http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.HydroPointOfInterest"
 tags: inspire production Name: "HY.PhysicalWaters.HydroPointOfInterest"
 Title: en "Hydro Point of Interest"
 , de "Interessante hydrologische Punkte"
 SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/hy-p/4.0:Rapids
-, http://inspire.ec.europa.eu/schemas/hy-p/4.0:Falls Styles: HY_P_Rapids , HY_P_Falls } Layer { id: "HY_Physica_2"
+, http://inspire.ec.europa.eu/schemas/hy-p/4.0:Falls Styles: HY_P_Rapids , HY_P_Falls } Layer { id: "HY_Physica_1_v5"
+registry-id: "http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.HydroPointOfInterest"
+tags: inspire production Name: "HY.PhysicalWaters.HydroPointOfInterest"
+Title: en "Hydro Point of Interest"
+, de "Interessante hydrologische Punkte"
+SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/hy-p/5.0:Rapids
+, http://inspire.ec.europa.eu/schemas/hy-p/5.0:Falls Styles: HY_P_Rapids_v5 , HY_P_Falls_v5 } Layer { id: "HY_Physica_2"
 registry-id: "http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.LandWaterBoundary"
 tags: inspire production Name: "HY.PhysicalWaters.LandWaterBoundary"
 Title: en "Land water boundary"
 , de "Uferlinien"
 SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/hy-p/4.0:LandWaterBoundary
-Styles: HY_P_LandWaterBoundary } Layer { id: "HY_Physica_4"
+Styles: HY_P_LandWaterBoundary } Layer { id: "HY_Physica_2_v5"
+registry-id: "http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.LandWaterBoundary"
+tags: inspire production Name: "HY.PhysicalWaters.LandWaterBoundary"
+Title: en "Land water boundary"
+, de "Uferlinien"
+SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/hy-p/5.0:LandWaterBoundary
+Styles: HY_P_LandWaterBoundary_v5 } Layer { id: "HY_Physica_4"
 registry-id: "http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.ManMadeObject"
 tags: inspire production Name: "HY.PhysicalWaters.ManMadeObject"
 Title: en "Man-made Object"
 , de "Bauwerke an Gewässern"
 SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/hy-p/4.0:Crossing
-, http://inspire.ec.europa.eu/schemas/hy-p/4.0:DamOrWeir , http://inspire.ec.europa.eu/schemas/hy-p/4.0:ShorelineConstruction , http://inspire.ec.europa.eu/schemas/hy-p/4.0:Ford , http://inspire.ec.europa.eu/schemas/hy-p/4.0:Lock Styles: HY_P_Crossing , HY_P_DamOrWeir , HY_P_ShoreLineConstruction , HY_P_Ford , HY_P_Lock } Layer { id: "HY_PhysicalWaters_Shore"
+, http://inspire.ec.europa.eu/schemas/hy-p/4.0:DamOrWeir , http://inspire.ec.europa.eu/schemas/hy-p/4.0:ShorelineConstruction , http://inspire.ec.europa.eu/schemas/hy-p/4.0:Ford , http://inspire.ec.europa.eu/schemas/hy-p/4.0:Lock Styles: HY_P_Crossing , HY_P_DamOrWeir , HY_P_ShoreLineConstruction , HY_P_Ford , HY_P_Lock } Layer { id: "HY_Physica_4_v5"
+registry-id: "http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.ManMadeObject"
+tags: inspire production Name: "HY.PhysicalWaters.ManMadeObject"
+Title: en "Man-made Object"
+, de "Bauwerke an Gewässern"
+SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/hy-p/4.0:Crossing
+, http://inspire.ec.europa.eu/schemas/hy-p/5.0:DamOrWeir , http://inspire.ec.europa.eu/schemas/hy-p/5.0:ShorelineConstruction , http://inspire.ec.europa.eu/schemas/hy-p/5.0:Ford , http://inspire.ec.europa.eu/schemas/hy-p/5.0:Lock Styles: HY_P_Crossing_v5 , HY_P_DamOrWeir_v5 , HY_P_ShoreLineConstruction_v5 , HY_P_Ford_v5 , HY_P_Lock_v5 } Layer { id: "HY_PhysicalWaters_Shore"
 registry-id: "http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.Shore"
 tags: inspire production Name: "HY.PhysicalWaters.Shore"
 Title: en "Shores"
 , de "Küsten"
 SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/hy-p/4.0:Shore
-Styles: HY_P_Shore } Layer { id: "HY_Physica_5"
+Styles: HY_P_Shore } Layer { id: "HY_PhysicalWaters_Shore_v5"
+registry-id: "http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.Shore"
+tags: inspire production Name: "HY.PhysicalWaters.Shore"
+Title: en "Shores"
+, de "Küsten"
+SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/hy-p/5.0:Shore
+Styles: HY_P_Shore_v5 } Layer { id: "HY_Physica_5"
 registry-id: "http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.Waterbodies"
 tags: inspire production Name: "HY.PhysicalWaters.Waterbodies"
 Title: en "Waterbody"
 , de "Wasserkörper"
 SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/hy-p/4.0:Watercourse
-, http://inspire.ec.europa.eu/schemas/hy-p/4.0:StandingWater Styles: HY_P_Watercourse , HY_P_StandingWater } Layer { id: "HY_Physica_6"
+, http://inspire.ec.europa.eu/schemas/hy-p/4.0:StandingWater Styles: HY_P_Watercourse , HY_P_StandingWater } Layer { id: "HY_Physica_5_v5"
+registry-id: "http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.Waterbodies"
+tags: inspire production Name: "HY.PhysicalWaters.Waterbodies"
+Title: en "Waterbody"
+, de "Wasserkörper"
+SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/hy-p/5.0:Watercourse
+, http://inspire.ec.europa.eu/schemas/hy-p/5.0:StandingWater Styles: HY_P_Watercourse_v5 , HY_P_StandingWater_v5 } Layer { id: "HY_Physica_6"
 registry-id: ""
 tags: inspire production Name: "HY.PhysicalWaters.Waterbodies.Man.Made"
 Title: en "Man-made Object (Natural)"
 SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/hy-p/4.0:Watercourse
-, http://inspire.ec.europa.eu/schemas/hy-p/4.0:StandingWater Styles: HY_P_Watercourse_ManMade , HY_P_StandingWater_ManMade } Layer { id: "HY_Physica_7"
+, http://inspire.ec.europa.eu/schemas/hy-p/4.0:StandingWater Styles: HY_P_Watercourse_ManMade , HY_P_StandingWater_ManMade } Layer { id: "HY_Physica_6_v5"
+registry-id: ""
+tags: inspire production Name: "HY.PhysicalWaters.Waterbodies.Man.Made"
+Title: en "Man-made Object (Natural)"
+SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/hy-p/5.0:Watercourse
+, http://inspire.ec.europa.eu/schemas/hy-p/5.0:StandingWater Styles: HY_P_Watercourse_ManMade_v5 , HY_P_StandingWater_ManMade_v5 } Layer { id: "HY_Physica_7"
 registry-id: ""
 tags: inspire production Name: "HY.PhysicalWaters.Waterbodies.Persistence"
 Title: en "Waterbody (Persistence)"
 SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/hy-p/4.0:Watercourse
-, http://inspire.ec.europa.eu/schemas/hy-p/4.0:StandingWater Styles: HY_P_WatercoursePersistence , HY_P_WaterbodiesPersistence } Layer { id: "HY_PhysicalWaters_Wetland"
+, http://inspire.ec.europa.eu/schemas/hy-p/4.0:StandingWater Styles: HY_P_WatercoursePersistence , HY_P_WaterbodiesPersistence } Layer { id: "HY_Physica_7_v5"
+registry-id: ""
+tags: inspire production Name: "HY.PhysicalWaters.Waterbodies.Persistence"
+Title: en "Waterbody (Persistence)"
+SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/hy-p/5.0:Watercourse
+, http://inspire.ec.europa.eu/schemas/hy-p/5.0:StandingWater Styles: HY_P_WatercoursePersistence_v5 , HY_P_WaterbodiesPersistence_v5 } Layer { id: "HY_PhysicalWaters_Wetland"
 registry-id: "http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.Wetland"
 tags: inspire production Name: "HY.PhysicalWaters.Wetland"
 Title: en "Wetlands"
 , de "Feuchtgebiete"
 SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/hy-p/4.0:Wetland
-Styles: HY_P_Wetland } Layer { id: "PS_ProtectedSite"
+Styles: HY_P_Wetland } Layer { id: "HY_PhysicalWaters_Wetland_v5"
+registry-id: "http://inspire.ec.europa.eu/layer/HY.PhysicalWaters.Wetland"
+tags: inspire production Name: "HY.PhysicalWaters.Wetland"
+Title: en "Wetlands"
+, de "Feuchtgebiete"
+SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/hy-p/5.0:Wetland
+Styles: HY_P_Wetland_v5 } Layer { id: "PS_ProtectedSite"
 registry-id: "http://inspire.ec.europa.eu/layer/PS.ProtectedSite"
 tags: inspire production Name: "PS.ProtectedSite"
 Title: en "Protected Sites"
 , de "Schutzgebiete"
 SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/ps/4.0:ProtectedSite
 Styles: PS_ProtectedSite } Layer { id: "PS_ProtectedSite_v5"
+registry-id: "http://inspire.ec.europa.eu/layer/PS.ProtectedSite"
+tags: inspire production Name: "PS.ProtectedSite"
+Title: en "Protected Sites"
+, de "Schutzgebiete"
+SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/ps/5.0:ProtectedSite
+Styles: PS_ProtectedSite_v5 } Layer { id: "PS_ProtectedSite_v5"
 registry-id: "http://inspire.ec.europa.eu/layer/PS.ProtectedSite"
 tags: inspire production Name: "PS.ProtectedSite_v5"
 Title: en "Protected Sites"
@@ -191,169 +261,337 @@ tags: inspire production Name: "TN.AirTransportNetwork.AerodromeArea"
 Title: en "Aerodrome Area Default Style"
 , de "Flugplatzgelände"
 SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-a/4.0:AerodromeArea
-Styles: TN_A_AerodromeArea } Layer { id: "TN_AirTran_1"
+Styles: TN_A_AerodromeArea } Layer { id: "TN_AirTran_v5"
+registry-id: "http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.AerodromeArea"
+tags: inspire production Name: "TN.AirTransportNetwork.AerodromeArea"
+Title: en "Aerodrome Area Default Style"
+, de "Flugplatzgelände"
+SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-a/5.0:AerodromeArea
+Styles: TN_A_AerodromeArea_v5 } Layer { id: "TN_AirTran_1"
 registry-id: "http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.AirLink"
 tags: inspire production Name: "TN.AirTransportNetwork.AirLink"
 Title: en "Air Link Default Style"
 , de "Luftverbindung"
 SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-a/4.0:ProcedureLink
-, http://inspire.ec.europa.eu/schemas/tn-a/4.0:AirRouteLink Styles: TN_A_ProcedureLink , TN_A_AirRouteLink } Layer { id: "TN_AirTran_2"
+, http://inspire.ec.europa.eu/schemas/tn-a/4.0:AirRouteLink Styles: TN_A_ProcedureLink , TN_A_AirRouteLink } Layer { id: "TN_AirTran_1_v5"
+registry-id: "http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.AirLink"
+tags: inspire production Name: "TN.AirTransportNetwork.AirLink"
+Title: en "Air Link Default Style"
+, de "Luftverbindung"
+SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-a/5.0:ProcedureLink
+, http://inspire.ec.europa.eu/schemas/tn-a/5.0:AirRouteLink Styles: TN_A_ProcedureLink_v5 , TN_A_AirRouteLink_v5 } Layer { id: "TN_AirTran_2"
 registry-id: "http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.AirspaceArea"
 tags: inspire production Name: "TN.AirTransportNetwork.AirSpaceArea"
 Title: en "Air Space Area Default Style"
 , de "Luftraumbereich"
 SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-a/4.0:AirspaceArea
-Styles: TN_A_AirspaceArea } Layer { id: "TN_AirTran_3"
+Styles: TN_A_AirspaceArea } Layer { id: "TN_AirTran_2_v5"
+registry-id: "http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.AirspaceArea"
+tags: inspire production Name: "TN.AirTransportNetwork.AirSpaceArea"
+Title: en "Air Space Area Default Style"
+, de "Luftraumbereich"
+SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-a/5.0:AirspaceArea
+Styles: TN_A_AirspaceArea_v5 } Layer { id: "TN_AirTran_3"
 registry-id: "http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.ApronArea"
 tags: inspire production Name: "TN.AirTransportNetwork.ApronArea"
 Title: en "Apron Area Default Style"
 , de "Vorfeldgelände"
 SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-a/4.0:ApronArea
-Styles: TN_A_ApronArea } Layer { id: "TN_AirTran_4"
+Styles: TN_A_ApronArea } Layer { id: "TN_AirTran_3_v5"
+registry-id: "http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.ApronArea"
+tags: inspire production Name: "TN.AirTransportNetwork.ApronArea"
+Title: en "Apron Area Default Style"
+, de "Vorfeldgelände"
+SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-a/5.0:ApronArea
+Styles: TN_A_ApronArea_v5 } Layer { id: "TN_AirTran_4"
 registry-id: "http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.RunwayArea"
 tags: inspire production Name: "TN.AirTransportNetwork.RunwayArea"
 Title: en "Runway Area Default Style"
 , de "Landebahngelände"
 SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-a/4.0:RunwayArea
-Styles: TN_A_RunwayArea } Layer { id: "TN_AirTran_5"
+Styles: TN_A_RunwayArea } Layer { id: "TN_AirTran_4_v5"
+registry-id: "http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.RunwayArea"
+tags: inspire production Name: "TN.AirTransportNetwork.RunwayArea"
+Title: en "Runway Area Default Style"
+, de "Landebahngelände"
+SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-a/5.0:RunwayArea
+Styles: TN_A_RunwayArea_v5 } Layer { id: "TN_AirTran_5"
 registry-id: "http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.TaxiwayArea"
 tags: inspire production Name: "TN.AirTransportNetwork.TaxiwayArea"
 Title: en "Taxiway Area Default Style"
 , de "Rollfeld"
 SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-a/4.0:TaxiwayArea
-Styles: TN_A_TaxiwayArea } Layer { id: "TN_AirTran_6"
+Styles: TN_A_TaxiwayArea } Layer { id: "TN_AirTran_5_v5"
+registry-id: "http://inspire.ec.europa.eu/layer/TN.AirTransportNetwork.TaxiwayArea"
+tags: inspire production Name: "TN.AirTransportNetwork.TaxiwayArea"
+Title: en "Taxiway Area Default Style"
+, de "Rollfeld"
+SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-a/5.0:TaxiwayArea
+Styles: TN_A_TaxiwayArea_v5 } Layer { id: "TN_AirTran_6"
 registry-id: ""
 tags: inspire production Name: "TN.AirTransportNetwork.DesignatedPoint"
 Title: en "Designated Point Default Style"
 , de "Designierter Punkt"
 SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-a/4.0:DesignatedPoint
-Styles: TN_A_DesignatedPoint } Layer { id: "TN_AirTran_7"
+Styles: TN_A_DesignatedPoint } Layer { id: "TN_AirTran_6_v5"
+registry-id: ""
+tags: inspire production Name: "TN.AirTransportNetwork.DesignatedPoint"
+Title: en "Designated Point Default Style"
+, de "Designierter Punkt"
+SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-a/5.0:DesignatedPoint
+Styles: TN_A_DesignatedPoint_v5 } Layer { id: "TN_AirTran_7"
 registry-id: ""
 tags: inspire production Name: "TN.AirTransportNetwork.AerodromeNode"
 Title: en "Aerodrome Node Default Style"
 , de "Flugplatzknotenpunkt"
 SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-a/4.0:AerodromeNode
-Styles: TN_A_AerodromeNode } Layer { id: "TN_AirTran_8"
+Styles: TN_A_AerodromeNode } Layer { id: "TN_AirTran_7_v5"
+registry-id: ""
+tags: inspire production Name: "TN.AirTransportNetwork.AerodromeNode"
+Title: en "Aerodrome Node Default Style"
+, de "Flugplatzknotenpunkt"
+SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-a/5.0:AerodromeNode
+Styles: TN_A_AerodromeNode_v5 } Layer { id: "TN_AirTran_8"
 registry-id: ""
 tags: inspire production Name: "TN.AirTransportNetwork.TouchDownLiftOff"
 Title: en "Touch Down Lift Off Area Default Style"
 , de "Start- und Landebereich für Hubschrauber"
 SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-a/4.0:TouchDownLiftOff
-Styles: TN_A_TouchDownLiftOff } Layer { id: "TN_AirTran_9"
+Styles: TN_A_TouchDownLiftOff } Layer { id: "TN_AirTran_8_v5"
+registry-id: ""
+tags: inspire production Name: "TN.AirTransportNetwork.TouchDownLiftOff"
+Title: en "Touch Down Lift Off Area Default Style"
+, de "Start- und Landebereich für Hubschrauber"
+SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-a/5.0:TouchDownLiftOff
+Styles: TN_A_TouchDownLiftOff_v5 } Layer { id: "TN_AirTran_9"
 registry-id: ""
 tags: inspire production Name: "TN.AirTransportNetwork.Navaid"
 Title: en "Navaid Default Style"
 , de "Navigationshilfe"
 SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-a/4.0:Navaid
-Styles: TN_A_Navaid } Layer { id: "TN_AirTran_10"
+Styles: TN_A_Navaid } Layer { id: "TN_AirTran_9_v5"
+registry-id: ""
+tags: inspire production Name: "TN.AirTransportNetwork.Navaid"
+Title: en "Navaid Default Style"
+, de "Navigationshilfe"
+SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-a/5.0:Navaid
+Styles: TN_A_Navaid_v5 } Layer { id: "TN_AirTran_10"
 registry-id: ""
 tags: inspire production Name: "TN.AirTransportNetwork.RunwayCentrelinePoint"
 Title: en "Runway Centreline Point Default Style"
 , de "Mittellinienpunkt der Landebahn"
 SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-a/4.0:RunwayCentrelinePoint
-Styles: TN_A_RunwayCentrelinePoint } Layer { id: "TN_CableTr"
+Styles: TN_A_RunwayCentrelinePoint } Layer { id: "TN_AirTran_10_v5"
+registry-id: ""
+tags: inspire production Name: "TN.AirTransportNetwork.RunwayCentrelinePoint"
+Title: en "Runway Centreline Point Default Style"
+, de "Mittellinienpunkt der Landebahn"
+SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-a/5.0:RunwayCentrelinePoint
+Styles: TN_A_RunwayCentrelinePoint_v5 } Layer { id: "TN_CableTr"
 registry-id: "http://inspire.ec.europa.eu/layer/TN.CableTransportNetwork.CablewayLink"
 tags: inspire production Name: "TN.CableTransportNetwork.CablewayLink"
 Title: en "Cableway Link Default Style"
 , de "Seilbahnverbindung"
 SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-c/4.0:CablewayLink
-Styles: TN_C_CablewayLink } Layer { id: "TN_CommonT"
+Styles: TN_C_CablewayLink } Layer { id: "TN_CableTr_v5"
+registry-id: "http://inspire.ec.europa.eu/layer/TN.CableTransportNetwork.CablewayLink"
+tags: inspire production Name: "TN.CableTransportNetwork.CablewayLink"
+Title: en "Cableway Link Default Style"
+, de "Seilbahnverbindung"
+SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-c/5.0:CablewayLink
+Styles: TN_C_CablewayLink_v5 } Layer { id: "TN_CommonT"
 registry-id: "http://inspire.ec.europa.eu/layer/TN.CommonTransportElements.TransportArea"
 tags: inspire production Name: "TN.CommonTransportElements.TransportArea"
 Title: en "Generic Transport Area Default Style"
 , de "Generischer Verkehrsbereich"
 SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn/4.0:TransportArea
-Styles: TN_TransportArea } Layer { id: "TN_CommonT_1"
+Styles: TN_TransportArea } Layer { id: "TN_CommonT_v5"
+registry-id: "http://inspire.ec.europa.eu/layer/TN.CommonTransportElements.TransportArea"
+tags: inspire production Name: "TN.CommonTransportElements.TransportArea"
+Title: en "Generic Transport Area Default Style"
+, de "Generischer Verkehrsbereich"
+SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn/5.0:TransportArea
+Styles: TN_TransportArea_v5 } Layer { id: "TN_CommonT_1"
 registry-id: "http://inspire.ec.europa.eu/layer/TN.CommonTransportElements.TransportLink"
 tags: inspire production Name: "TN.CommonTransportElements.TransportLink"
 Title: en "Generic Transport Link Default Style"
 , de "Generisches Verkehrssegment"
 SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn/4.0:TransportLink
-Styles: TN_TransportLink } Layer { id: "TN_CommonT_2"
+Styles: TN_TransportLink } Layer { id: "TN_CommonT_1_v5"
+registry-id: "http://inspire.ec.europa.eu/layer/TN.CommonTransportElements.TransportLink"
+tags: inspire production Name: "TN.CommonTransportElements.TransportLink"
+Title: en "Generic Transport Link Default Style"
+, de "Generisches Verkehrssegment"
+SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn/5.0:TransportLink
+Styles: TN_TransportLink_v5 } Layer { id: "TN_CommonT_2"
 registry-id: "http://inspire.ec.europa.eu/layer/TN.CommonTransportElements.TransportNode"
 tags: inspire production Name: "TN.CommonTransportElements.TransportNode"
 Title: en "Generic Transport Node Default Style"
 , de "Generischer Verkehrsknotenpunkt"
 SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn/4.0:TransportNode
-Styles: TN_TransportNode } Layer { id: "TN_RailTra"
+Styles: TN_TransportNode } Layer { id: "TN_CommonT_2_v5"
+registry-id: "http://inspire.ec.europa.eu/layer/TN.CommonTransportElements.TransportNode"
+tags: inspire production Name: "TN.CommonTransportElements.TransportNode"
+Title: en "Generic Transport Node Default Style"
+, de "Generischer Verkehrsknotenpunkt"
+SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn/5.0:TransportNode
+Styles: TN_TransportNode_v5 } Layer { id: "TN_RailTra"
 registry-id: "http://inspire.ec.europa.eu/layer/TN.RailTransportNetwork.RailwayArea"
 tags: inspire production Name: "TN.RailTransportNetwork.RailwayArea"
 Title: en "Railway Area Default Style"
 , de "Bahngelände"
 SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-ra/4.0:RailwayArea
-Styles: TN_RA_RailwayArea } Layer { id: "TN_RailTra_1"
+Styles: TN_RA_RailwayArea } Layer { id: "TN_RailTra_v5"
+registry-id: "http://inspire.ec.europa.eu/layer/TN.RailTransportNetwork.RailwayArea"
+tags: inspire production Name: "TN.RailTransportNetwork.RailwayArea"
+Title: en "Railway Area Default Style"
+, de "Bahngelände"
+SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-ra/5.0:RailwayArea
+Styles: TN_RA_RailwayArea_v5 } Layer { id: "TN_RailTra_1"
 registry-id: "http://inspire.ec.europa.eu/layer/TN.RailTransportNetwork.RailwayLink"
 tags: inspire production Name: "TN.RailTransportNetwork.RailwayLink"
 Title: en "Railway Link Default Style"
 , de "Eisenbahnverbindung"
 SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-ra/4.0:RailwayLink
-Styles: TN_RA_RailwayLink } Layer { id: "TN_RailTra_2"
+Styles: TN_RA_RailwayLink } Layer { id: "TN_RailTra_1_v5"
+registry-id: "http://inspire.ec.europa.eu/layer/TN.RailTransportNetwork.RailwayLink"
+tags: inspire production Name: "TN.RailTransportNetwork.RailwayLink"
+Title: en "Railway Link Default Style"
+, de "Eisenbahnverbindung"
+SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-ra/5.0:RailwayLink
+Styles: TN_RA_RailwayLink_v5 } Layer { id: "TN_RailTra_2"
 registry-id: "http://inspire.ec.europa.eu/layer/TN.RailTransportNetwork.RailwayStationArea"
 tags: inspire production Name: "TN.RailTransportNetwork.RailwayStationArea"
 Title: en "Railway Station Area Default Style"
 , de "Bahnhofsgelände"
 SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-ra/4.0:RailwayStationArea
-Styles: TN_RA_RailwayStationArea } Layer { id: "TN_RailTra_3"
+Styles: TN_RA_RailwayStationArea } Layer { id: "TN_RailTra_2_v5"
+registry-id: "http://inspire.ec.europa.eu/layer/TN.RailTransportNetwork.RailwayStationArea"
+tags: inspire production Name: "TN.RailTransportNetwork.RailwayStationArea"
+Title: en "Railway Station Area Default Style"
+, de "Bahnhofsgelände"
+SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-ra/5.0:RailwayStationArea
+Styles: TN_RA_RailwayStationArea_v5 } Layer { id: "TN_RailTra_3"
 registry-id: "http://inspire.ec.europa.eu/layer/TN.RailTransportNetwork.RailwayYardArea"
 tags: inspire production Name: "TN.RailTransportNetwork.RailwayYardArea"
 Title: en "Railway Yard Area Default Style"
 , de "Rangierbahnhofsgelände"
 SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-ra/4.0:RailwayYardArea
-Styles: TN_RA_RailwayYardArea } Layer { id: "TN_RoadTra"
+Styles: TN_RA_RailwayYardArea } Layer { id: "TN_RailTra_3_v5"
+registry-id: "http://inspire.ec.europa.eu/layer/TN.RailTransportNetwork.RailwayYardArea"
+tags: inspire production Name: "TN.RailTransportNetwork.RailwayYardArea"
+Title: en "Railway Yard Area Default Style"
+, de "Rangierbahnhofsgelände"
+SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-ra/5.0:RailwayYardArea
+Styles: TN_RA_RailwayYardArea_v5 } Layer { id: "TN_RoadTra"
 registry-id: "http://inspire.ec.europa.eu/layer/TN.RoadTransportNetwork.RoadArea"
 tags: inspire production Name: "TN.RoadTransportNetwork.RoadArea"
 Title: en "Road Area Default Style"
 , de "Straßenfläche"
 SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-ro/4.0:RoadArea
-Styles: TN_RO_RoadArea } Layer { id: "TN_RoadTra_1"
+Styles: TN_RO_RoadArea } Layer { id: "TN_RoadTra_v5"
+registry-id: "http://inspire.ec.europa.eu/layer/TN.RoadTransportNetwork.RoadArea"
+tags: inspire production Name: "TN.RoadTransportNetwork.RoadArea"
+Title: en "Road Area Default Style"
+, de "Straßenfläche"
+SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-ro/5.0:RoadArea
+Styles: TN_RO_RoadArea_v5 } Layer { id: "TN_RoadTra_1"
 registry-id: "http://inspire.ec.europa.eu/layer/TN.RoadTransportNetwork.RoadLink"
 tags: inspire production Name: "TN.RoadTransportNetwork.RoadLink"
 Title: en "Road Link Default Style"
 , de "Straßensegment"
 SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-ro/4.0:RoadLink
-Styles: TN_RO_RoadLink } Layer { id: "TN_RoadTra_2"
+Styles: TN_RO_RoadLink } Layer { id: "TN_RoadTra_1_v5"
+registry-id: "http://inspire.ec.europa.eu/layer/TN.RoadTransportNetwork.RoadLink"
+tags: inspire production Name: "TN.RoadTransportNetwork.RoadLink"
+Title: en "Road Link Default Style"
+, de "Straßensegment"
+SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-ro/5.0:RoadLink
+Styles: TN_RO_RoadLink_v5 } Layer { id: "TN_RoadTra_2"
 registry-id: "http://inspire.ec.europa.eu/layer/TN.RoadTransportNetwork.RoadServiceArea"
 tags: inspire production Name: "TN.RoadTransportNetwork.RoadServiceArea"
 Title: en "Road Service Area Default Style"
 , de "Servicebereich"
 SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-ro/4.0:RoadServiceArea
-Styles: TN_RO_RoadServiceArea } Layer { id: "TN_RoadTra_3"
+Styles: TN_RO_RoadServiceArea } Layer { id: "TN_RoadTra_2_v5"
+registry-id: "http://inspire.ec.europa.eu/layer/TN.RoadTransportNetwork.RoadServiceArea"
+tags: inspire production Name: "TN.RoadTransportNetwork.RoadServiceArea"
+Title: en "Road Service Area Default Style"
+, de "Servicebereich"
+SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-ro/5.0:RoadServiceArea
+Styles: TN_RO_RoadServiceArea_v5 } Layer { id: "TN_RoadTra_3"
 registry-id: "http://inspire.ec.europa.eu/layer/TN.RoadTransportNetwork.VehicleTrafficArea"
 tags: inspire production Name: "TN.RoadTransportNetwork.VehicleTrafficArea"
 Title: en "Vehicle traffic Area Default Style"
 , de "Verkehrsfläche"
 SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-ro/4.0:VehicleTrafficArea
-Styles: TN_RO_VehicleTrafficArea } Layer { id: "TN_WaterTr"
+Styles: TN_RO_VehicleTrafficArea } Layer { id: "TN_RoadTra_3_v5"
+registry-id: "http://inspire.ec.europa.eu/layer/TN.RoadTransportNetwork.VehicleTrafficArea"
+tags: inspire production Name: "TN.RoadTransportNetwork.VehicleTrafficArea"
+Title: en "Vehicle traffic Area Default Style"
+, de "Verkehrsfläche"
+SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-ro/5.0:VehicleTrafficArea
+Styles: TN_RO_VehicleTrafficArea_v5 } Layer { id: "TN_WaterTr"
 registry-id: "http://inspire.ec.europa.eu/layer/TN.WaterTransportNetwork.FairwayArea"
 tags: inspire production Name: "TN.WaterTransportNetwork.FairwayArea"
 Title: en "Fairway Area Default Style"
 , de "Fahrrinnenbereich"
 SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-w/4.0:FairwayArea
-Styles: TN_W_FairwayArea } Layer { id: "TN_WaterTr_1"
+Styles: TN_W_FairwayArea } Layer { id: "TN_WaterTr_v5"
+registry-id: "http://inspire.ec.europa.eu/layer/TN.WaterTransportNetwork.FairwayArea"
+tags: inspire production Name: "TN.WaterTransportNetwork.FairwayArea"
+Title: en "Fairway Area Default Style"
+, de "Fahrrinnenbereich"
+SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-w/5.0:FairwayArea
+Styles: TN_W_FairwayArea_v5 } Layer { id: "TN_WaterTr_1"
 registry-id: "http://inspire.ec.europa.eu/layer/TN.WaterTransportNetwork.PortArea"
 tags: inspire production Name: "TN.WaterTransportNetwork.PortArea"
 Title: en "Port Area Default Style"
 , de "Hafengelände"
 SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-w/4.0:PortArea
-Styles: TN_W_PortArea } Layer { id: "TN_WaterTr_2"
+Styles: TN_W_PortArea } Layer { id: "TN_WaterTr_1_v5"
+registry-id: "http://inspire.ec.europa.eu/layer/TN.WaterTransportNetwork.PortArea"
+tags: inspire production Name: "TN.WaterTransportNetwork.PortArea"
+Title: en "Port Area Default Style"
+, de "Hafengelände"
+SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-w/5.0:PortArea
+Styles: TN_W_PortArea_v5 } Layer { id: "TN_WaterTr_2"
 registry-id: "http://inspire.ec.europa.eu/layer/TN.WaterTransportNetwork.WaterwayLink"
 tags: inspire production Name: "TN.WaterTransportNetwork.WaterwayLink"
 Title: en "Waterway Link Default Style"
 , de "Wasserstraßenverbindung"
 SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-w/4.0:WaterwayLink
-Styles: TN_W_WaterwayLink } Layer { id: "LC_LandCoverSurfaces"
+Styles: TN_W_WaterwayLink } Layer { id: "TN_WaterTr_2_v5"
+registry-id: "http://inspire.ec.europa.eu/layer/TN.WaterTransportNetwork.WaterwayLink"
+tags: inspire production Name: "TN.WaterTransportNetwork.WaterwayLink"
+Title: en "Waterway Link Default Style"
+, de "Wasserstraßenverbindung"
+SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-w/5.0:WaterwayLink
+Styles: TN_W_WaterwayLink_v5 } Layer { id: "LC_LandCoverSurfaces"
 registry-id: "http://inspire.ec.europa.eu/layer/LC.LandCoverSurfaces"
 tags: production inspire Name: "LC.LandCoverSurfaces"
 Title: en "Land Cover Surfaces"
 , de "Bodenbedeckungsflächen"
 SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/lcv/4.0:LandCoverUnit
-Styles: LC_LandCoverSurfaces } Layer { id: "LC_LandCoverPoints"
+Styles: LC_LandCoverSurfaces } Layer { id: "LC_LandCoverSurfaces_v5"
+registry-id: "http://inspire.ec.europa.eu/layer/LC.LandCoverSurfaces"
+tags: production inspire Name: "LC.LandCoverSurfaces"
+Title: en "Land Cover Surfaces"
+, de "Bodenbedeckungsflächen"
+SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/lcv/5.0:LandCoverUnit
+Styles: LC_LandCoverSurfaces_v5 } Layer { id: "LC_LandCoverPoints"
 registry-id: "http://inspire.ec.europa.eu/layer/LC.LandCoverPoints"
 tags: production inspire Name: "LC.LandCoverPoints"
 Title: en "Land Cover Points"
 , de "Bodenbedeckungspunkte"
 SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/lcv/4.0:LandCoverUnit
-Styles: LC_LandCoverPoints } Layer { id: "BU_Building"
+Styles: LC_LandCoverPoints } Layer { id: "LC_LandCoverPoints_v5"
+registry-id: "http://inspire.ec.europa.eu/layer/LC.LandCoverPoints"
+tags: production inspire Name: "LC.LandCoverPoints"
+Title: en "Land Cover Points"
+, de "Bodenbedeckungspunkte"
+SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/lcv/5.0:LandCoverUnit
+Styles: LC_LandCoverPoints_v5 } Layer { id: "BU_Building"
 registry-id: "http://inspire.ec.europa.eu/layer/BU.Building"
 tags: inspire production Name: "BU.Building"
 Title: en "Building"
@@ -395,7 +633,13 @@ tags: inspire Name: "US.GovernmentalService"
 Title: en "Governmental Service"
 , de "Staatlicher Dienst"
 SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/us-govserv/4.0:GovernmentalService
-Styles: US_GovernmentalService } Layer { id: "AM_AirQualityManagementZone"
+Styles: US_GovernmentalService } Layer { id: "US_GovernmentalService_v5"
+registry-id: ""
+tags: inspire Name: "US.GovernmentalService"
+Title: en "Governmental Service"
+, de "Staatlicher Dienst"
+SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/us-govserv/5.0:GovernmentalService
+Styles: US_GovernmentalService_v5 } Layer { id: "AM_AirQualityManagementZone"
 registry-id: "http://inspire.ec.europa.eu/layer/AM.AirQualityManagementZone"
 tags: inspire production Name: "AM.AirQualityManagementZone"
 Title: en "Air Quality Management Zone"
@@ -515,19 +759,37 @@ tags: inspire production Name: "US.EnvironmentalManagementFacility"
 Title: en "Environmental Management Facility"
 , de "Umweltmanagementeinrichtungen"
 SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/us-emf/4.0:EnvironmentalManagementFacility
-Styles: US_EnvironmentalManagementFacility } Layer { id: "US_UtilityNetworkAppurtenance"
+Styles: US_EnvironmentalManagementFacility } Layer { id: "US_EnvironmentalManagementFacility_v5"
+registry-id: "https://inspire.ec.europa.eu/layer/US.EnvironmentalManagementFacility"
+tags: inspire production Name: "US.EnvironmentalManagementFacility"
+Title: en "Environmental Management Facility"
+, de "Umweltmanagementeinrichtungen"
+SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/us-emf/5.0:EnvironmentalManagementFacility
+Styles: US_EnvironmentalManagementFacility_v5 } Layer { id: "US_UtilityNetworkAppurtenance"
 registry-id: ""
 tags: inspire production Name: "US.UtilityNetworkAppurtenance"
 Title: en "Appurtenance"
 , de "Zubehörteil"
 SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/us-net-common/4.0:Appurtenance
-Styles: US_UtilityNetworkAppurtenance } Layer { id: "US_UtilityNetworkLink"
+Styles: US_UtilityNetworkAppurtenance } Layer { id: "US_UtilityNetworkAppurtenance_v5"
+registry-id: ""
+tags: inspire production Name: "US.UtilityNetworkAppurtenance"
+Title: en "Appurtenance"
+, de "Zubehörteil"
+SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/us-net-common/5.0:Appurtenance
+Styles: US_UtilityNetworkAppurtenance_v5 } Layer { id: "US_UtilityNetworkLink"
 registry-id: ""
 tags: inspire production Name: "US.UtilityNetworkLink"
 Title: en "Utility Link"
 , de "Versorgungsverbindung"
 SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/us-net-common/4.0:UtilityLink
-Styles: US_UtilityNetworkLink } Layer { id: "EF_EnvironmentalMonitoringFacilities"
+Styles: US_UtilityNetworkLink } Layer { id: "US_UtilityNetworkLink_v5"
+registry-id: ""
+tags: inspire production Name: "US.UtilityNetworkLink"
+Title: en "Utility Link"
+, de "Versorgungsverbindung"
+SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/us-net-common/5.0:UtilityLink
+Styles: US_UtilityNetworkLink_v5 } Layer { id: "EF_EnvironmentalMonitoringFacilities"
 registry-id: "http://inspire.ec.europa.eu/layer/EF.EnvironmentalMonitoringFacilities"
 tags: inspire production Name: "EF.EnvironmentalMonitoringFacilities"
 Title: en "Environmental Monitoring Facilities"
@@ -575,31 +837,61 @@ tags: inspire production Name: "TN.CommonTransportElements.MarkerPost"
 Title: en "Marker Post"
 , de "Stationszeichen"
 SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn/4.0:MarkerPost
-Styles: TN_MarkerPost } Layer { id: "TN_W_Beacon"
+Styles: TN_MarkerPost } Layer { id: "TN_MarkerPost_v5"
+registry-id: ""
+tags: inspire production Name: "TN.CommonTransportElements.MarkerPost"
+Title: en "Marker Post"
+, de "Stationszeichen"
+SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn/5.0:MarkerPost
+Styles: TN_MarkerPost_v5 } Layer { id: "TN_W_Beacon"
 registry-id: ""
 tags: inspire production Name: "TN.WaterTransportNetwork.Beacon"
 Title: en "Beacon"
 , de "Leuchtfeuer"
 SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-w/4.0:Beacon
-Styles: TN_W_Beacon } Layer { id: "TN_W_Buoy"
+Styles: TN_W_Beacon } Layer { id: "TN_W_Beacon_v5"
+registry-id: ""
+tags: inspire production Name: "TN.WaterTransportNetwork.Beacon"
+Title: en "Beacon"
+, de "Leuchtfeuer"
+SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-w/5.0:Beacon
+Styles: TN_W_Beacon_v5 } Layer { id: "TN_W_Buoy"
 registry-id: ""
 tags: inspire production Name: "TN.WaterTransportNetwork.Buoy"
 Title: en "Buoy"
 , de "Tonne"
 SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-w/4.0:Buoy
-Styles: TN_W_Buoy } Layer { id: "TN_W_TrafficSeparationSchemeCrossing"
+Styles: TN_W_Buoy } Layer { id: "TN_W_Buoy_v5"
+registry-id: ""
+tags: inspire production Name: "TN.WaterTransportNetwork.Buoy"
+Title: en "Buoy"
+, de "Tonne"
+SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-w/5.0:Buoy
+Styles: TN_W_Buoy_v5 } Layer { id: "TN_W_TrafficSeparationSchemeCrossing"
 registry-id: ""
 tags: inspire production Name: "TN.WaterTransportNetwork.TrafficSeparationSchemeCrossing"
 Title: en "Traffic Separation Scheme Crossing"
 , de "Kreuzung eines Verkehrstrennungsgebiets"
 SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-w/4.0:TrafficSeparationSchemeCrossing
-Styles: TN_W_TrafficSeparationSchemeCrossing } Layer { id: "TN_W_TrafficSeparationSchemeSeparator"
+Styles: TN_W_TrafficSeparationSchemeCrossing } Layer { id: "TN_W_TrafficSeparationSchemeCrossing_v5"
+registry-id: ""
+tags: inspire production Name: "TN.WaterTransportNetwork.TrafficSeparationSchemeCrossing"
+Title: en "Traffic Separation Scheme Crossing"
+, de "Kreuzung eines Verkehrstrennungsgebiets"
+SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-w/5.0:TrafficSeparationSchemeCrossing
+Styles: TN_W_TrafficSeparationSchemeCrossing_v5 } Layer { id: "TN_W_TrafficSeparationSchemeSeparator"
 registry-id: ""
 tags: inspire production Name: "TN.WaterTransportNetwork.TrafficSeparationSchemeSeparator"
 Title: en "Traffic Separation Scheme Separator"
 , de "Übergangszone eines Verkehrstrennungsgebiets"
 SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-w/4.0:TrafficSeparationSchemeSeparator
-Styles: TN_W_TrafficSeparationSchemeSeparator } Layer { id: "PF_ProductionFacility"
+Styles: TN_W_TrafficSeparationSchemeSeparator } Layer { id: "TN_W_TrafficSeparationSchemeSeparator_v5"
+registry-id: ""
+tags: inspire production Name: "TN.WaterTransportNetwork.TrafficSeparationSchemeSeparator"
+Title: en "Traffic Separation Scheme Separator"
+, de "Übergangszone eines Verkehrstrennungsgebiets"
+SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-w/5.0:TrafficSeparationSchemeSeparator
+Styles: TN_W_TrafficSeparationSchemeSeparator_v5 } Layer { id: "PF_ProductionFacility"
 registry-id: ""
 tags: inspire Name: "PF.ProductionFacility"
 Title: en "Production Facility"
@@ -683,7 +975,13 @@ tags: inspire production Name: "HH.HealthDeterminantMeasure"
 Title: en "Health determinant measure"
 , de "Messwerte für Gesundheitsfaktoren"
 SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/hh/4.0:EnvHealthDeterminantMeasure
-Styles: HH_HealthDeterminantMeasure } Layer { id: "EL_BreakLine"
+Styles: HH_HealthDeterminantMeasure } Layer { id: "HH_HealthDeterminantMeasure_v5"
+registry-id: "http://inspire.ec.europa.eu/layer/HH.HealthDeterminantMeasure"
+tags: inspire production Name: "HH.HealthDeterminantMeasure"
+Title: en "Health determinant measure"
+, de "Messwerte für Gesundheitsfaktoren"
+SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/hh/5.0:EnvHealthDeterminantMeasure
+Styles: HH_HealthDeterminantMeasure_v5 } Layer { id: "EL_BreakLine"
 registry-id: "http://inspire.ec.europa.eu/layer/EL.BreakLine"
 tags: inspire production Name: "EL.BreakLine"
 Title: en "Break Line"
@@ -737,7 +1035,13 @@ tags: inspire production Name: "TN.RoadNode"
 Title: en "Road Node"
 , de "Strassenknotenpunkt"
 SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-ro/4.0:RoadNode
-Styles: TN_RO_RoadNode } Layer { id: "SF_SpatialSamplingFeature"
+Styles: TN_RO_RoadNode } Layer { id: "TN_RO_RoadNode_v5"
+registry-id: ""
+tags: inspire production Name: "TN.RoadNode"
+Title: en "Road Node"
+, de "Strassenknotenpunkt"
+SpatialObjectTypes: http://inspire.ec.europa.eu/schemas/tn-ro/5.0:RoadNode
+Styles: TN_RO_RoadNode_v5 } Layer { id: "SF_SpatialSamplingFeature"
 registry-id: ""
 tags: inspire production Name: "SF.SpatialSamplingFeature"
 Title: en "Spatial Sampling Feature"
@@ -758,10 +1062,24 @@ Style {
 	}
 }
 Style {
+	id: "US_UtilityNetworkAppurtenance_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/us-net-common/5.0:Appurtenance
+		URL: "feature-styles/US_UtilityNetworkAppurtenance_v5_0.se"
+	}
+}
+Style {
 	id: "US_UtilityNetworkLink"
 	Remote {
 		FeatureType: http://inspire.ec.europa.eu/schemas/us-net-common/4.0:UtilityLink
 		URL: "feature-styles/US_UtilityNetworkLink.se"
+	}
+}
+Style {
+	id: "US_UtilityNetworkLink_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/us-net-common/5.0:UtilityLink
+		URL: "feature-styles/US_UtilityNetworkLink_v5_0.se"
 	}
 }
 Style {
@@ -772,10 +1090,24 @@ Style {
 	}
 }
 Style {
+	id: "US_EnvironmentalManagementFacility_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/us-emf/5.0:EnvironmentalManagementFacility
+		URL: "feature-styles/US_EnvironmentalManagementFacility_v5_0.se"
+	}
+}
+Style {
 	id: "TN_A_DesignatedPoint"
 	Remote {
 		FeatureType: http://inspire.ec.europa.eu/schemas/tn-a/4.0:DesignatedPoint
 		URL: "feature-styles/TN_A_DesignatedPoint.se"
+	}
+}
+Style {
+	id: "TN_A_DesignatedPoint_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/tn-a/5.0:DesignatedPoint
+		URL: "feature-styles/TN_A_DesignatedPoint_v5_0.se"
 	}
 }
 Style {
@@ -786,10 +1118,24 @@ Style {
 	}
 }
 Style {
+	id: "TN_A_Navaid_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/tn-a/5.0:Navaid
+		URL: "feature-styles/TN_A_Navaid_v5_0.se"
+	}
+}
+Style {
 	id: "TN_A_RunwayCentrelinePoint"
 	Remote {
 		FeatureType: http://inspire.ec.europa.eu/schemas/tn-a/4.0:RunwayCentrelinePoint
 		URL: "feature-styles/TN_A_RunwayCentrelinePoint.se"
+	}
+}
+Style {
+	id: "TN_A_RunwayCentrelinePoint_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/tn-a/5.0:RunwayCentrelinePoint
+		URL: "feature-styles/TN_A_RunwayCentrelinePoint_v5_0.se"
 	}
 }
 Style {
@@ -800,6 +1146,13 @@ Style {
 	}
 }
 Style {
+	id: "TN_A_AerodromeNode_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/tn-a/5.0:AerodromeNode
+		URL: "feature-styles/TN_A_AerodromeNode_v5_0.se"
+	}
+}
+Style {
 	id: "TN_A_TouchDownLiftOff"
 	Remote {
 		FeatureType: http://inspire.ec.europa.eu/schemas/tn-a/4.0:TouchDownLiftOff
@@ -807,10 +1160,24 @@ Style {
 	}
 }
 Style {
+	id: "TN_A_TouchDownLiftOff_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/tn-a/5.0:TouchDownLiftOff
+		URL: "feature-styles/TN_A_TouchDownLiftOff_v5_0.se"
+	}
+}
+Style {
 	id: "TN_RO_RoadNode"
 	Remote {
 		FeatureType: http://inspire.ec.europa.eu/schemas/tn-ro/4.0:RoadNode
 		URL: "feature-styles/TN_RO_RoadNode.se"
+	}
+}
+Style {
+	id: "TN_RO_RoadNode_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/tn-ro/5.0:RoadNode
+		URL: "feature-styles/TN_RO_RoadNode_v5_0.se"
 	}
 }
 Style {
@@ -874,6 +1241,13 @@ Style {
 	Remote {
 		FeatureType: http://inspire.ec.europa.eu/schemas/hh/4.0:EnvHealthDeterminantMeasure
 		URL: "feature-styles/HH_HealthDeterminantMeasure.se"
+	}
+}
+Style {
+	id: "HH_HealthDeterminantMeasure_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/hh/5.0:EnvHealthDeterminantMeasure
+		URL: "feature-styles/HH_HealthDeterminantMeasure_v5_0.se"
 	}
 }
 Style {
@@ -968,10 +1342,24 @@ Style {
 	}
 }
 Style {
+	id: "TN_W_TrafficSeparationSchemeSeparator_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/tn-w/5.0:TrafficSeparationSchemeSeparator
+		URL: "feature-styles/TN_W_TrafficSeparationSchemeSeparator_v5_0.se"
+	}
+}
+Style {
 	id: "TN_W_TrafficSeparationSchemeCrossing"
 	Remote {
 		FeatureType: http://inspire.ec.europa.eu/schemas/tn-w/4.0:TrafficSeparationSchemeCrossing
 		URL: "feature-styles/TN_W_TrafficSeparationSchemeCrossing.se"
+	}
+}
+Style {
+	id: "TN_W_TrafficSeparationSchemeCrossing_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/tn-w/5.0:TrafficSeparationSchemeCrossing
+		URL: "feature-styles/TN_W_TrafficSeparationSchemeCrossing_v5_0.se"
 	}
 }
 Style {
@@ -982,6 +1370,13 @@ Style {
 	}
 }
 Style {
+	id: "TN_W_Buoy_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/tn-w/5.0:Buoy
+		URL: "feature-styles/TN_W_Buoy_v5_0.se"
+	}
+}
+Style {
 	id: "TN_W_Beacon"
 	Remote {
 		FeatureType: http://inspire.ec.europa.eu/schemas/tn-w/4.0:Beacon
@@ -989,10 +1384,24 @@ Style {
 	}
 }
 Style {
+	id: "TN_W_Beacon_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/tn-w/5.0:Beacon
+		URL: "feature-styles/TN_W_Beacon_v5_0.se"
+	}
+}
+Style {
 	id: "TN_MarkerPost"
 	Remote {
 		FeatureType: http://inspire.ec.europa.eu/schemas/tn/4.0:MarkerPost
 		URL: "feature-styles/TN_MarkerPost.se"
+	}
+}
+Style {
+	id: "TN_MarkerPost_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/tn/5.0:MarkerPost
+		URL: "feature-styles/TN_MarkerPost_v5_0.se"
 	}
 }
 Style {
@@ -1185,6 +1594,13 @@ Style {
 	}
 }
 Style {
+	id: "US_GovernmentalService_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/us-govserv/5.0:GovernmentalService
+		URL: "feature-styles/US_GovernmentalService_v5_0.se"
+	}
+}
+Style {
 	id: "LU_SupplementaryRegulation"
 	Remote {
 		FeatureType: http://inspire.ec.europa.eu/schemas/plu/4.0:SupplementaryRegulation
@@ -1346,10 +1762,24 @@ Style {
 	}
 }
 Style {
+	id: "HY_N_WatercourseLink_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/hy-n/5.0:WatercourseLink
+		URL: "feature-styles/HY_N_WatercourseLink_v5_0.se"
+	}
+}
+Style {
 	id: "HY_N_HydroNode"
 	Remote {
 		FeatureType: http://inspire.ec.europa.eu/schemas/hy-n/4.0:HydroNode
 		URL: "feature-styles/HY_N_HydroNode.se"
+	}
+}
+Style {
+	id: "HY_N_HydroNode_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/hy-n/5.0:HydroNode
+		URL: "feature-styles/HY_N_HydroNode_v5_0.se"
 	}
 }
 Style {
@@ -1360,10 +1790,24 @@ Style {
 	}
 }
 Style {
+	id: "HY_P_DrainageBasin_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/hy-p/5.0:DrainageBasin
+		URL: "feature-styles/HY_P_DrainageBasin_v5_0.se"
+	}
+}
+Style {
 	id: "HY_P_RiverBasin"
 	Remote {
 		FeatureType: http://inspire.ec.europa.eu/schemas/hy-p/4.0:RiverBasin
 		URL: "feature-styles/HY_P_RiverBasin.se"
+	}
+}
+Style {
+	id: "HY_P_RiverBasin_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/hy-p/5.0:RiverBasin
+		URL: "feature-styles/HY_P_RiverBasin_v5_0.se"
 	}
 }
 Style {
@@ -1374,10 +1818,24 @@ Style {
 	}
 }
 Style {
+	id: "HY_P_Rapids_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/hy-p/5.0:Rapids
+		URL: "feature-styles/HY_P_Rapids_v5_0.se"
+	}
+}
+Style {
 	id: "HY_P_Falls"
 	Remote {
 		FeatureType: http://inspire.ec.europa.eu/schemas/hy-p/4.0:Falls
 		URL: "feature-styles/HY_P_Falls.se"
+	}
+}
+Style {
+	id: "HY_P_Falls_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/hy-p/5.0:Falls
+		URL: "feature-styles/HY_P_Falls_v5_0.se"
 	}
 }
 Style {
@@ -1388,10 +1846,24 @@ Style {
 	}
 }
 Style {
+	id: "HY_P_LandWaterBoundary_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/hy-p/5.0:LandWaterBoundary
+		URL: "feature-styles/HY_P_LandWaterBoundary_v5_0.se"
+	}
+}
+Style {
 	id: "HY_P_Crossing"
 	Remote {
 		FeatureType: http://inspire.ec.europa.eu/schemas/hy-p/4.0:Crossing
 		URL: "feature-styles/HY_P_Crossing.se"
+	}
+}
+Style {
+	id: "HY_P_Crossing_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/hy-p/5.0:Crossing
+		URL: "feature-styles/HY_P_Crossing_v5_0.se"
 	}
 }
 Style {
@@ -1402,10 +1874,24 @@ Style {
 	}
 }
 Style {
+	id: "HY_P_DamOrWeir_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/hy-p/5.0:DamOrWeir
+		URL: "feature-styles/HY_P_DamOrWeir_v5_0.se"
+	}
+}
+Style {
 	id: "HY_P_ShoreLineConstruction"
 	Remote {
 		FeatureType: http://inspire.ec.europa.eu/schemas/hy-p/4.0:ShorelineConstruction
 		URL: "feature-styles/HY_P_ShoreLineConstruction.se"
+	}
+}
+Style {
+	id: "HY_P_ShoreLineConstruction_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/hy-p/5.0:ShorelineConstruction
+		URL: "feature-styles/HY_P_ShoreLineConstruction_v5_0.se"
 	}
 }
 Style {
@@ -1416,10 +1902,24 @@ Style {
 	}
 }
 Style {
+	id: "HY_P_Ford_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/hy-p/5.0:Ford
+		URL: "feature-styles/HY_P_Ford_v5_0.se"
+	}
+}
+Style {
 	id: "HY_P_Lock"
 	Remote {
 		FeatureType: http://inspire.ec.europa.eu/schemas/hy-p/4.0:Lock
 		URL: "feature-styles/HY_P_Lock.se"
+	}
+}
+Style {
+	id: "HY_P_Lock_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/hy-p/5.0:Lock
+		URL: "feature-styles/HY_P_Lock_v5_0.se"
 	}
 }
 Style {
@@ -1430,10 +1930,24 @@ Style {
 	}
 }
 Style {
+	id: "HY_P_Shore_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/hy-p/5.0:Shore
+		URL: "feature-styles/HY_P_Shore_v5_0.se"
+	}
+}
+Style {
 	id: "HY_P_Watercourse"
 	Remote {
 		FeatureType: http://inspire.ec.europa.eu/schemas/hy-p/4.0:Watercourse
 		URL: "feature-styles/HY_P_Watercourse.se"
+	}
+}
+Style {
+	id: "HY_P_Watercourse_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/hy-p/5.0:Watercourse
+		URL: "feature-styles/HY_P_Watercourse_v5_0.se"
 	}
 }
 Style {
@@ -1444,10 +1958,24 @@ Style {
 	}
 }
 Style {
+	id: "HY_P_StandingWater_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/hy-p/5.0:StandingWater
+		URL: "feature-styles/HY_P_StandingWater_v5_0.se"
+	}
+}
+Style {
 	id: "HY_P_Watercourse_ManMade"
 	Remote {
 		FeatureType: http://inspire.ec.europa.eu/schemas/hy-p/4.0:Watercourse
 		URL: "feature-styles/HY_P_Watercourse_ManMade.se"
+	}
+}
+Style {
+	id: "HY_P_Watercourse_ManMade_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/hy-p/5.0:Watercourse
+		URL: "feature-styles/HY_P_Watercourse_ManMade_v5_0.se"
 	}
 }
 Style {
@@ -1458,10 +1986,24 @@ Style {
 	}
 }
 Style {
+	id: "HY_P_StandingWater_ManMade_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/hy-p/5.0:StandingWater
+		URL: "feature-styles/HY_P_StandingWater_ManMade_v5_0.se"
+	}
+}
+Style {
 	id: "HY_P_WatercoursePersistence"
 	Remote {
 		FeatureType: http://inspire.ec.europa.eu/schemas/hy-p/4.0:Watercourse
 		URL: "feature-styles/HY_P_WatercoursePersistence.se"
+	}
+}
+Style {
+	id: "HY_P_WatercoursePersistence_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/hy-p/5.0:Watercourse
+		URL: "feature-styles/HY_P_WatercoursePersistence_v5_0.se"
 	}
 }
 Style {
@@ -1472,6 +2014,13 @@ Style {
 	}
 }
 Style {
+	id: "HY_P_WaterbodiesPersistence_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/hy-p/5.0:StandingWater
+		URL: "feature-styles/HY_P_WaterbodiesPersistence_v5_0.se"
+	}
+}
+Style {
 	id: "HY_P_Wetland"
 	Remote {
 		FeatureType: http://inspire.ec.europa.eu/schemas/hy-p/4.0:Wetland
@@ -1479,10 +2028,24 @@ Style {
 	}
 }
 Style {
+	id: "HY_P_Wetland_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/hy-p/5.0:Wetland
+		URL: "feature-styles/HY_P_Wetland_v5_0.se"
+	}
+}
+Style {
 	id: "PS_ProtectedSite"
 	Remote {
 		FeatureType: http://inspire.ec.europa.eu/schemas/ps/4.0:ProtectedSite
 		URL: "feature-styles/PS_ProtectedSites.se"
+	}
+}
+Style {
+	id: "PS_ProtectedSite_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/ps/5.0:ProtectedSite
+		URL: "feature-styles/PS_ProtectedSites_v5_0.se"
 	}
 }
 Style {
@@ -1500,10 +2063,24 @@ Style {
 	}
 }
 Style {
+	id: "TN_A_AerodromeArea_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/tn-a/5.0:AerodromeArea
+		URL: "feature-styles/TN_A_AerodromeArea_v5_0.se"
+	}
+}
+Style {
 	id: "TN_A_ProcedureLink"
 	Remote {
 		FeatureType: http://inspire.ec.europa.eu/schemas/tn-a/4.0:ProcedureLink
 		URL: "feature-styles/TN_A_ProcedureLink.se"
+	}
+}
+Style {
+	id: "TN_A_ProcedureLink_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/tn-a/5.0:ProcedureLink
+		URL: "feature-styles/TN_A_ProcedureLink_v5_0.se"
 	}
 }
 Style {
@@ -1514,10 +2091,24 @@ Style {
 	}
 }
 Style {
+	id: "TN_A_AirRouteLink_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/tn-a/5.0:AirRouteLink
+		URL: "feature-styles/TN_A_AirRouteLink_v5_0.se"
+	}
+}
+Style {
 	id: "TN_A_AirspaceArea"
 	Remote {
 		FeatureType: http://inspire.ec.europa.eu/schemas/tn-a/4.0:AirspaceArea
 		URL: "feature-styles/TN_A_AirspaceArea.se"
+	}
+}
+Style {
+	id: "TN_A_AirspaceArea_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/tn-a/5.0:AirspaceArea
+		URL: "feature-styles/TN_A_AirspaceArea_v5_0.se"
 	}
 }
 Style {
@@ -1528,10 +2119,24 @@ Style {
 	}
 }
 Style {
+	id: "TN_A_ApronArea_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/tn-a/5.0:ApronArea
+		URL: "feature-styles/TN_A_ApronArea_v5_0.se"
+	}
+}
+Style {
 	id: "TN_A_RunwayArea"
 	Remote {
 		FeatureType: http://inspire.ec.europa.eu/schemas/tn-a/4.0:RunwayArea
 		URL: "feature-styles/TN_A_RunwayArea.se"
+	}
+}
+Style {
+	id: "TN_A_RunwayArea_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/tn-a/5.0:RunwayArea
+		URL: "feature-styles/TN_A_RunwayArea_v5_0.se"
 	}
 }
 Style {
@@ -1542,10 +2147,24 @@ Style {
 	}
 }
 Style {
+	id: "TN_A_TaxiwayArea_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/tn-a/5.0:TaxiwayArea
+		URL: "feature-styles/TN_A_TaxiwayArea_v5_0.se"
+	}
+}
+Style {
 	id: "TN_C_CablewayLink"
 	Remote {
 		FeatureType: http://inspire.ec.europa.eu/schemas/tn-c/4.0:CablewayLink
 		URL: "feature-styles/TN_C_CablewayLink.se"
+	}
+}
+Style {
+	id: "TN_C_CablewayLink_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/tn-c/5.0:CablewayLink
+		URL: "feature-styles/TN_C_CablewayLink_v5_0.se"
 	}
 }
 Style {
@@ -1556,10 +2175,24 @@ Style {
 	}
 }
 Style {
+	id: "TN_TransportArea_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/tn/5.0:TransportArea
+		URL: "feature-styles/TN_TransportArea_v5_0.se"
+	}
+}
+Style {
 	id: "TN_TransportLink"
 	Remote {
 		FeatureType: http://inspire.ec.europa.eu/schemas/tn/4.0:TransportLink
 		URL: "feature-styles/TN_TransportLink.se"
+	}
+}
+Style {
+	id: "TN_TransportLink_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/tn/5.0:TransportLink
+		URL: "feature-styles/TN_TransportLink_v5_0.se"
 	}
 }
 Style {
@@ -1570,10 +2203,24 @@ Style {
 	}
 }
 Style {
+	id: "TN_TransportNode_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/tn/5.0:TransportNode
+		URL: "feature-styles/TN_TransportNode_v5_0.se"
+	}
+}
+Style {
 	id: "TN_RA_RailwayArea"
 	Remote {
 		FeatureType: http://inspire.ec.europa.eu/schemas/tn-ra/4.0:RailwayArea
 		URL: "feature-styles/TN_RA_RailwayArea.se"
+	}
+}
+Style {
+	id: "TN_RA_RailwayArea_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/tn-ra/5.0:RailwayArea
+		URL: "feature-styles/TN_RA_RailwayArea_v5_0.se"
 	}
 }
 Style {
@@ -1584,10 +2231,24 @@ Style {
 	}
 }
 Style {
+	id: "TN_RA_RailwayLink_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/tn-ra/5.0:RailwayLink
+		URL: "feature-styles/TN_RA_RailwayLink_v5_0.se"
+	}
+}
+Style {
 	id: "TN_RA_RailwayStationArea"
 	Remote {
 		FeatureType: http://inspire.ec.europa.eu/schemas/tn-ra/4.0:RailwayStationArea
 		URL: "feature-styles/TN_RA_RailwayStationArea.se"
+	}
+}
+Style {
+	id: "TN_RA_RailwayStationArea_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/tn-ra/5.0:RailwayStationArea
+		URL: "feature-styles/TN_RA_RailwayStationArea_v5_0.se"
 	}
 }
 Style {
@@ -1598,10 +2259,24 @@ Style {
 	}
 }
 Style {
+	id: "TN_RA_RailwayYardArea_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/tn-ra/5.0:RailwayYardArea
+		URL: "feature-styles/TN_RA_RailwayYardArea_v5_0.se"
+	}
+}
+Style {
 	id: "TN_RO_RoadArea"
 	Remote {
 		FeatureType: http://inspire.ec.europa.eu/schemas/tn-ro/4.0:RoadArea
 		URL: "feature-styles/TN_RO_RoadArea.se"
+	}
+}
+Style {
+	id: "TN_RO_RoadArea_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/tn-ro/5.0:RoadArea
+		URL: "feature-styles/TN_RO_RoadArea_v5_0.se"
 	}
 }
 Style {
@@ -1612,10 +2287,24 @@ Style {
 	}
 }
 Style {
+	id: "TN_RO_RoadLink_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/tn-ro/5.0:RoadLink
+		URL: "feature-styles/TN_RO_RoadLink_v5_0.se"
+	}
+}
+Style {
 	id: "TN_RO_RoadServiceArea"
 	Remote {
 		FeatureType: http://inspire.ec.europa.eu/schemas/tn-ro/4.0:RoadServiceArea
 		URL: "feature-styles/TN_RO_RoadServiceArea.se"
+	}
+}
+Style {
+	id: "TN_RO_RoadServiceArea_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/tn-ro/5.0:RoadServiceArea
+		URL: "feature-styles/TN_RO_RoadServiceArea_v5_0.se"
 	}
 }
 Style {
@@ -1626,10 +2315,24 @@ Style {
 	}
 }
 Style {
+	id: "TN_RO_VehicleTrafficArea_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/tn-ro/5.0:VehicleTrafficArea
+		URL: "feature-styles/TN_RO_VehicleTrafficArea_v5_0.se"
+	}
+}
+Style {
 	id: "TN_W_FairwayArea"
 	Remote {
 		FeatureType: http://inspire.ec.europa.eu/schemas/tn-w/4.0:FairwayArea
 		URL: "feature-styles/TN_W_FairwayArea.se"
+	}
+}
+Style {
+	id: "TN_W_FairwayArea_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/tn-w/5.0:FairwayArea
+		URL: "feature-styles/TN_W_FairwayArea_v5_0.se"
 	}
 }
 Style {
@@ -1640,10 +2343,24 @@ Style {
 	}
 }
 Style {
+	id: "TN_W_PortArea_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/tn-w/5.0:PortArea
+		URL: "feature-styles/TN_W_PortArea_v5_0.se"
+	}
+}
+Style {
 	id: "TN_W_WaterwayLink"
 	Remote {
 		FeatureType: http://inspire.ec.europa.eu/schemas/tn-w/4.0:WaterwayLink
 		URL: "feature-styles/TN_W_WaterwayLink.se"
+	}
+}
+Style {
+	id: "TN_W_WaterwayLink_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/tn-w/5.0:WaterwayLink
+		URL: "feature-styles/TN_W_WaterwayLink_v5_0.se"
 	}
 }
 Style {
@@ -1654,10 +2371,24 @@ Style {
 	}
 }
 Style {
+	id: "LC_LandCoverSurfaces_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/lcv/5.0:LandCoverUnit
+		URL: "feature-styles/LC_LandCoverSurfaces_v5_0.se"
+	}
+}
+Style {
 	id: "LC_LandCoverPoints"
 	Remote {
 		FeatureType: http://inspire.ec.europa.eu/schemas/lcv/4.0:LandCoverUnit
 		URL: "feature-styles/LC_LandCoverPoints.se"
+	}
+}
+Style {
+	id: "LC_LandCoverPoints_v5"
+	Remote {
+		FeatureType: http://inspire.ec.europa.eu/schemas/lcv/5.0:LandCoverUnit
+		URL: "feature-styles/LC_LandCoverPoints_v5_0.se"
 	}
 }
 Style {


### PR DESCRIPTION
In this PR, se files are added that have a schema in INSPIRE version 5.0. Within the se files, the namespaces were changed accordingly. The corresponding configuration files (config.xmi and config.style) were adapted accordingly. In addition, the corresponding files (config.xmi, config.xml, generated.style and se files) were automatically created in the generated folder in eclipse, so that INSPIRE themes that have schemas in INSPIRE version 5.0, the appropriate se files are automatically used for the presentation of the services.


